### PR TITLE
Function contracts should be in their own comment

### DIFF
--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -155,12 +155,12 @@ axiom:
 
 func:
 | FUNCTION fun_rec=boption(REC) fun_name=func_name fun_params=loption(params)
-    COLON ty=typ fun_def=preceded(EQUAL, term)? fun_spec=nonempty_func_spec? EOF
-  { { fun_name; fun_rec; fun_type = Some ty; fun_params; fun_def; fun_spec;
+    COLON ty=typ fun_def=preceded(EQUAL, term)? EOF
+  { { fun_name; fun_rec; fun_type = Some ty; fun_params; fun_def; fun_spec = None;
       fun_loc = mk_loc $loc } }
 | PREDICATE fun_rec=boption(REC) fun_name=func_name fun_params=params
-    fun_def=preceded(EQUAL, term)? fun_spec=nonempty_func_spec? EOF
-  { { fun_name; fun_rec; fun_type = None; fun_params; fun_def; fun_spec;
+    fun_def=preceded(EQUAL, term)? EOF
+  { { fun_name; fun_rec; fun_type = None; fun_params; fun_def; fun_spec = None;
       fun_loc = mk_loc $loc } }
 ;
 

--- a/test/negative/t13.mli
+++ b/test/negative/t13.mli
@@ -12,10 +12,10 @@
 (*@ function to_float (i: integer): float *)
 
 (*@ function i (a:float):float =
-      to_float (int_of_float a + 1)
-    requires int_of_float a > 0
+      to_float (int_of_float a + 1) *)
+(*@ requires int_of_float a > 0
     ensures let old_a [@ athing] = int_of_float (old a) in
-            a = old_a + 1*)
+            a = old_a + 1 *)
 
 (* ERROR:
    Line 18

--- a/test/negative/t13.mli.expected
+++ b/test/negative/t13.mli.expected
@@ -6,10 +6,11 @@
 [@@@gospel {| function to_float (i: integer): float |}]
 [@@@gospel
   {| function i (a:float):float =
-      to_float (int_of_float a + 1)
-    requires int_of_float a > 0
+      to_float (int_of_float a + 1) |}
+  [@@gospel
+    {| requires int_of_float a > 0
     ensures let old_a [@ athing] = int_of_float (old a) in
-            a = old_a + 1|}]
+            a = old_a + 1 |}]]
 
 *******************************
 ****** GOSPEL translation *****
@@ -24,5 +25,5 @@
     requires ...
     ensures ...
      *)
-File "_none_", line 5, characters 12-13:
+File "_none_", line 3, characters 12-13:
 Error: Type mysmatch. Cannot match float with integer

--- a/test/negative/t5.mli
+++ b/test/negative/t5.mli
@@ -8,12 +8,11 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ function p (x:integer):integer = x
-  requires x
-  variant x
-  ensures x = 2
-  ensures x > 2
-  ensures x > 1
-*)
+(*@ function p (x:integer):integer = x *)
+(*@ requires x
+    variant x
+    ensures x = 2
+    ensures x > 2
+    ensures x > 1 *)
 
 (* ERROR: the term in the requires clause should be of type bool or prop *)

--- a/test/negative/t5.mli.expected
+++ b/test/negative/t5.mli.expected
@@ -3,13 +3,12 @@
 ********** Parsed file ********
 *******************************
 [@@@gospel
-  {| function p (x:integer):integer = x
-  requires x
-  variant x
-  ensures x = 2
-  ensures x > 2
-  ensures x > 1
-|}]
+  {| function p (x:integer):integer = x |}[@@gospel
+                                            {| requires x
+    variant x
+    ensures x = 2
+    ensures x > 2
+    ensures x > 1 |}]]
 
 *******************************
 ****** GOSPEL translation *****
@@ -23,5 +22,5 @@
     ensures ...
     ensures ...
      *)
-File "_none_", line 2, characters 11-12:
+File "_none_", line 1, characters 10-11:
 Error: Type mysmatch. Cannot match integer with bool

--- a/test/negative/t6.mli
+++ b/test/negative/t6.mli
@@ -8,12 +8,11 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ function p (x:integer):integer = x
-  requires x > 0
-  variant x = 0
-  ensures x = 2
-  ensures x > 2
-  ensures x > 1
-*)
+(*@ function p (x:integer):integer = x *)
+(*@ requires x > 0
+    variant x = 0
+    ensures x = 2
+    ensures x > 2
+    ensures x > 1 *)
 
 (* ERROR: the term in the variant clause should be of type integer *)

--- a/test/negative/t6.mli.expected
+++ b/test/negative/t6.mli.expected
@@ -3,13 +3,12 @@
 ********** Parsed file ********
 *******************************
 [@@@gospel
-  {| function p (x:integer):integer = x
-  requires x > 0
-  variant x = 0
-  ensures x = 2
-  ensures x > 2
-  ensures x > 1
-|}]
+  {| function p (x:integer):integer = x |}[@@gospel
+                                            {| requires x > 0
+    variant x = 0
+    ensures x = 2
+    ensures x > 2
+    ensures x > 1 |}]]
 
 *******************************
 ****** GOSPEL translation *****
@@ -23,5 +22,5 @@
     ensures ...
     ensures ...
      *)
-File "_none_", line 3, characters 10-15:
+File "_none_", line 2, characters 12-17:
 Error: Term was expected

--- a/test/negative/t7.mli
+++ b/test/negative/t7.mli
@@ -8,12 +8,11 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ function p (x:integer):integer = x
-  requires x > 0
-  variant x = 0
-  ensures x
-  ensures x > 2
-  ensures x > 1
-*)
+(*@ function p (x:integer):integer = x *)
+(*@ requires x > 0
+    variant x = 0
+    ensures x
+    ensures x > 2
+    ensures x > 1 *)
 
 (* ERROR: the term in the ensures clause should be of type integer *)

--- a/test/negative/t7.mli.expected
+++ b/test/negative/t7.mli.expected
@@ -3,13 +3,12 @@
 ********** Parsed file ********
 *******************************
 [@@@gospel
-  {| function p (x:integer):integer = x
-  requires x > 0
-  variant x = 0
-  ensures x
-  ensures x > 2
-  ensures x > 1
-|}]
+  {| function p (x:integer):integer = x |}[@@gospel
+                                            {| requires x > 0
+    variant x = 0
+    ensures x
+    ensures x > 2
+    ensures x > 1 |}]]
 
 *******************************
 ****** GOSPEL translation *****
@@ -23,5 +22,5 @@
     ensures ...
     ensures ...
      *)
-File "_none_", line 4, characters 10-11:
+File "_none_", line 3, characters 12-13:
 Error: Type mysmatch. Cannot match integer with bool

--- a/test/positive/basic_functions_axioms.mli
+++ b/test/positive/basic_functions_axioms.mli
@@ -24,13 +24,12 @@
 
 (*@ predicate pred (x:bool) = x *)
 
-(*@ function p (x:integer):integer = x
-  requires x = 1
-  variant x
-  ensures x = 2
-  ensures x > 2
-  ensures x > 1
-*)
+(*@ function p (x:integer):integer = x *)
+(*@ requires x = 1
+    variant x
+    ensures x = 2
+    ensures x > 2
+    ensures x > 1 *)
 
 (*@ function rec f (x:bool): bool = f x *)
 
@@ -63,10 +62,10 @@
       int_of_integer (to_integer a + 1) *)
 
 (*@ function i (a:int):int =
-      int_of_integer (to_integer a + 1)
-    requires to_integer a > 0
+      int_of_integer (to_integer a + 1) *)
+(*@ requires to_integer a > 0
     ensures let old_a [@ athing] = to_integer (old a) in
-            to_integer a = old_a + 1*)
+            to_integer a = old_a + 1 *)
 
 type 'a t1 = C of 'a * int
 

--- a/test/positive/basic_functions_axioms.mli.expected
+++ b/test/positive/basic_functions_axioms.mli.expected
@@ -11,13 +11,12 @@
 [@@@gospel {| function f (x:bool): bool = x |}]
 [@@@gospel {| predicate pred (x:bool) = x |}]
 [@@@gospel
-  {| function p (x:integer):integer = x
-  requires x = 1
-  variant x
-  ensures x = 2
-  ensures x > 2
-  ensures x > 1
-|}]
+  {| function p (x:integer):integer = x |}[@@gospel
+                                            {| requires x = 1
+    variant x
+    ensures x = 2
+    ensures x > 2
+    ensures x > 1 |}]]
 [@@@gospel {| function rec f (x:bool): bool = f x |}]
 [@@@gospel {| function rec f (x: bool) (y: int): bool = f x y |}]
 [@@@gospel
@@ -44,10 +43,11 @@
       int_of_integer (to_integer a + 1) |}]
 [@@@gospel
   {| function i (a:int):int =
-      int_of_integer (to_integer a + 1)
-    requires to_integer a > 0
+      int_of_integer (to_integer a + 1) |}
+  [@@gospel
+    {| requires to_integer a > 0
     ensures let old_a [@ athing] = to_integer (old a) in
-            to_integer a = old_a + 1|}]
+            to_integer a = old_a + 1 |}]]
 type 'a t1 =
   | C of 'a * int 
 [@@@gospel


### PR DESCRIPTION
After this patch, it is no longer possible possible to have function and predicates specs in the same comment as their declaration, the contract must be attached just like for `val` and `spec`.

```ocaml
(*@ function f : (x: int) : int
    requires x > 0 *)
```
should now be written
```ocaml
(*@ function f : (x: int) : int *)
(*@ requires x > 0 *)
``` 
(both were previously possible)