### PR TITLE
Add basic preprocessor

### DIFF
--- a/pps/dune
+++ b/pps/dune
@@ -1,0 +1,5 @@
+(ocamllex
+ (modules gospel_pps))
+
+(executable
+ (public_name gospel_pps))

--- a/pps/gospel_pps.mli
+++ b/pps/gospel_pps.mli
@@ -1,0 +1,1 @@
+(* Left empty on purpose. *)

--- a/pps/gospel_pps.mll
+++ b/pps/gospel_pps.mll
@@ -1,0 +1,68 @@
+{
+  type t = Gospel of string | Other of string
+
+  let queue = Queue.create ()
+  let empty_line = ref true
+  let buf = Buffer.create 1024
+
+  let push () =
+    if Buffer.length buf > 0 then (
+      Queue.push (Other (Buffer.contents buf)) queue;
+      Buffer.clear buf)
+
+  let flush () =
+    push ();
+    let print = function
+      | Gospel s ->
+          let ats = if !empty_line then "@@@" else "@@" in
+          Format.printf "[%sgospel {|%s|}]%!" ats s
+      | Other s -> print_string s
+    in
+    Queue.iter print queue;
+    Queue.clear queue
+}
+
+let space = [ ' ' '\t' '\r' '\n' ]
+
+rule scan = parse
+  | '\n' space* '\n' as s
+      { flush (); empty_line := true; print_string s; scan lexbuf }
+  | "(*@"
+      {
+        push ();
+        comment lexbuf;
+        let s = Buffer.contents buf in
+        Buffer.clear buf;
+        Queue.push (Gospel s) queue;
+        scan lexbuf
+      }
+  | "(*"
+      {
+        Buffer.add_string buf "(*";
+        comment lexbuf;
+        Buffer.add_string buf "*)";
+        scan lexbuf
+      }
+  | space as c { Buffer.add_char buf c; scan lexbuf }
+  | _ as c { Buffer.add_char buf c; empty_line := false; scan lexbuf }
+  | eof { flush () }
+
+(* FIXME: Strings in comments. *)
+and comment = parse
+  | "*)" {}
+  | "(*"
+      {
+        Buffer.add_string buf "(*";
+        comment lexbuf;
+        Buffer.add_string buf "*)";
+        comment lexbuf }
+  | _ as c { Buffer.add_char buf c; comment lexbuf }
+
+{
+  let () =
+    let c =
+      if Array.length Sys.argv > 1 then Sys.argv.(1) |> open_in else stdin
+    in
+    Lexing.from_channel c |> scan;
+    close_in c
+}

--- a/src/dune
+++ b/src/dune
@@ -11,8 +11,7 @@
  (name gospel)
  (public_name gospel)
  (flags :standard -w -9 -linkall)
- (modules_without_implementation oasttypes oparsetree uast)
- )
+ (modules_without_implementation oasttypes oparsetree uast))
 
 (rule
  (targets gospelstdlib.ml)


### PR DESCRIPTION
The goal of this preprocessor is to turn Gospel special comments `(*@ ... *)` into Gospel attributes `[@@gospel {|...|}]` to make them available to the OCaml parser.

Special comments that are adjacent to OCaml declarations are turned into attached attributes while those that are surrounded by empty lines are turned into floating attributes.
This is intended to be used on interface files only.