### PR TITLE
Make function and type specs optional

### DIFF
--- a/src/tast.ml
+++ b/src/tast.ml
@@ -225,7 +225,7 @@ type function_ = {
     fun_rec    : bool;
     fun_params : vsymbol list;
     fun_def    : term option;
-    fun_spec   : fun_spec;
+    fun_spec   : fun_spec option;
     fun_loc    : Location.t;
 }
 
@@ -262,18 +262,25 @@ let mk_function ?result ls r params def spec loc =
 
   (* check 3 *)
   Option.iter (t_free_vs_in_set args) def;
-  List.iter (t_free_vs_in_set args) spec.fun_req;
+  Option.iter
+    (fun spec -> List.iter (t_free_vs_in_set args) spec.fun_req)
+    spec;
   let args_r = match result,ls.ls_value with
     | Some vs, Some ty ->
        ty_equal_check vs.vs_ty ty; Svs.add vs args
     | _ -> args in
-  List.iter (t_free_vs_in_set args_r) spec.fun_ens;
+  Option.iter
+    (fun spec -> List.iter (t_free_vs_in_set args_r) spec.fun_ens)
+    spec;
 
   (* check 4 and 5 *)
   let check_ty ty t = t_ty_check t ty in
   Option.iter (check_ty ls.ls_value) def;
-  List.iter (check_ty (Some ty_integer)) spec.fun_variant;
-  List.iter (check_ty None) spec.fun_ens;
+  Option.iter
+    (fun spec ->
+       List.iter (check_ty (Some ty_integer)) spec.fun_variant;
+       List.iter (check_ty None) spec.fun_ens)
+    spec;
 
   function_ ls r params def spec loc
 
@@ -548,8 +555,21 @@ let print_function f x =
   let func_pred = if x.fun_ls.ls_value = None then "predicate" else "function" in
   let print_term f t = pp f "@[%a@]" print_term t in
   let print_term f t = pp f "@[%a@]" print_term t in
+  let func_spec f x =
+    pp f "%a%a%a%a"
+      (fun f _ -> if x.fun_coer then pp f "@\ncoercion" else ()) ()
+      (list ~first:(newline ++ const string "variant ")
+         ~sep:(newline ++ const string "variant ")
+         print_term) x.fun_variant
+      (list ~first:(newline ++ const string "requires ")
+         ~sep:(newline ++ const string "requires ")
+         print_term) x.fun_req
+      (list ~first:(newline ++ const string "ensures ")
+         ~sep:(newline ++ const string "ensures ")
+         print_term) x.fun_ens
+  in
   let func f x =
-    pp f "@[%s %s%a %a%a%a%a%a%a%a@]"
+    pp f "@[%s %s%a %a%a%a%a@]"
       func_pred
       (if x.fun_rec then "rec " else "")
       Ident.pp x.fun_ls.ls_name
@@ -558,16 +578,7 @@ let print_function f x =
       (option
          (fun f -> pp f " =@\n@[<hov2>@[%a@]@]" print_term))
       x.fun_def
-      (fun f _ -> if x.fun_spec.fun_coer then pp f "@\ncoercion" else ()) ()
-      (list ~first:(newline ++ const string "variant ")
-         ~sep:(newline ++ const string "variant ")
-         print_term) x.fun_spec.fun_variant
-      (list ~first:(newline ++ const string "requires ")
-         ~sep:(newline ++ const string "requires ")
-         print_term) x.fun_spec.fun_req
-      (list ~first:(newline ++ const string "ensures ")
-         ~sep:(newline ++ const string "ensures ")
-         print_term) x.fun_spec.fun_ens
+      (option func_spec) x.fun_spec
   in
   spec func f x
 

--- a/src/tast.ml
+++ b/src/tast.ml
@@ -178,7 +178,7 @@ type type_declaration = {
     td_private  : private_flag;
     td_manifest : ty option;
     td_attrs    : Parsetree.attributes;
-    td_spec     : type_spec;
+    td_spec     : type_spec option;
     td_loc      : Location.t;
 }
 
@@ -482,7 +482,7 @@ let print_type_declaration fmt td =
     print_type_kind td.td_kind
     (if td.td_cstrs = [] then "" else " constraint ")
     (list ~sep:(const string " constraint ") print_constraint) td.td_cstrs
-    print_type_spec td.td_spec
+    (option print_type_spec) td.td_spec
 
 let print_lb_arg fmt = function
   | Lunit -> pp fmt "()"

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -314,8 +314,10 @@ let add_sig_contents muc sig_ =
   match sig_.sig_desc with
   | Sig_function f ->
      let muc = add_ls ~export:true muc f.fun_ls.ls_name.id_str f.fun_ls in
-     let muc =
-       if f.fun_spec.fun_coer then add_coer muc f.fun_ls else muc in
+     let muc = match f.fun_spec with
+       | Some spec when spec.fun_coer -> add_coer muc f.fun_ls
+       | _ -> muc
+     in
      add_kid muc f.fun_ls.ls_name sig_
   | Sig_type (_,tdl,_) ->
      let add_td muc td =

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -324,7 +324,11 @@ let add_sig_contents muc sig_ =
        let csl = get_cs_pjs td.td_kind in
        let muc = List.fold_left (fun muc cs ->
          add_ls ~export:true muc cs.ls_name.id_str cs) muc csl in
-       let fields = List.map fst td.td_spec.ty_fields in
+       let fields =
+         Option.fold
+           ~none:[] ~some:(fun spec -> List.map fst spec.ty_fields)
+           td.td_spec
+       in
        let muc = List.fold_left (fun muc ls ->
          add_ls ~export:true muc ls.ls_name.id_str ls) muc fields in
        add_kid muc td.td_ts.ts_ident sig_  in

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -517,7 +517,7 @@ let type_type_declaration kid crcm ns tdl =
     in
 
     let params = List.combine params variance_list in
-    let spec = process_type_spec kid crcm ns ty td.tspec in
+    let spec = Option.map (process_type_spec kid crcm ns ty) td.tspec in
 
     if  td.tcstrs != [] then
       not_supported ~loc:td.tloc "type constraints not supported";

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -694,12 +694,16 @@ let process_function kid crcm ns f =
     | Some ty -> Option.map (term_with_unify kid crcm ty ns env) f.fun_def in
 
   let spec =
-    let req = List.map (fmla kid crcm ns env) f.fun_spec.fun_req in
-    let ens = List.map (fmla kid crcm ns env) f.fun_spec.fun_ens in
-    let variant =
-      List.map (term_with_unify kid crcm ty_integer ns env)
-        f.fun_spec.fun_variant in
-    mk_fun_spec req ens variant f.fun_spec.fun_coer in
+    Option.map (fun (spec: Uast.fun_spec) ->
+        let req = List.map (fmla kid crcm ns env) spec.fun_req in
+        let ens = List.map (fmla kid crcm ns env) spec.fun_ens in
+        let variant =
+          List.map (term_with_unify kid crcm ty_integer ns env)
+            spec.fun_variant
+        in
+        mk_fun_spec req ens variant spec.fun_coer)
+      f.fun_spec
+  in
   let f = mk_function ?result ls f.fun_rec params def spec f.fun_loc in
   mk_sig_item (Sig_function f) f.fun_loc
 

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -193,7 +193,7 @@ type s_type_declaration =
     tprivate    : private_flag;   (* = private ... *)
     tmanifest   : core_type option;  (* = T *)
     tattributes : attributes;   (* ... [@@id1] [@@id2] *)
-    tspec       : type_spec; (* specification *)
+    tspec       : type_spec option; (* specification *)
     tloc        : Location.t;
   }
 

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -150,7 +150,7 @@ type function_ = {
   fun_type    : pty option;
   fun_params  : param list;
   fun_def     : term option;
-  fun_spec    : fun_spec;
+  fun_spec    : fun_spec option;
   fun_loc     : Location.t;
 }
 

--- a/src/uast_utils.ml
+++ b/src/uast_utils.ml
@@ -38,34 +38,41 @@ let array_get s e =
 
 let dummy_position = Location.none
 
+let empty_fspec = {
+  fun_req     = [];
+  fun_ens     = [];
+  fun_variant = [];
+  fun_coer    = false;
+}
+
 let fspec_union s1 s2 = {
-      fun_req     = s1.fun_req @ s2.fun_req;
-      fun_ens     = s1.fun_ens @ s2.fun_ens;
-      fun_variant = s1.fun_variant @ s2.fun_variant;
-      fun_coer    = s1.fun_coer || s2.fun_coer;
-    }
+  fun_req     = s1.fun_req @ s2.fun_req;
+  fun_ens     = s1.fun_ens @ s2.fun_ens;
+  fun_variant = s1.fun_variant @ s2.fun_variant;
+  fun_coer    = s1.fun_coer || s2.fun_coer;
+}
 
 let empty_tspec = {
-    ty_ephemeral = false;
-    ty_field = [];
-    ty_invariant = [];
-  }
+  ty_ephemeral = false;
+  ty_field = [];
+  ty_invariant = [];
+}
 
 let tspec_union s1 s2 = {
-    ty_ephemeral = s1.ty_ephemeral || s2.ty_ephemeral;
-    ty_field = s1.ty_field @ s2.ty_field;
-    ty_invariant = s1.ty_invariant @ s2.ty_invariant;
-  }
+  ty_ephemeral = s1.ty_ephemeral || s2.ty_ephemeral;
+  ty_field = s1.ty_field @ s2.ty_field;
+  ty_invariant = s1.ty_invariant @ s2.ty_invariant;
+}
 
-let rev_tspec ts =
-  { ts with
-    ty_field = List.rev ts.ty_field;
-    ty_invariant = List.rev ts.ty_invariant;
-  }
+let rev_tspec ts = {
+  ts with
+  ty_field = List.rev ts.ty_field;
+  ty_invariant = List.rev ts.ty_invariant;
+}
 
 let pid_of_label = function
-    | Lunit -> invalid_arg "pid_of_label Lunit"
-    | Lnone p | Lquestion p | Lnamed p | Lghost (p,_) -> p
+  | Lunit -> invalid_arg "pid_of_label Lunit"
+  | Lnone p | Lquestion p | Lnamed p | Lghost (p,_) -> p
 
 let str_of_label l = (pid_of_label l).pid_str
 

--- a/src/uattr2spec.ml
+++ b/src/uattr2spec.ml
@@ -145,11 +145,13 @@ let type_spec ?(extra_spec=[]) t =
   let tspec = List.map get_type_spec tspec in
   let tspec = tspec @ extra_spec in
   let tspec = List.fold_left tspec_union empty_tspec tspec in
-  let td = { tname = t.ptype_name;       tparams= t.ptype_params;
-             tcstrs = t.ptype_cstrs;     tkind = t.ptype_kind;
-             tprivate = t.ptype_private; tmanifest = t.ptype_manifest;
-             tattributes = attr;         tspec = tspec;
-             tloc = t.ptype_loc;} in
+  let td = {
+    tname = t.ptype_name;       tparams= t.ptype_params;
+    tcstrs = t.ptype_cstrs;     tkind = t.ptype_kind;
+    tprivate = t.ptype_private; tmanifest = t.ptype_manifest;
+    tattributes = attr;         tloc = t.ptype_loc;
+    tspec = if tspec = empty_tspec then None else Some tspec; }
+  in
   td, fspec
 
 (** It parses a list of type declarations. If more than one item is
@@ -255,7 +257,7 @@ let with_constraint c =
       tcstrs = t.ptype_cstrs; tkind = t.ptype_kind;
       tprivate = t.ptype_private; tmanifest = t.ptype_manifest;
       tattributes = t.ptype_attributes;
-      tspec = empty_tspec; tloc = t.ptype_loc;}
+      tspec = None; tloc = t.ptype_loc;}
   in match c with
   | Pwith_type (l,t) -> Wtype (l,no_spec_type_decl t)
   | Pwith_module (l1,l2) -> Wmodule (l1,l2)

--- a/src/uattr2spec.ml
+++ b/src/uattr2spec.ml
@@ -209,12 +209,18 @@ let rec floating_specs = function
      {sdesc=Sig_ghost_open od; sloc} :: floating_specs xs
   | Sfunction (f,sloc) :: xs ->
      (* Look forward and get floating function specification *)
-     let (fun_specs,xs) = split_at_f is_func_spec xs in
+     let fun_specs, xs = split_at_f is_func_spec xs in
      let fun_specs = List.map get_func_spec fun_specs in
-     let fun_specs = List.fold_left Uast_utils.fspec_union
-                     f.fun_spec fun_specs in
-     let f = {f with fun_spec = fun_specs } in
-     {sdesc=Sig_function f;sloc} :: floating_specs xs
+     let fun_specs =
+       List.fold_left Uast_utils.fspec_union
+         (Option.value ~default:empty_fspec f.fun_spec)
+         fun_specs
+     in
+     let f = {
+       f with
+       fun_spec = if fun_specs = empty_fspec then None else Some fun_specs }
+     in
+     {sdesc=Sig_function f; sloc} :: floating_specs xs
   | Saxiom (a,sloc) :: xs ->
      {sdesc=Sig_axiom a;sloc} :: floating_specs xs
   | Stype_ghost (r,td,sloc) :: xs ->

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -14,13 +14,6 @@
   open Uast
   open Uast_utils
 
-  let empty_fspec = {
-      fun_req     = [];
-      fun_ens     = [];
-      fun_variant = [];
-      fun_coer    = false;
-    }
-
   let empty_vspec = {
     sp_hd_ret  = [];
     sp_hd_nm   = mk_pid "" Lexing.dummy_pos Lexing.dummy_pos;
@@ -35,12 +28,6 @@
     sp_diverge = false;
     sp_equiv   = [];
   }
-
-  let empty_tspec = {
-      ty_ephemeral = false;
-      ty_field     = [];
-      ty_invariant = [];
-    }
 
 %}
 
@@ -130,11 +117,11 @@ axiom:
 
 func:
 | FUNCTION fun_rec=boption(REC) fun_name=func_name fun_params=loption(params)
-    COLON ty=typ fun_def=preceded(EQUAL, term)? fun_spec=func_spec
+    COLON ty=typ fun_def=preceded(EQUAL, term)? fun_spec=nonempty_func_spec?
   { { fun_name; fun_rec; fun_type = Some ty; fun_params; fun_def; fun_spec;
       fun_loc = mk_loc $startpos $endpos } }
 | PREDICATE fun_rec=boption(REC) fun_name=func_name fun_params=params
-    fun_def=preceded(EQUAL, term)? fun_spec=func_spec
+    fun_def=preceded(EQUAL, term)? fun_spec=nonempty_func_spec?
   { { fun_name; fun_rec; fun_type = None; fun_params; fun_def; fun_spec;
       fun_loc = mk_loc $startpos $endpos } }
 ;

--- a/src/upretty_printer.ml
+++ b/src/upretty_printer.ml
@@ -152,18 +152,22 @@ let function_ f x =
   let keyword = match x.fun_type with
     | None -> "predicate"
     | Some _ -> "function" in
-  let sep f _ =  match x.fun_spec with
+  let sep f x =  match x with
     | { fun_req=[];fun_ens=[];fun_variant=[];_ } -> () | _ -> pp f "@\n" in
+  let func_spec f x =
+    pp f "%a%a%a%a%a"
+      (fun f _ -> if x.fun_coer then pp f "@\ncoercion" else ()) ()
+      sep x
+      (list_keyword "variant ...") x.fun_variant
+      (list_keyword "requires ...") x.fun_req
+      (list_keyword "ensures ...") x.fun_ens
+  in
   let func f x =
-    pp f "@[%s %s%a ...%a%a%a%a%a@]"
+    pp f "@[%s %s%a ...%a@]"
       keyword
       (if x.fun_rec then "rec " else "")
       Preid.pp x.fun_name
-      (fun f _ -> if x.fun_spec.fun_coer then pp f "@\ncoercion" else ()) ()
-      sep ()
-      (list_keyword "variant ...") x.fun_spec.fun_variant
-      (list_keyword "requires ...") x.fun_spec.fun_req
-      (list_keyword "ensures ...") x.fun_spec.fun_ens
+      (option func_spec) x.fun_spec
   in
   spec func f x
 

--- a/src/upretty_printer.ml
+++ b/src/upretty_printer.ml
@@ -139,7 +139,7 @@ let s_type_declaration_rec_flag f (rf,l) =
       eq
       s_type_declaration x
       (item_attributes reset_ctxt) x.tattributes
-      type_spec x.tspec
+      (option type_spec) x.tspec
   in
   match l with
   | [] -> assert false


### PR DESCRIPTION
Currently, only `val` specifications are optional in the AST.
`type` and `function` specs are not optional, which means it's impossible to make a difference between an empty spec, or a spec that just repeats the defaults, and no spec at all.
This is problematic if we want a different behaviour (and it seems that we do).
The current handling is a bit hacky, particularly in `Uattr2spec`, but this bit will be removed in a subsequent PR anyway. 