### PR TITLE
Separate pres and checks

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -599,8 +599,9 @@ let process_val_spec kid crcm ns id cty vs =
 
   let env, args = process_args vs.sp_hd_args args Mstr.empty [] in
 
-  let pre   = List.map (fun (t,c) ->
-                  fmla kid crcm ns env t, c) vs.sp_pre in
+  let pre = List.map (fmla kid crcm ns env) vs.sp_pre in
+
+  let checks = List.map (fmla kid crcm ns env) vs.sp_checks in
 
   let wr = List.map (fun t -> let dt = dterm kid crcm ns env t in
                               term env dt) vs.sp_writes in
@@ -652,7 +653,7 @@ let process_val_spec kid crcm ns id cty vs =
        process_args vs.sp_hd_ret [(ret,Asttypes.Nolabel)] env [] in
   let post = List.map (fmla kid crcm ns env) vs.sp_post in
 
-  mk_val_spec args ret pre post xpost wr cs vs.sp_diverge vs.sp_equiv
+  mk_val_spec args ret pre checks post xpost wr cs vs.sp_diverge vs.sp_equiv
 
 let process_val ~loc ?(ghost=false) kid crcm ns vd =
   let id = Ident.set_loc (Ident.create vd.vname.txt) vd.vname.loc in

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -91,37 +91,23 @@ and term_desc =
 
 (* Specification *)
 
-type invariant = term list
-
-type pre = term * bool (* wether it is a checks *)
-type post = term
 type xpost = Location.t * (qualid * (pattern * term) option) list
 
 type val_spec = {
-    sp_hd_nm   : Preid.t;             (* header name *)
-    sp_hd_ret  : labelled_arg list; (* Can only be LNone or LGhost *)
-    sp_hd_args : labelled_arg list; (* header arguments' names *)
-    sp_pre     : pre list;
-    sp_post    : post list;
-    sp_xpost   : xpost list;
-    sp_reads   : qualid list;        (* TODO *)
-    sp_writes  : term list;
-    sp_consumes: term list;
-    sp_alias   : (term * term) list; (* TODO *)
-    sp_diverge : bool;
-    sp_equiv   : string list;
+  sp_hd_nm   : Preid.t;           (* header name *)
+  sp_hd_ret  : labelled_arg list; (* Can only be LNone or LGhost *)
+  sp_hd_args : labelled_arg list; (* header arguments' names *)
+  sp_pre     : term list;
+  sp_checks  : term list;
+  sp_post    : term list;
+  sp_xpost   : xpost list;
+  sp_reads   : qualid list;        (* TODO *)
+  sp_writes  : term list;
+  sp_consumes: term list;
+  sp_alias   : (term * term) list; (* TODO *)
+  sp_diverge : bool;
+  sp_equiv   : string list;
 }
-
-(*
-1  val f : 'a -> 'b
-2  (*@ x = f y
-3      raises E1, E2                l1 = [(E1,None); (E2,None)]
-4      raises E1 -> t1
-5           | E2 -> t2              l2 = [(E1, Some (..., t1)); (E2, Some (...,t2))]
-6  *)
-
-  [(3,l1); (4,l2)]
-*)
 
 type field = {
   f_loc     : Location.t;
@@ -133,7 +119,7 @@ type field = {
 type type_spec = {
   ty_ephemeral : bool;
   ty_field     : field list;
-  ty_invariant : invariant;
+  ty_invariant : term list;
 }
 
 type fun_spec = {

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -26,6 +26,7 @@
     sp_hd_nm   = mk_pid "" Lexing.dummy_pos Lexing.dummy_pos;
     sp_hd_args = [];
     sp_pre     = [];
+    sp_checks  = [];
     sp_post    = [];
     sp_xpost   = [];
     sp_reads   = [];
@@ -203,9 +204,9 @@ val_spec_body:
 | CONSUMES cs=separated_list(COMMA, term) bd=val_spec_body
   { { bd with sp_consumes = cs @ bd.sp_consumes } }
 | REQUIRES t=term bd=val_spec_body
-  { { bd with sp_pre = (t,false) :: bd.sp_pre } }
+  { { bd with sp_pre = t :: bd.sp_pre } }
 | CHECKS t=term bd=val_spec_body
-  { { bd with sp_pre = (t,true) :: bd.sp_pre } }
+  { { bd with sp_checks = t :: bd.sp_pre } }
 | ENSURES t=term bd=val_spec_body
   { { bd with sp_post = t :: bd.sp_post} }
 | RAISES r=bar_list1(raises) bd=val_spec_body

--- a/test/positive/basic_functions_axioms.mli.expected
+++ b/test/positive/basic_functions_axioms.mli.expected
@@ -377,10 +377,9 @@ module basic_functions_axioms.mli.pp
     
     val f_7 : int -> int -> int
     (*@ r:int = f_7 x_16:int y_5:int
-        requires (((integer_of_int_1 
-                 y_5:int):integer + 2:integer):integer < 0:integer):prop
-                 requires ((integer_of_int_1 
-                          x_16:int):integer > 0:integer):prop
+        requires ((integer_of_int_1  x_16:int):integer > 0:integer):prop
+                 requires (((integer_of_int_1 
+                          y_5:int):integer + 2:integer):integer < 0:integer):prop
         ensures ((integer_of_int_1  r:int):integer = ((integer_of_int_1 
                 x_16:int):integer + (integer_of_int_1 
                 y_5:int):integer):integer):prop*)

--- a/test/positive/complex_vals.mli.expected
+++ b/test/positive/complex_vals.mli.expected
@@ -77,11 +77,11 @@ module complex_vals.mli.pp
     
     val f : int -> int -> int
     (*@ r:int = f x:int y:int
-        requires (((integer_of_int 
-                 x:int):integer + 1:integer):integer < 0:integer):prop
+        requires ((integer_of_int  x:int):integer > 0:integer):prop
                  requires (((integer_of_int 
                           y:int):integer + 2:integer):integer < 0:integer):prop
-                 requires ((integer_of_int  x:int):integer > 0:integer):prop
+                 requires (((integer_of_int 
+                          x:int):integer + 1:integer):integer < 0:integer):prop
         ensures ((integer_of_int  r:int):integer = ((integer_of_int 
                 x:int):integer + (integer_of_int 
                 y:int):integer):integer):prop
@@ -94,12 +94,11 @@ module complex_vals.mli.pp
     
     val f_1 : int -> int -> int
     (*@ r_1:int = f_1 x_1:int y_1:int
-        requires (((integer_of_int 
-                 x_1:int):integer + 1:integer):integer < 0:integer):prop
+        requires ((integer_of_int  x_1:int):integer > 0:integer):prop
                  requires (((integer_of_int 
                           y_1:int):integer + 2:integer):integer < 0:integer):prop
-                 requires ((integer_of_int 
-                          x_1:int):integer > 0:integer):prop
+                 requires (((integer_of_int 
+                          x_1:int):integer + 1:integer):integer < 0:integer):prop
         ensures ((integer_of_int  r_1:int):integer = ((integer_of_int 
                 x_1:int):integer + (integer_of_int 
                 y_1:int):integer):integer):prop


### PR DESCRIPTION
Those were previously stored in `term * bool` elements, the boolean value indicating whether the term is a `check` or a `require`.
This is error-prone, and the two end up being split most of the time, because their semantics are quite different.
This PR introduces two separate fields for them.