### PR TITLE
Do not fold exceptional postconditions

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -606,13 +606,13 @@ let process_val_spec kid crcm ns id cty vs =
   let cs = List.map (fun t -> let dt = dterm kid crcm ns env t in
                               term env dt) vs.sp_consumes in
 
-  let process_xpost mxs (loc,exn) =
+  let process_xpost (loc, exn) =
     let merge_xpost t tl = match t, tl with
       | None, None -> Some []
       | None, Some tl -> Some tl
       | Some t, None -> Some [t]
       | Some t, Some tl -> Some (t::tl) in
-    let process mxs (q,pt) =
+    let process mxs (q, pt) =
       let xs = find_q_xs ns q in
       match pt with
       | None -> Mxs.update xs (merge_xpost None) mxs
@@ -633,9 +633,13 @@ let process_val_spec kid crcm ns id cty vs =
          let choose_snd _ _ vs = Some vs in
          let env = Mstr.union choose_snd env vars in
          let t = fmla kid crcm ns env t in
-         Mxs.update xs (merge_xpost (Some (p,t))) mxs in
-    List.fold_left process mxs exn in
-  let xpost = List.fold_left process_xpost Mxs.empty vs.sp_xpost in
+         Mxs.update xs (merge_xpost (Some (p,t))) mxs
+    in
+    List.fold_left process Mxs.empty exn |> Mxs.bindings
+  in
+  let xpost =
+    List.fold_left (fun acc xp -> process_xpost xp @ acc) [] vs.sp_xpost
+  in
 
   let env, ret = match vs.sp_hd_ret, ret.ty_node with
     | [], _ -> env, []

--- a/test/positive/complex_vals.mli.expected
+++ b/test/positive/complex_vals.mli.expected
@@ -105,11 +105,11 @@ module complex_vals.mli.pp
                 y_1:int):integer):integer):prop
                 ensures ((integer_of_int  r_1:int):integer > 2:integer):prop
                 ensures ((integer_of_int  r_1:int):integer = 3:integer):prop
-        raisesX  -> ((integer_of_int  x_1:int):integer = 2:integer):prop
         raisesY i:int -> ((integer_of_int 
-              i:int):integer = (((integer_of_int 
-              y_1:int):integer + 2:integer):integer - (3:integer / (integer_of_int 
-              x_1:int):integer):integer):integer):prop*)
+                         i:int):integer = (((integer_of_int 
+                         y_1:int):integer + 2:integer):integer - (3:integer / (integer_of_int 
+                         x_1:int):integer):integer):integer):prop
+        raisesX  -> ((integer_of_int  x_1:int):integer = 2:integer):prop*)
 
 
 *** OK ***

--- a/test/positive/exceptions.mli
+++ b/test/positive/exceptions.mli
@@ -43,7 +43,7 @@ exception E10 of {x : int -> int -> float;
 
 val f : 'a -> 'a
 (*@ x = f y
-    raises E1 x -> integer_of_int x = 1
+    raises E1 x -> integer_of_int x = 1 | E1 _ -> false
     raises E2 _ -> true
     raises E2 (x, y) -> true
     raises E2 (_, _) -> true

--- a/test/positive/exceptions.mli.expected
+++ b/test/positive/exceptions.mli.expected
@@ -26,7 +26,7 @@ exception E10 of {
 [@@@gospel {| function int_of_integer (x:integer): int |}]
 val f : 'a -> 'a[@@gospel
                   {| x = f y
-    raises E1 x -> integer_of_int x = 1
+    raises E1 x -> integer_of_int x = 1 | E1 _ -> false
     raises E2 _ -> true
     raises E2 (x, y) -> true
     raises E2 (_, _) -> true
@@ -165,31 +165,35 @@ module exceptions.mli.pp
     
     val f : 'a -> 'a
     (*@ x_2:'a = f y:'a
-        raisesE1 x_3:int -> ((integer_of_int 
-              x_3:int):integer = 1:integer):prop
-        raisesE2 _, _ -> true:prop
-              raisesE2 x_4:int, y_1:int -> true:prop
-              raisesE2 _ -> true:prop
-        raisesE2pair z:int * int -> true:prop
-              raisesE2pair _, _ -> true:prop
-              raisesE2pair x_5:int, y_2:int -> true:prop
-              raisesE2pair _ -> true:prop
-        raisesE3 l:int list -> (match l:int list with
-              | [] -> (False ):bool
-              | infix :: y_3:int ys:int list -> if ((integer_of_int 
-                                                y_3:int):integer = 2:
-                                                integer):prop then (True ):
-                                                bool else (False ):bool
-              end::bool = (True ):bool):prop
-        raisesE4 i:int, l_1:int list -> (match l_1:int list with
-              | [] -> (True ):bool
-              | infix :: y_4:int ys_1:int list -> if (y_4:int = i:int):prop then (True ):
-                                                  bool else (False ):
-                                                  bool
-              end::bool = (True ):bool):prop
         raisesE5 f_1:int -> int -> ((integer_of_int 
-              (apply  f_1:int -> int (int_of_integer  3:integer):int):int):
-              integer = 4:integer):prop*)
+                                   (apply 
+                                   f_1:int -> int (int_of_integer 
+                                   3:integer):int):int):integer = 4:integer):prop
+        raisesE3 l:int list -> (match l:int list with
+                               | [] -> (False ):bool
+                               | infix :: y_1:int ys:int list -> if ((integer_of_int 
+                                                                 y_1:int):
+                                                                 integer = 2:
+                                                                 integer):prop then (True ):
+                                                                 bool else (False ):
+                                                                 bool
+                               end::bool = (True ):bool):prop
+        raisesE4 i:int, l_1:int list -> (match l_1:int list with
+                                        | [] -> (True ):bool
+                                        | infix :: y_2:int ys_1:int list -> 
+                                        if (y_2:int = i:int):prop then (True ):
+                                        bool else (False ):bool
+                                        end::bool = (True ):bool):prop
+        raisesE2pair z:int * int -> true:prop
+        raisesE2pair _, _ -> true:prop
+        raisesE2pair x_3:int, y_3:int -> true:prop
+        raisesE2pair _ -> true:prop
+        raisesE2 _, _ -> true:prop
+        raisesE2 x_4:int, y_4:int -> true:prop
+        raisesE2 _ -> true:prop
+        raisesE1 _ -> false:prop
+              | E1 x_5:int -> ((integer_of_int 
+                              x_5:int):integer = 1:integer):prop*)
 
 
 *** OK ***


### PR DESCRIPTION
Depends on #12.

This fixes the representation of exceptional postconditions, which used to be
```ocaml
(pattern * term) list Mxs.t
```
into 
```ocaml
(xsymbol * (pattern * post) list) list
```

In the former, all `raises` clauses with the same exception constructor were folded into a single `(pattern * term) list`, while we would like to keep them separated to implement the specification we started writing [here](https://ocaml-gospel.github.io/gospel/language.html#exceptional-postconditions), which is `raises` are independent from each other, and thus can generally not be merged. 
It is therefore possible to get multiple identical `xsymbol`s in the new association list, when multiple `raises` treated that exception.

As a side effect, we don't have to expose `Mxs`, which forced Gospel clients to use Gospel's internals.

This probably have implications for the why3plugin plugin /cc @mariojppereira.