### PR TITLE
Use `_` instead of `#` when printing tagged identifiers

### DIFF
--- a/src/identifier.ml
+++ b/src/identifier.ml
@@ -51,7 +51,7 @@ module Ident = struct
       | Not_found ->
           let x = current id.id_str in
           let str = if x = 0 then id.id_str else
-              id.id_str ^ "#" ^ string_of_int x in
+              id.id_str ^ "_" ^ string_of_int x in
           Hashtbl.replace output id.id_tag str; str in
     fun ppf t ->
       Format.fprintf ppf "%s%a" (str_of_id t) pp_attrs t.id_attrs

--- a/test/positive/FM19.mli.expected
+++ b/test/positive/FM19.mli.expected
@@ -261,20 +261,20 @@ module FM19.mli
         writes q:'a t*)
     
     val pop : 'a t -> 'a
-    (*@ v#1:'a = pop q#1:'a t
-        requires not ((view q#1:'a t):'a seq = (empty ):'a seq):prop
-        ensures (old ((view q#1:'a t):'a seq) = ((view q#1:'a t):'a seq ++ (cons  
-                v#1:'a (empty ):'a seq):'a seq):'a seq):prop
-        writes q#1:'a t*)
+    (*@ v_1:'a = pop q_1:'a t
+        requires not ((view q_1:'a t):'a seq = (empty ):'a seq):prop
+        ensures (old ((view q_1:'a t):'a seq) = ((view q_1:'a t):'a seq ++ (cons  
+                v_1:'a (empty ):'a seq):'a seq):'a seq):prop
+        writes q_1:'a t*)
     
     val is_empty : 'a t -> bool
-    (*@ b:bool = is_empty q#2:'a t
-        ensures (b:bool = (True ):bool):prop <-> ((view q#2:'a t):'a 
+    (*@ b:bool = is_empty q_2:'a t
+        ensures (b:bool = (True ):bool):prop <-> ((view q_2:'a t):'a 
                 seq = (empty ):'a seq):prop*)
     
     val create : unit -> 'a t
-    (*@ q#3:'a t = create ():unit
-        ensures ((view q#3:'a t):'a seq = (empty ):'a seq):prop*)
+    (*@ q_3:'a t = create ():unit
+        ensures ((view q_3:'a t):'a seq = (empty ):'a seq):prop*)
     
     val in_place_concat : 'a t -> 'a t -> unit
     (*@  in_place_concat q1:'a t q2:'a t
@@ -285,49 +285,49 @@ module FM19.mli
         writes q2:'a t*)
     
     val in_place_destructive_concat : 'a t -> 'a t -> unit
-    (*@  in_place_destructive_concat q1#1:'a t q2#1:'a t
-        ensures ((view q2#1:'a t):'a seq = old (((view q1#1:'a t):'a 
-                seq ++ old ((view q2#1:'a t):'a seq)):'a seq)):prop
-        writes q2#1:'a t
-        consumes q1#1:'a t*)
+    (*@  in_place_destructive_concat q1_1:'a t q2_1:'a t
+        ensures ((view q2_1:'a t):'a seq = old (((view q1_1:'a t):'a 
+                seq ++ old ((view q2_1:'a t):'a seq)):'a seq)):prop
+        writes q2_1:'a t
+        consumes q1_1:'a t*)
     
     val nondestructive_concat : 'a t -> 'a t -> 'a t
-    (*@ q3:'a t = nondestructive_concat q1#2:'a t q2#2:'a t
-        ensures ((view q3:'a t):'a seq = ((view q1#2:'a t):'a seq ++ (view 
-                q2#2:'a t):'a seq):'a seq):prop*)
+    (*@ q3:'a t = nondestructive_concat q1_2:'a t q2_2:'a t
+        ensures ((view q3:'a t):'a seq = ((view q1_2:'a t):'a seq ++ (view 
+                q2_2:'a t):'a seq):'a seq):prop*)
     
     val map : ('a -> 'b) -> 'a t -> 'b t
-    (*@ r:'b#1 t = map f:'a -> 'b#1 q#4:'a t
-        ensures ((length (view r:'b#1 t):'b#1 seq):integer = (length (view 
-                q#4:'a t):'a seq):integer):prop
+    (*@ r:'b_1 t = map f:'a -> 'b_1 q_4:'a t
+        ensures ((length (view r:'b_1 t):'b_1 seq):integer = (length (view 
+                q_4:'a t):'a seq):integer):prop
         ensures forall i:integer . (0:integer <= i:integer):prop /\ (
-                i:integer < (length (view q#4:'a t):'a seq):integer):prop -> ((mixfix [_]  (view 
-                r:'b#1 t):'b#1 seq i:integer):'b#1 = (apply  f:'a -> 'b#1 (mixfix [_]  (view 
-                q#4:'a t):'a seq i:integer):'a):'b#1):prop*)
+                i:integer < (length (view q_4:'a t):'a seq):integer):prop -> ((mixfix [_]  (view 
+                r:'b_1 t):'b_1 seq i:integer):'b_1 = (apply  f:'a -> 'b_1 (mixfix [_]  (view 
+                q_4:'a t):'a seq i:integer):'a):'b_1):prop*)
     
     (*@ function power (x:integer) (y:integer): integer *)
     
     val power_2_below : int -> int
-    (*@ r#1:int, [k:integer: integer] = power_2_below n:int
+    (*@ r_1:int, [k:integer: integer] = power_2_below n:int
         requires ((integer_of_int n:int):integer >= 1:integer):prop
-        ensures ((integer_of_int r#1:int):integer = (power  2:integer 
-                k:integer):integer):prop && ((integer_of_int r#1:int):
+        ensures ((integer_of_int r_1:int):integer = (power  2:integer 
+                k:integer):integer):prop && ((integer_of_int r_1:int):
                 integer <= (integer_of_int n:int):integer):prop /\ ((integer_of_int 
-                n:int):integer < (2:integer * (integer_of_int r#1:int):
+                n:int):integer < (2:integer * (integer_of_int r_1:int):
                 integer):integer):prop*)
     
     type rand_state
     (*@ ephemeral
-        mutable model internal#1 : unit *)
+        mutable model internal_1 : unit *)
     
     val random_init : int -> rand_state
     
     
     val random_int : rand_state -> int -> int
-    (*@ n#1:int = random_int s:rand_state m:int
+    (*@ n_1:int = random_int s:rand_state m:int
         requires ((integer_of_int m:int):integer > 0:integer):prop
-        ensures (0:integer <= (integer_of_int n#1:int):integer):prop /\ ((integer_of_int 
-                n#1:int):integer < (integer_of_int m:int):integer):prop
+        ensures (0:integer <= (integer_of_int n_1:int):integer):prop /\ ((integer_of_int 
+                n_1:int):integer < (integer_of_int m:int):integer):prop
         writes s:rand_state*)
     
     (*@ open Set *)
@@ -342,39 +342,39 @@ module FM19.mli
         mutable model dom : elem set
         mutable model rep : elem -> elem
         mutable model internal : unit
-        invariant forall x#1:elem . (mem  x#1:elem (dom#1 ):elem set):prop -> (mem  (apply  (rep#1 ):
-                  elem -> elem x#1:elem):elem (dom#1 ):elem set):prop
-        invariant forall x#2:elem . (mem  x#2:elem (dom#1 ):elem set):prop -> ((apply  (rep#1 ):
-                  elem -> elem (apply  (rep#1 ):elem -> elem x#2:elem):
-                  elem):elem = (apply  (rep#1 ):elem -> elem x#2:elem):
+        invariant forall x_1:elem . (mem  x_1:elem (dom_1 ):elem set):prop -> (mem  (apply  (rep_1 ):
+                  elem -> elem x_1:elem):elem (dom_1 ):elem set):prop
+        invariant forall x_2:elem . (mem  x_2:elem (dom_1 ):elem set):prop -> ((apply  (rep_1 ):
+                  elem -> elem (apply  (rep_1 ):elem -> elem x_2:elem):
+                  elem):elem = (apply  (rep_1 ):elem -> elem x_2:elem):
                   elem):prop *) *)
     
     val equiv : elem -> elem -> bool
-    (*@ b#2:bool = equiv [uf:uf_instance: uf_instance] e1:elem e2:elem
+    (*@ b_2:bool = equiv [uf:uf_instance: uf_instance] e1:elem e2:elem
         requires (mem  e1:elem (dom uf:uf_instance):elem set):prop && (mem  
                  e2:elem (dom uf:uf_instance):elem set):prop
-        ensures (b#2:bool = (True ):bool):prop <-> ((apply  (rep uf:uf_instance):
+        ensures (b_2:bool = (True ):bool):prop <-> ((apply  (rep uf:uf_instance):
                 elem -> elem e1:elem):elem = (apply  (rep uf:uf_instance):
                 elem -> elem e2:elem):elem):prop
         writes (internal uf:uf_instance):unit*)
     
     (*@
     val create_instance : unit -> uf_instance
-    (*@ uf#1:uf_instance = create_instance ()#1:unit
-        ensures ((dom uf#1:uf_instance):elem set = (mixfix {} ):elem 
+    (*@ uf_1:uf_instance = create_instance ()_1:unit
+        ensures ((dom uf_1:uf_instance):elem set = (mixfix {} ):elem 
                 set):prop*)
     *)
     
     val make : unit -> elem
-    (*@ e:elem = make [uf#2:uf_instance: uf_instance] ()#2:unit
-        ensures not (mem  e:elem old ((dom uf#2:uf_instance):elem set)):prop
-        ensures ((dom uf#2:uf_instance):elem set = (union  old ((dom 
-                uf#2:uf_instance):elem set) (mixfix {:_:} e:elem):elem 
+    (*@ e:elem = make [uf_2:uf_instance: uf_instance] ()_2:unit
+        ensures not (mem  e:elem old ((dom uf_2:uf_instance):elem set)):prop
+        ensures ((dom uf_2:uf_instance):elem set = (union  old ((dom 
+                uf_2:uf_instance):elem set) (mixfix {:_:} e:elem):elem 
                 set):elem set):prop
-        ensures ((rep uf#2:uf_instance):elem -> elem = (mixfix [<-]  old ((rep 
-                uf#2:uf_instance):elem -> elem) e:elem e:elem):elem -> 
+        ensures ((rep uf_2:uf_instance):elem -> elem = (mixfix [<-]  old ((rep 
+                uf_2:uf_instance):elem -> elem) e:elem e:elem):elem -> 
                 elem):prop
-        writes uf#2:uf_instance*)
+        writes uf_2:uf_instance*)
     
     type type1
     
@@ -387,9 +387,9 @@ module FM19.mli
         mutable model left : type1
         mutable model right : type2 *)
     
-    val f#1 : tt -> tt -> tt -> tt -> int -> (tt * tt * int)
-    (*@ p5:tt, p6:tt, m#1:int, [h:integer: integer] = f#1
-        p1:tt p2:tt p3:tt p4:tt n#2:int [g:integer: integer]
+    val f_1 : tt -> tt -> tt -> tt -> int -> (tt * tt * int)
+    (*@ p5:tt, p6:tt, m_1:int, [h:integer: integer] = f_1
+        p1:tt p2:tt p3:tt p4:tt n_2:int [g:integer: integer]
         requires true:prop
         ensures true:prop
         writes p1:tt

--- a/test/positive/a3.mli.expected
+++ b/test/positive/a3.mli.expected
@@ -92,8 +92,8 @@ module a3.mli
                 Type symbols
                   
                 Logic Symbols
-                  function length#1 (_:'a array) : integer
-                  function mixfix [_]#1 (_:'a array) (_:integer) : 'a
+                  function length_1 (_:'a array) : integer
+                  function mixfix [_]_1 (_:'a array) (_:integer) : 'a
                   
                 Exception Symbols
                   
@@ -142,7 +142,7 @@ module a3.mli
                   
                 Logic Symbols
                   function mixfix [<-] (_:'a -> 'b) (_:'a) (_:'b) : 'a -> 'b
-                  function mixfix [_]#2 (_:'a -> 'b) (_:'a) : 'b
+                  function mixfix [_]_2 (_:'a -> 'b) (_:'a) : 'b
                   
                 Exception Symbols
                   
@@ -164,11 +164,11 @@ module a3.mli
                   
               Namespace: Peano
                 Type symbols
-                   t#1
+                   t_1
                   
                 Logic Symbols
-                  function int_of_peano (_:t#1) : integer
-                  function v (_:t#1) : integer
+                  function int_of_peano (_:t_1) : integer
+                  function v (_:t_1) : integer
                   
                 Exception Symbols
                   
@@ -190,8 +190,8 @@ module a3.mli
                   function hd (_:'a seq) : 'a
                   function len (_:'a seq) : integer
                   function map (_:'a -> 'b) (_:'a seq) : 'b seq
-                  predicate mem#1 (_:'a seq) (_:'a)
-                  function mixfix [<-]#1 (_:'a seq) (_:integer) (_:'a) : 'a 
+                  predicate mem_1 (_:'a seq) (_:'a)
+                  function mixfix [<-]_1 (_:'a seq) (_:integer) (_:'a) : 'a 
                   seq
                   function rev (_:'a seq) : 'a seq
                   function snoc (_:'a seq) (_:'a) : 'a seq
@@ -213,7 +213,7 @@ module a3.mli
                   integer
                   predicate permut (_:'a seq) (_:'a seq) (_:integer) (_:
                   integer)
-                  predicate permut_all#1 (_:'a seq) (_:'a seq)
+                  predicate permut_all_1 (_:'a seq) (_:'a seq)
                   
                 Exception Symbols
                   
@@ -226,11 +226,11 @@ module a3.mli
                   'a set
                   
                 Logic Symbols
-                  predicate mem#2 (_:'a) (_:'a set)
+                  predicate mem_2 (_:'a) (_:'a set)
                   function mixfix {:_:} (_:'a) : 'a set
                   function mixfix {}  : 'a set
                   function sum (_:'a -> integer) (_:'a set) : integer
-                  function union#1 (_:'a set) (_:'a set) : 'a set
+                  function union_1 (_:'a set) (_:'a set) : 'a set
                   
                 Exception Symbols
                   

--- a/test/positive/abstract_functions.mli.expected
+++ b/test/positive/abstract_functions.mli.expected
@@ -142,39 +142,39 @@ module abstract_functions.mli
     
     (*@ function h1 (x:integer): integer *)
     
-    (*@ function h2 (x#1:integer) (y:integer): integer *)
+    (*@ function h2 (x_1:integer) (y:integer): integer *)
     
-    (*@ function h3 (x#2:t1) (y#1:integer t2): integer *)
+    (*@ function h3 (x_2:t1) (y_1:integer t2): integer *)
     
-    (*@ function h4 (x#3:(integer,'a) t3) (y#2:integer t2): integer *)
+    (*@ function h4 (x_3:(integer,'a) t3) (y_2:integer t2): integer *)
     
-    (*@ predicate h5 (x#4:integer) *)
+    (*@ predicate h5 (x_4:integer) *)
     
-    (*@ predicate h6 (x#5:integer) (y#3:integer) *)
+    (*@ predicate h6 (x_5:integer) (y_3:integer) *)
     
-    (*@ predicate h7 (x#6:t1) (y#4:integer t2) *)
+    (*@ predicate h7 (x_6:t1) (y_4:integer t2) *)
     
-    (*@ predicate h8 (x#7:(integer,'a) t3) (y#5:integer t2) *)
+    (*@ predicate h8 (x_7:(integer,'a) t3) (y_5:integer t2) *)
     
-    (*@ function prefix !! (x#8:integer): integer *)
+    (*@ function prefix !! (x_8:integer): integer *)
     
-    (*@ function prefix ?? (x#9:'a): 'a *)
+    (*@ function prefix ?? (x_9:'a): 'a *)
     
-    (*@ function prefix !? (x#10:'a): 'a * 'b *)
+    (*@ function prefix !? (x_10:'a): 'a * 'b *)
     
-    (*@ function h9 (x#11:'a): 'a * 'b *)
+    (*@ function h9 (x_11:'a): 'a * 'b *)
     
-    (*@ function h10 (x#12:'a) (y#6:'b): 'a * 'b *)
+    (*@ function h10 (x_12:'a) (y_6:'b): 'a * 'b *)
     
-    (*@ predicate h11 (x#13:'a) (y#7:'b) (z:'c) *)
+    (*@ predicate h11 (x_13:'a) (y_7:'b) (z:'c) *)
     
-    (*@ function h12 (x#14:'a): 'b -> 'c *)
+    (*@ function h12 (x_14:'a): 'b -> 'c *)
     
-    (*@ function h13 (x#15:'a * 'b) (y#8:'b * 'a): 'a * 'b *)
+    (*@ function h13 (x_15:'a * 'b) (y_8:'b * 'a): 'a * 'b *)
     
-    (*@ function h14 (x#16:'a): test *)
+    (*@ function h14 (x_16:'a): test *)
     
-    (*@ function h15 (x#17:test): integer *)
+    (*@ function h15 (x_17:test): integer *)
 
 
 *** OK ***

--- a/test/positive/basic_functions_axioms.mli.expected
+++ b/test/positive/basic_functions_axioms.mli.expected
@@ -256,82 +256,82 @@ module basic_functions_axioms.mli
     
     (*@ axiom a2: (1:integer = 0:integer):prop *)
     
-    (*@ function f1 (x#1:int): int *)
+    (*@ function f1 (x_1:int): int *)
     
-    (*@ function f2 (x#2:int): int =
-        x#2:int *)
+    (*@ function f2 (x_2:int): int =
+        x_2:int *)
     
-    (*@ function f#1 (x#3:integer): bool =
-        if (x#3:integer = 2:integer):prop then (True ):bool else (False ):
+    (*@ function f_1 (x_3:integer): bool =
+        if (x_3:integer = 2:integer):prop then (True ):bool else (False ):
         bool
     *)
     
-    (*@ function f#2 (x#4:integer): bool =
+    (*@ function f_2 (x_4:integer): bool =
         (True ):bool *)
     
-    (*@ function f#3 (x#5:bool): bool =
-        x#5:bool *)
+    (*@ function f_3 (x_5:bool): bool =
+        x_5:bool *)
     
-    (*@ predicate pred (x#6:bool) =
-        (x#6:bool = (True ):bool):prop *)
+    (*@ predicate pred (x_6:bool) =
+        (x_6:bool = (True ):bool):prop *)
     
-    (*@ function p (x#7:integer): integer =
-        x#7:integer
-        variant x#7:integer
-        requires (x#7:integer = 1:integer):prop
-        ensures (x#7:integer = 2:integer):prop
-        ensures (x#7:integer > 2:integer):prop
-        ensures (x#7:integer > 1:integer):prop
+    (*@ function p (x_7:integer): integer =
+        x_7:integer
+        variant x_7:integer
+        requires (x_7:integer = 1:integer):prop
+        ensures (x_7:integer = 2:integer):prop
+        ensures (x_7:integer > 2:integer):prop
+        ensures (x_7:integer > 1:integer):prop
     *)
     
-    (*@ function rec f#4 (x#8:bool): bool =
-        (f#4 x#8:bool):bool *)
+    (*@ function rec f_4 (x_8:bool): bool =
+        (f_4 x_8:bool):bool *)
     
-    (*@ function rec f#5 (x#9:bool) (y#1:int): bool =
-        (f#5  x#9:bool y#1:int):bool
+    (*@ function rec f_5 (x_9:bool) (y_1:int): bool =
+        (f_5  x_9:bool y_1:int):bool
     *)
     
-    (*@ function g#1 (a#1:int): integer =
-        if ((f#5  (True ):bool a#1:int):bool = (True ):bool):prop then 1:
+    (*@ function g_1 (a_1:int): integer =
+        if ((f_5  (True ):bool a_1:int):bool = (True ):bool):prop then 1:
         integer else 2:integer
     *)
     
-    (*@ function int_of_integer (x#10:integer): int *)
+    (*@ function int_of_integer (x_10:integer): int *)
     
-    (*@ function h#1 (a#2:int) (b:bool) (c:'a): bool =
-        if (a#2:int = (int_of_integer 2:integer):int):prop then (f#5  
-        b:bool (int_of_integer 3:integer):int):bool else if ((g#1 (int_of_integer 4:
+    (*@ function h_1 (a_2:int) (b:bool) (c:'a): bool =
+        if (a_2:int = (int_of_integer 2:integer):int):prop then (f_5  
+        b:bool (int_of_integer 3:integer):int):bool else if ((g_1 (int_of_integer 4:
         integer):int):integer = 5:integer):prop then (True ):bool else (False ):
         bool
     *)
     
-    (*@ function h#2 (a#3:int) (b#1:bool) (c#1:'a): bool =
-        if (a#3:int = (int_of_integer 2:integer):int):prop then (f#5  if (pred 
-        b#1:bool):prop then (True ):bool else (False ):bool (int_of_integer 3:
-        integer):int):bool else if ((g#1 (int_of_integer 4:integer):int):
+    (*@ function h_2 (a_3:int) (b_1:bool) (c_1:'a): bool =
+        if (a_3:int = (int_of_integer 2:integer):int):prop then (f_5  if (pred 
+        b_1:bool):prop then (True ):bool else (False ):bool (int_of_integer 3:
+        integer):int):bool else if ((g_1 (int_of_integer 4:integer):int):
         integer = 5:integer):prop then (True ):bool else (False ):bool
     *)
     
-    (*@ function h#3 (b#2:bool): bool =
-        if (pred b#2:bool):prop then (True ):bool else (False ):bool
+    (*@ function h_3 (b_2:bool): bool =
+        if (pred b_2:bool):prop then (True ):bool else (False ):bool
     *)
     
     (*@ function h : bool =
         [@ athing](True ):bool *)
     
-    (*@ function to_integer (i#1:int): integer *)
+    (*@ function to_integer (i_1:int): integer *)
     
-    (*@ function i#2 (a#4:int): int =
-        (int_of_integer ((to_integer a#4:int):integer + 1:integer):integer):
+    (*@ function i_2 (a_4:int): int =
+        (int_of_integer ((to_integer a_4:int):integer + 1:integer):integer):
         int
     *)
     
-    (*@ function i#3 (a#5:int): int =
-        (int_of_integer ((to_integer a#5:int):integer + 1:integer):integer):
+    (*@ function i_3 (a_5:int): int =
+        (int_of_integer ((to_integer a_5:int):integer + 1:integer):integer):
         int
-        requires ((to_integer a#5:int):integer > 0:integer):prop
-        ensures let old_a[@athing]:integer = (to_integer old (a#5:int)):
-                integer in ((to_integer a#5:int):integer = (old_a[@athing]:
+        requires ((to_integer a_5:int):integer > 0:integer):prop
+        ensures let old_a[@athing]:integer = (to_integer old (a_5:int)):
+                integer in ((to_integer a_5:int):integer = (old_a[@athing]:
                                                             integer + 1:
                 integer):integer):prop
     *)
@@ -340,9 +340,9 @@ module basic_functions_axioms.mli
                  function C (_:'a * int) : 'a t1
     
     
-    (*@ function i (a#6:'a t1): int =
-        match a#6:'a t1 with
-        | C (_, y#2:int) -> y#2:int
+    (*@ function i (a_6:'a t1): int =
+        match a_6:'a t1 with
+        | C (_, y_2:int) -> y_2:int
         end::int
     *)
     
@@ -356,36 +356,36 @@ module basic_functions_axioms.mli
     
     (*@ function gnr : 'a *)
     
-    (*@ function g#2 (x#11:'a) (y#3:'a) (i#4:int): 'a *)
+    (*@ function g_2 (x_11:'a) (y_3:'a) (i_4:int): 'a *)
     
-    (*@ function f#6 (x#12:'a t2): 'a =
-        match x#12:'a t2 with
-        | C2 x#13:'a -> x#13:'a
-        | C3 b#3:bool -> (gnr ):'a
-        | C4 (i#5:int, x#14:'a) -> (g#2  x#14:'a x#14:'a i#5:int):'a
+    (*@ function f_6 (x_12:'a t2): 'a =
+        match x_12:'a t2 with
+        | C2 x_13:'a -> x_13:'a
+        | C3 b_3:bool -> (gnr ):'a
+        | C4 (i_5:int, x_14:'a) -> (g_2  x_14:'a x_14:'a i_5:int):'a
         end::'a
     *)
     
-    (*@ axiom ax1: forall x#15:'a214 t2 y#4:'a214 . (y#4:'a214 = (f#6 
-    x#15:'a214 t2):'a214):prop *)
+    (*@ axiom ax1: forall x_15:'a214 t2 y_4:'a214 . (y_4:'a214 = (f_6 
+    x_15:'a214 t2):'a214):prop *)
     
-    val f#7 : int -> int -> int
-    (*@ r:int = f#7 x#16:int y#5:int
-        requires (((integer_of_int#1 y#5:int):integer + 2:integer):integer < 0:
+    val f_7 : int -> int -> int
+    (*@ r:int = f_7 x_16:int y_5:int
+        requires (((integer_of_int_1 y_5:int):integer + 2:integer):integer < 0:
                  integer):prop
-        requires ((integer_of_int#1 x#16:int):integer > 0:integer):prop
-        ensures ((integer_of_int#1 r:int):integer = ((integer_of_int#1 
-                x#16:int):integer + (integer_of_int#1 y#5:int):integer):
+        requires ((integer_of_int_1 x_16:int):integer > 0:integer):prop
+        ensures ((integer_of_int_1 r:int):integer = ((integer_of_int_1 
+                x_16:int):integer + (integer_of_int_1 y_5:int):integer):
                 integer):prop*)
     
-    type 'a t3 = A#1 of 
-                 function A#1  : 'a t3
+    type 'a t3 = A_1 of 
+                 function A_1  : 'a t3
     
     
-    (*@ function f (x#17:int): int t3 =
-        (A#1 ):int t3 *)
+    (*@ function f (x_17:int): int t3 =
+        (A_1 ):int t3 *)
     
-    (*@ function integer_of_int (x#18:int): integer *)
+    (*@ function integer_of_int (x_18:int): integer *)
     
     type t4 = A of 
               function A  : t4
@@ -405,18 +405,18 @@ module basic_functions_axioms.mli
                 function yy (_:'a t6) : int
     
     
-    (*@ function g#3 (a#7:t4) (b#4:t4 t5): t4 t6 =
-        match b#4:t4 t5 with
-        | constr#t5 x#19:int A -> (constr#t6  (B ):t4 x#19:int):t4 t6
-        | constr#t5 x#20:int B -> (constr#t6  (y b#4:t4 t5):t4 (int_of_integer 10:
+    (*@ function g_3 (a_7:t4) (b_4:t4 t5): t4 t6 =
+        match b_4:t4 t5 with
+        | constr#t5 x_19:int A -> (constr#t6  (B ):t4 x_19:int):t4 t6
+        | constr#t5 x_20:int B -> (constr#t6  (y b_4:t4 t5):t4 (int_of_integer 10:
                                   integer):int):t4 t6
         end::t4 t6
     *)
     
-    (*@ function g (a#8:t4) (b#5:t4 t5): t4 t6 =
-        match b#5:t4 t5 with
-        | constr#t5 x#21:int y#6:t4 -> (constr#t6  y#6:t4 x#21:int):t4 t6
-        | constr#t5 x#22:int B -> (constr#t6  (y b#5:t4 t5):t4 (int_of_integer 10:
+    (*@ function g (a_8:t4) (b_5:t4 t5): t4 t6 =
+        match b_5:t4 t5 with
+        | constr#t5 x_21:int y_6:t4 -> (constr#t6  y_6:t4 x_21:int):t4 t6
+        | constr#t5 x_22:int B -> (constr#t6  (y b_5:t4 t5):t4 (int_of_integer 10:
                                   integer):int):t4 t6
         end::t4 t6
     *)

--- a/test/positive/complex_vals.mli.expected
+++ b/test/positive/complex_vals.mli.expected
@@ -91,22 +91,22 @@ module complex_vals.mli
     
     exception Y
     
-    val f#1 : int -> int -> int
-    (*@ r#1:int = f#1 x#1:int y#1:int
-        requires (((integer_of_int x#1:int):integer + 1:integer):integer < 0:
+    val f_1 : int -> int -> int
+    (*@ r_1:int = f_1 x_1:int y_1:int
+        requires (((integer_of_int x_1:int):integer + 1:integer):integer < 0:
                  integer):prop
-        requires (((integer_of_int y#1:int):integer + 2:integer):integer < 0:
+        requires (((integer_of_int y_1:int):integer + 2:integer):integer < 0:
                  integer):prop
-        requires ((integer_of_int x#1:int):integer > 0:integer):prop
-        ensures ((integer_of_int r#1:int):integer = ((integer_of_int 
-                x#1:int):integer + (integer_of_int y#1:int):integer):
+        requires ((integer_of_int x_1:int):integer > 0:integer):prop
+        ensures ((integer_of_int r_1:int):integer = ((integer_of_int 
+                x_1:int):integer + (integer_of_int y_1:int):integer):
                 integer):prop
-        ensures ((integer_of_int r#1:int):integer > 2:integer):prop
-        ensures ((integer_of_int r#1:int):integer = 3:integer):prop
-        raises X  -> ((integer_of_int x#1:int):integer = 2:integer):prop
+        ensures ((integer_of_int r_1:int):integer > 2:integer):prop
+        ensures ((integer_of_int r_1:int):integer = 3:integer):prop
+        raises X  -> ((integer_of_int x_1:int):integer = 2:integer):prop
         raises Y i:int -> ((integer_of_int i:int):integer = (((integer_of_int 
-          y#1:int):integer + 2:integer):integer - (3:integer / (integer_of_int 
-          x#1:int):integer):integer):integer):prop*)
+          y_1:int):integer + 2:integer):integer - (3:integer / (integer_of_int 
+          x_1:int):integer):integer):integer):prop*)
 
 
 *** OK ***

--- a/test/positive/exceptions.mli.expected
+++ b/test/positive/exceptions.mli.expected
@@ -141,23 +141,23 @@ module exceptions.mli
     
     (*@ function integer_of_int (x:int): integer *)
     
-    (*@ function int_of_integer (x#1:integer): int *)
+    (*@ function int_of_integer (x_1:integer): int *)
     
     val f : 'a -> 'a
-    (*@ x#2:'a = f y:'a
-        raises E1 x#3:int -> ((integer_of_int x#3:int):integer = 1:integer):prop
+    (*@ x_2:'a = f y:'a
+        raises E1 x_3:int -> ((integer_of_int x_3:int):integer = 1:integer):prop
         raises E3 l:int list -> (match l:int list with
           | [] -> (False ):bool
-          | infix :: y#1:int ys:int list -> if ((integer_of_int y#1:int):
+          | infix :: y_1:int ys:int list -> if ((integer_of_int y_1:int):
                                             integer = 2:integer):prop then (True ):
                                             bool else (False ):bool
           end::bool = (True ):bool):prop
-        raises E4 i:int, l#1:int list -> (match l#1:int list with
+        raises E4 i:int, l_1:int list -> (match l_1:int list with
           | [] -> (True ):bool
-          | infix :: y#2:int ys#1:int list -> if (y#2:int = i:int):prop then (True ):
+          | infix :: y_2:int ys_1:int list -> if (y_2:int = i:int):prop then (True ):
                                               bool else (False ):bool
           end::bool = (True ):bool):prop
-        raises E5 f#1:int -> int -> ((integer_of_int (apply  f#1:int -> int (int_of_integer 3:
+        raises E5 f_1:int -> int -> ((integer_of_int (apply  f_1:int -> int (int_of_integer 3:
           integer):int):int):integer = 4:integer):prop*)
 
 

--- a/test/positive/modules.mli.expected
+++ b/test/positive/modules.mli.expected
@@ -268,15 +268,15 @@ module modules.mli
       type ta = C of int
                 function C (_:int) : ta
       
-      (*@ function int_of_integer (x#1:integer): int *)
-      (*@ function integer_of_int (x#2:int): integer *)
+      (*@ function int_of_integer (x_1:integer): int *)
+      (*@ function integer_of_int (x_2:int): integer *)
       module MB :
       sig
-        (*@ function fb (x#3:integer) (y#1:integer): ta =
-            (C (int_of_integer (x#3:integer + y#1:integer):integer):int):ta
+        (*@ function fb (x_3:integer) (y_1:integer): ta =
+            (C (int_of_integer (x_3:integer + y_1:integer):integer):int):ta
         *)
-        (*@ function int_of_float (x#4:float): int *)
-        (*@ function float_of_int (x#5:int): float *)
+        (*@ function int_of_float (x_4:float): int *)
+        (*@ function float_of_int (x_5:int): float *)
         module MC :
         sig
           type tc = {x:int; y:float}
@@ -284,8 +284,8 @@ module modules.mli
                    function x (_:tc) : int
                    function y (_:tc) : float
           
-          (*@ function fc (y#2:tc): ta =
-              (C (x y#2:tc):int):ta *)
+          (*@ function fc (y_2:tc): ta =
+              (C (x y_2:tc):int):ta *)
           (*@ function fcc (a:ta): tc =
               match a:ta with
               | C b:int -> (constr#tc  b:int (float_of_int b:int):float):tc
@@ -294,10 +294,10 @@ module modules.mli
         end
         module MD :
         sig
-          (*@ function td (a#1:ta) (b#1:tc): integer =
-              match a#1:ta with
+          (*@ function td (a_1:ta) (b_1:tc): integer =
+              match a_1:ta with
               | C c:int -> ((integer_of_int c:int):integer + (integer_of_int (x 
-                           b#1:tc):int):integer):integer
+                           b_1:tc):int):integer):integer
               end::integer
           *)
         end
@@ -312,17 +312,17 @@ module modules.mli
         
         val f : ft -> ft
         
-        (*@ function ff (x#6:ft): ft *)
-        (*@ predicate fp1 (x#7:ft) *)
-        (*@ predicate fp2 (x#8:ft) *)
+        (*@ function ff (x_6:ft): ft *)
+        (*@ predicate fp1 (x_7:ft) *)
+        (*@ predicate fp2 (x_8:ft) *)
       end
     
     module MF : MTF
     
     val default : MF.ft -> MF.ft
-    (*@ x#9:ft = default y#3:ft
-        requires (fp1 y#3:ft):prop
-        ensures (fp2 x#9:ft):prop*)
+    (*@ x_9:ft = default y_3:ft
+        requires (fp1 y_3:ft):prop
+        ensures (fp2 x_9:ft):prop*)
 
 
 *** OK ***

--- a/test/positive/more_types.mli.expected
+++ b/test/positive/more_types.mli.expected
@@ -91,14 +91,14 @@ module more_types.mli
     type 'a t2 = t1
     
     
-    (*@ function f#1 (x#1:t1): t1 =
-        x#1:t1 *)
+    (*@ function f_1 (x_1:t1): t1 =
+        x_1:t1 *)
     
     type 'c t3 = t1
     
     
-    (*@ function f#2 (x#2:t1): t1 =
-        x#2:t1 *)
+    (*@ function f_2 (x_2:t1): t1 =
+        x_2:t1 *)
     
     type ('a,'b) t4
     
@@ -106,11 +106,11 @@ module more_types.mli
     type 'a t5 = ('a,'a) t4
     
     
-    (*@ function f#3 (x#3:('a,'a) t4): ('a,'a) t4 =
-        x#3:('a,'a) t4 *)
+    (*@ function f_3 (x_3:('a,'a) t4): ('a,'a) t4 =
+        x_3:('a,'a) t4 *)
     
-    (*@ function f#4 (x#4:('a,'a) t4): ('a,'a) t4 =
-        x#4:('a,'a) t4 *)
+    (*@ function f_4 (x_4:('a,'a) t4): ('a,'a) t4 =
+        x_4:('a,'a) t4 *)
     
     type 'a t6 = {x:int; y:'a}
               function constr#t6 (_:int) (_:'a) : 'a t6
@@ -121,9 +121,9 @@ module more_types.mli
     type ('a,'b) t7 = 'a t6
     
     
-    (*@ function f (x#5:'a t6): 'a t6 =
-        match x#5:'a t6 with
-        | constr#t6 x#6:int y#1:'a -> (constr#t6  x#6:int y#1:'a):'a t6
+    (*@ function f (x_5:'a t6): 'a t6 =
+        match x_5:'a t6 with
+        | constr#t6 x_6:int y_1:'a -> (constr#t6  x_6:int y_1:'a):'a t6
         end::'a t6
     *)
 

--- a/test/positive/type_decl.mli.expected
+++ b/test/positive/type_decl.mli.expected
@@ -211,7 +211,7 @@ module type_decl.mli
       'a t2
       'b t20 [='b t19]
       'a t21 [='a t22]
-      'b t22#1
+      'b t22_1
        t23 [=u]
       ('a,'b) t3
        test
@@ -221,11 +221,11 @@ module type_decl.mli
       'a test5
       ('a,'b) test6
       ('x,'g) test7
-       u#1
+       u_1
        v [=u]
       
     Logic Symbols
-      function C (_:u) : u#1
+      function C (_:u) : u_1
       function C1 (_:'a * 'b) : ('a,'b,'c) t18
       function C2 (_:int) (_:'a) : ('a,'b,'c) t18
       function C3  : ('a,'b,'c) t18
@@ -250,7 +250,7 @@ module type_decl.mli
       function constr#t10 (_:int) : t10
       function constr#t11 (_:int) (_:float) : t11
       function constr#t12 (_:'a) (_:'a * int) : 'a t12
-      function x#1 (_:'a t12) : 'a
+      function x_1 (_:'a t12) : 'a
       function y (_:'a t12) : 'a * int
       
     Exception Symbols
@@ -309,32 +309,32 @@ module type_decl.mli
                          function T12 (_:'g * int) : ('x,'g) test7
     
     
-    type t10 = {x#2:int}
+    type t10 = {x_2:int}
             function constr#t10 (_:int) : t10
-              function x#2 (_:t10) : int
+              function x_2 (_:t10) : int
     
     
-    type t11 = {x#3:int; mutable y#1:float}
+    type t11 = {x_3:int; mutable y_1:float}
             function constr#t11 (_:int) (_:float) : t11
-              function x#3 (_:t11) : int
-              function y#1 (_:t11) : float
+              function x_3 (_:t11) : int
+              function y_1 (_:t11) : float
     
     
-    type 'a t12 = {x#1:'a; y:'a * int}
+    type 'a t12 = {x_1:'a; y:'a * int}
                function constr#t12 (_:'a) (_:'a * int) : 'a t12
-                 function x#1 (_:'a t12) : 'a
+                 function x_1 (_:'a t12) : 'a
                  function y (_:'a t12) : 'a * int
     
     
-    type t13 = T13 of {x#4:int}
+    type t13 = T13 of {x_4:int}
                function T13 (_:int) : t13
     
     
-    type 'a t14 = T14 of {x#5:'a; y#2:int}
+    type 'a t14 = T14 of {x_5:'a; y_2:int}
                   function T14 (_:'a) (_:int) : 'a t14
     
     
-    type 'a t15 = T151 of {x#6:'a; y#3:int}
+    type 'a t15 = T151 of {x_6:'a; y_3:int}
                   function T151 (_:'a) (_:int) : 'a t15
                | T152 of int * 'a
                  function T152 (_:int * 'a) : 'a t15
@@ -348,34 +348,34 @@ module type_decl.mli
     
     type ('a,'b,'c) t18 = C1 of 'a * 'b
                           function C1 (_:'a * 'b) : ('a,'b,'c) t18
-                       | C2 of {i:int; a#1:'a}
+                       | C2 of {i:int; a_1:'a}
                          function C2 (_:int) (_:'a) : ('a,'b,'c) t18
                        | C3 of 
                          function C3  : ('a,'b,'c) t18
-                       | C4 of {i#1:int; a#2:'a}
+                       | C4 of {i_1:int; a_2:'a}
                          function C4 (_:int) (_:'a) : ('a,'b,'c) t18
-                       | C5 of {c#1:'c}
+                       | C5 of {c_1:'c}
                          function C5 (_:'c) : ('a,'b,'c) t18
     
     
-    type 'a t19 = C#1 of 'a
-                  function C#1 (_:'a) : 'a t19
+    type 'a t19 = C_1 of 'a
+                  function C_1 (_:'a) : 'a t19
     
-    and 'b t20 = 'b t19 = C#2 of 'b
-                          function C#2 (_:'b) : 'b t19
+    and 'b t20 = 'b t19 = C_2 of 'b
+                          function C_2 (_:'b) : 'b t19
     
     
-    type 'a t21 = 'a t22 = C#3 of 'a
-                           function C#3 (_:'a) : 'a t22
+    type 'a t21 = 'a t22 = C_3 of 'a
+                           function C_3 (_:'a) : 'a t22
     
-    and 'b t22#1 = C#4 of 'b
-                   function C#4 (_:'b) : 'b t22#1
+    and 'b t22_1 = C_4 of 'b
+                   function C_4 (_:'b) : 'b t22_1
     
     
     type t23 = u
     
-    and u#1 = C of u
-              function C (_:u) : u#1
+    and u_1 = C of u
+              function C (_:u) : u_1
     
     and v = u
     

--- a/test/positive/vals.mli.expected
+++ b/test/positive/vals.mli.expected
@@ -100,49 +100,49 @@ module vals.mli
     val f : int -> int -> int
     (*@ r:int = f y:int x:int*)
     
-    val f#1 : y:int -> int -> int
-    (*@ r#1:int = f#1 ~y#1:int x#1:int*)
+    val f_1 : y:int -> int -> int
+    (*@ r_1:int = f_1 ~y_1:int x_1:int*)
     
-    val f#2 : ?y:int -> int -> int
-    (*@ r#2:int = f#2 ?y#2:int option x#2:int*)
+    val f_2 : ?y:int -> int -> int
+    (*@ r_2:int = f_2 ?y_2:int option x_2:int*)
     
-    val f#3 : y:int -> ?x:int -> int
-    (*@ r#3:int = f#3 ~y#3:int ?x#3:int option*)
+    val f_3 : y:int -> ?x:int -> int
+    (*@ r_3:int = f_3 ~y_3:int ?x_3:int option*)
     
-    val f#4 : ?y:int -> x:int -> int
-    (*@ r#4:int = f#4 ?y#4:int option ~x#4:int*)
+    val f_4 : ?y:int -> x:int -> int
+    (*@ r_4:int = f_4 ?y_4:int option ~x_4:int*)
     
-    val f#5 : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c
-    (*@ r#5:'c = f#5 x#5:'a -> 'b -> 'c y#5:'a z:'b*)
+    val f_5 : ('a -> 'b -> 'c) -> 'a -> 'b -> 'c
+    (*@ r_5:'c = f_5 x_5:'a -> 'b -> 'c y_5:'a z:'b*)
     
-    val f#6 : x:('a -> 'b -> 'c) -> 'a -> 'b -> 'c
-    (*@ r#6:'c = f#6 ~x#6:'a -> 'b -> 'c y#6:'a z#1:'b*)
+    val f_6 : x:('a -> 'b -> 'c) -> 'a -> 'b -> 'c
+    (*@ r_6:'c = f_6 ~x_6:'a -> 'b -> 'c y_6:'a z_1:'b*)
     
-    val f#7 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
-    (*@ r#7:'c = f#7 ~x#7:'a -> 'b -> 'c ~y#7:'a z#2:'b*)
+    val f_7 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
+    (*@ r_7:'c = f_7 ~x_7:'a -> 'b -> 'c ~y_7:'a z_2:'b*)
     
-    val f#8 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
-    (*@ r#8:'c = f#8 ~x#8:'a -> 'b -> 'c [w:int: int] ~y#8:'a z#3:'b*)
+    val f_8 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
+    (*@ r_8:'c = f_8 ~x_8:'a -> 'b -> 'c [w:int: int] ~y_8:'a z_3:'b*)
     
-    val f#9 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
-    (*@ r#9:'c = f#9
-        ~x#9:'a -> 'b -> 'c [w#1:int: int] ~y#9:'a [p:integer: integer] 
-        z#4:'b*)
+    val f_9 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
+    (*@ r_9:'c = f_9
+        ~x_9:'a -> 'b -> 'c [w_1:int: int] ~y_9:'a [p:integer: integer] 
+        z_4:'b*)
     
-    val f#10 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
-    (*@ r#10:'c, [a#1:'a: 'a] = f#10
-        ~x#10:'a -> 'b -> 'c [w#2:int: int] ~y#10:'a [p#1:integer: integer] 
-        z#5:'b*)
+    val f_10 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
+    (*@ r_10:'c, [a_1:'a: 'a] = f_10
+        ~x_10:'a -> 'b -> 'c [w_2:int: int] ~y_10:'a [p_1:integer: integer] 
+        z_5:'b*)
     
-    val f#11 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
-    (*@ [b#1:integer: integer], r#11:'c, [a#2:'a: 'a] = f#11
-        ~x#11:'a -> 'b -> 'c [w#3:int: int] ~y#11:'a [p#2:integer: integer] 
-        z#6:'b*)
+    val f_11 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
+    (*@ [b_1:integer: integer], r_11:'c, [a_2:'a: 'a] = f_11
+        ~x_11:'a -> 'b -> 'c [w_3:int: int] ~y_11:'a [p_2:integer: integer] 
+        z_6:'b*)
     
-    val f#12 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
-    (*@ [b#2:integer: integer], r#12:'c, [a#3:'a: 'a] = f#12
-        ~x#12:'a -> 'b -> 'c [w#4:int: int] ~y#12:'a [p#3:integer: integer] 
-        z#7:'b*)
+    val f_12 : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
+    (*@ [b_2:integer: integer], r_12:'c, [a_3:'a: 'a] = f_12
+        ~x_12:'a -> 'b -> 'c [w_4:int: int] ~y_12:'a [p_3:integer: integer] 
+        z_7:'b*)
 
 
 *** OK ***


### PR DESCRIPTION
The simplest way to make pretty-printed identifiers valid for OCaml. Happy to change to something different if there's a better way.