### PR TITLE
Apply preprocessor automatically

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -73,7 +73,7 @@ let run_tc backtrace bench_mode print_intermediate print_parsed parse_only
     file
 
 let tc =
-  let doc = "Run GOSPEL type-checker." in
+  let doc = "Run Gospel type-checker." in
   ( Term.(
       const run_tc
       $ backtrace
@@ -86,14 +86,18 @@ let tc =
       $ files),
     Term.info "tc" ~doc )
 
+let pps =
+  let doc = "Run Gospel preprocessor." in
+  (Term.(const Pps.run $ files), Term.info "pps" ~doc)
+
 let wc =
-  let doc = "Run GOSPEL line count." in
+  let doc = "Run Gospel line count." in
   (Term.(const Wc.run $ files), Term.info "wc" ~doc)
 
 let usage_cmd =
-  let doc = "The GOSPEL command line tool." in
+  let doc = "The Gospel command line tool." in
   (Term.(ret (const (`Help (`Auto, None)))), Term.info "gospel" ~doc)
 
 let () =
-  let commands = [ tc; wc ] in
+  let commands = [ tc; wc; pps ] in
   Term.(exit @@ eval_choice usage_cmd commands)

--- a/bin/pps.ml
+++ b/bin/pps.ml
@@ -1,0 +1,16 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  GOSPEL -- A Specification Language for OCaml                          *)
+(*                                                                        *)
+(*  Copyright (c) 2018- The VOCaL Project                                 *)
+(*                                                                        *)
+(*  This software is free software, distributed under the MIT license     *)
+(*  (as described in file LICENSE enclosed).                              *)
+(**************************************************************************)
+
+let run_file file =
+  let ic = open_in file in
+  Lexing.from_channel ic |> Gospel.Pps.run |> print_endline;
+  close_in ic
+
+let run = List.iter run_file

--- a/bin/pps.mli
+++ b/bin/pps.mli
@@ -1,0 +1,11 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  GOSPEL -- A Specification Language for OCaml                          *)
+(*                                                                        *)
+(*  Copyright (c) 2018- The VOCaL Project                                 *)
+(*                                                                        *)
+(*  This software is free software, distributed under the MIT license     *)
+(*  (as described in file LICENSE enclosed).                              *)
+(**************************************************************************)
+
+val run : string list -> unit

--- a/pps/dune
+++ b/pps/dune
@@ -1,5 +1,0 @@
-(ocamllex
- (modules gospel_pps))
-
-(executable
- (public_name gospel_pps))

--- a/pps/gospel_pps.mli
+++ b/pps/gospel_pps.mli
@@ -1,1 +1,0 @@
-(* Left empty on purpose. *)

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (ocamllex
- (modules ulexer))
+ (modules pps ulexer))
 
 (menhir
  (modules uparser))
@@ -12,14 +12,6 @@
 
 (rule
  (targets gospelstdlib.ml)
- (deps gospelstdlib.mli.pp)
- (action
-  (run stdlib/file_to_string.exe %{deps} %{targets})))
-
-(rule
- (targets gospelstdlib.mli.pp)
  (deps stdlib/gospelstdlib.mli)
  (action
-  (with-stdout-to
-   %{targets}
-   (run gospel_pps %{deps}))))
+  (run stdlib/file_to_string.exe %{deps} %{targets})))

--- a/src/parser_frontend.mli
+++ b/src/parser_frontend.mli
@@ -26,8 +26,6 @@ val with_loadpath : string list -> string -> string
     Raise Ocaml_syntax_error if there is an OCaml syntax error. *)
 val parse_ocaml : string -> Parsetree.signature
 
-val parse_ocaml_lb : Lexing.lexbuf -> Parsetree.signature
-
 (** [parse_gospel sig_list module_name] parses the GOSPEL attributes and
     integrates them in the corresponding OCaml signatures. *)
 val parse_gospel :

--- a/src/pps.mli
+++ b/src/pps.mli
@@ -1,0 +1,1 @@
+val run : Lexing.lexbuf -> string

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -4,6 +4,8 @@
   let queue = Queue.create ()
   let buf = Buffer.create 1024
 
+  let clear () = Queue.clear queue
+
   let push () =
     if Buffer.length buf > 0 then (
       Queue.push (Other (Buffer.contents buf)) queue;
@@ -11,29 +13,21 @@
 
   let rec print = function
   | Ghost g :: Spec s :: l ->
-    Format.printf "[@@@@@@gospel {|%s|}[@@@@gospel {|%s|}]]" g s;
-    print l
+    Fmt.str "[@@@@@@gospel {|%s|}[@@@@gospel {|%s|}]]%s" g s (print l)
   | Ghost g :: Spaces sp :: Spec s :: l ->
-    Format.printf "[@@@@@@gospel {|%s|}%s[@@@@gospel {|%s|}]]" g sp s;
-    print l
+    Fmt.str "[@@@@@@gospel {|%s|}%s[@@@@gospel {|%s|}]]%s" g sp s (print l)
   | Ghost g :: l ->
-    Format.printf "[@@@@@@gospel {|%s|}]" g;
-    print l
+    Fmt.str "[@@@@@@gospel {|%s|}]%s" g (print l)
   | Other o :: Spec s :: l ->
-    Format.printf "%s[@@@@gospel {|%s|}]" o s;
-    print l
+    Fmt.str "%s[@@@@gospel {|%s|}]%s" o s (print l)
   | Spec s :: l ->
     (* FIXME: we could fail right here *)
-    Format.printf "[@@@@gospel {|%s|}]" s;
-    print l
+    Fmt.str "[@@@@gospel {|%s|}]%s" s (print l)
   | Other o :: Spaces sp :: Spec s :: l ->
-    Format.printf "%s%s[@@@@gospel {|%s|}]" o sp s;
-    print l
+    Fmt.str "%s%s[@@@@gospel {|%s|}]%s" o sp s (print l)
   | (Other s | Spaces s) :: l ->
-    Format.print_string s;
-    print l
-  | [] ->
-    Format.printf "@?"
+    Fmt.str "%s%s" s (print l)
+  | [] -> ""
 
   let flush () =
     push ();
@@ -89,10 +83,7 @@ and comment = parse
   | _ as c { Buffer.add_char buf c; comment lexbuf }
 
 {
-  let () =
-    let c =
-      if Array.length Sys.argv > 1 then Sys.argv.(1) |> open_in else stdin
-    in
-    Lexing.from_channel c |> scan;
-    close_in c
+  let run lb =
+    clear ();
+    scan lb
 }

--- a/src/stdlib/file_to_string.ml
+++ b/src/stdlib/file_to_string.ml
@@ -12,4 +12,3 @@ let oc = open_out output
 let fmt = formatter_of_out_channel oc
 let () = fprintf fmt "let contents = %S@." contents
 let () = close_out oc
-

--- a/test/coercions/negative/dune.inc
+++ b/test/coercions/negative/dune.inc
@@ -1,26 +1,14 @@
 (rule
- (target bad_type_id.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:bad_type_id.mli}))))
-
-(rule
  (targets bad_type_id.mli.output)
  (action
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:bad_type_id.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:bad_type_id.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:bad_type_id.mli.expected} %{dep:bad_type_id.mli.output})))
-
-(rule
- (target bad_type_multiple_args.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:bad_type_multiple_args.mli}))))
 
 (rule
  (targets bad_type_multiple_args.mli.output)
@@ -28,17 +16,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:bad_type_multiple_args.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:bad_type_multiple_args.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:bad_type_multiple_args.mli.expected} %{dep:bad_type_multiple_args.mli.output})))
-
-(rule
- (target complex_cycle.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:complex_cycle.mli}))))
 
 (rule
  (targets complex_cycle.mli.output)
@@ -46,17 +28,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:complex_cycle.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:complex_cycle.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:complex_cycle.mli.expected} %{dep:complex_cycle.mli.output})))
-
-(rule
- (target double_definition.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:double_definition.mli}))))
 
 (rule
  (targets double_definition.mli.output)
@@ -64,17 +40,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:double_definition.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:double_definition.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:double_definition.mli.expected} %{dep:double_definition.mli.output})))
-
-(rule
- (target simple_cycle.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:simple_cycle.mli}))))
 
 (rule
  (targets simple_cycle.mli.output)
@@ -82,7 +52,7 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:simple_cycle.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:simple_cycle.mli}")))))
 
 (rule
  (alias runtest)

--- a/test/coercions/positive/basic.mli.expected
+++ b/test/coercions/positive/basic.mli.expected
@@ -23,9 +23,9 @@ type t2
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module basic.mli.pp
+module basic.mli
 
-  Namespace: basic.mli.pp
+  Namespace: basic.mli
     Type symbols
        t1
        t2

--- a/test/coercions/positive/dune.inc
+++ b/test/coercions/positive/dune.inc
@@ -1,16 +1,10 @@
 (rule
- (target basic.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:basic.mli}))))
-
-(rule
  (targets basic.mli.output)
  (action
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:basic.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:basic.mli}")))))
 
 (rule
  (alias runtest)

--- a/test/gen/gen.ml
+++ b/test/gen/gen.ml
@@ -1,27 +1,7 @@
-let print_rule pp_only file =
+let print_rule file =
   if Filename.extension file = ".mli" then
-    let pp_file = (Filename.chop_extension file) ^ ".mli.pp" in
-    if pp_only then
-      Printf.printf
-        {|(rule
- (target %s)
- (action
-  (with-outputs-to %%{target}
-     (run gospel_pps %%{dep:%s}))))
-
-(rule
- (alias runtest)
- (action (diff %%{dep:%s.expected} %%{dep:%s})))|}
-        pp_file file file pp_file
-        else
     Printf.printf
       {|(rule
- (target %s)
- (action
-  (with-outputs-to %%{target}
-     (run gospel_pps %%{dep:%s}))))
-
-(rule
  (targets %s.output)
  (action
    (with-outputs-to %%{targets}
@@ -34,10 +14,9 @@ let print_rule pp_only file =
  (action (diff %%{dep:%s.expected} %%{dep:%s.output})))
 
 |}
-      pp_file file file pp_file file file
+      file file file file
 
 let () =
-  let pp_only = Array.length Sys.argv > 1 &&  Sys.argv.(1) = "--pp-only" in
   let files = Filename.current_dir_name |> Sys.readdir in
   Array.sort String.compare files;
-  Array.iter (print_rule pp_only) files
+  Array.iter print_rule files

--- a/test/negative/dune.inc
+++ b/test/negative/dune.inc
@@ -1,26 +1,14 @@
 (rule
- (target char1.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:char1.mli}))))
-
-(rule
  (targets char1.mli.output)
  (action
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:char1.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:char1.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:char1.mli.expected} %{dep:char1.mli.output})))
-
-(rule
- (target t1.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t1.mli}))))
 
 (rule
  (targets t1.mli.output)
@@ -28,17 +16,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t1.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t1.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t1.mli.expected} %{dep:t1.mli.output})))
-
-(rule
- (target t10.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t10.mli}))))
 
 (rule
  (targets t10.mli.output)
@@ -46,17 +28,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t10.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t10.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t10.mli.expected} %{dep:t10.mli.output})))
-
-(rule
- (target t11.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t11.mli}))))
 
 (rule
  (targets t11.mli.output)
@@ -64,17 +40,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t11.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t11.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t11.mli.expected} %{dep:t11.mli.output})))
-
-(rule
- (target t12.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t12.mli}))))
 
 (rule
  (targets t12.mli.output)
@@ -82,17 +52,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t12.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t12.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t12.mli.expected} %{dep:t12.mli.output})))
-
-(rule
- (target t13.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t13.mli}))))
 
 (rule
  (targets t13.mli.output)
@@ -100,17 +64,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t13.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t13.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t13.mli.expected} %{dep:t13.mli.output})))
-
-(rule
- (target t14.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t14.mli}))))
 
 (rule
  (targets t14.mli.output)
@@ -118,17 +76,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t14.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t14.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t14.mli.expected} %{dep:t14.mli.output})))
-
-(rule
- (target t15.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t15.mli}))))
 
 (rule
  (targets t15.mli.output)
@@ -136,17 +88,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t15.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t15.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t15.mli.expected} %{dep:t15.mli.output})))
-
-(rule
- (target t16.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t16.mli}))))
 
 (rule
  (targets t16.mli.output)
@@ -154,17 +100,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t16.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t16.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t16.mli.expected} %{dep:t16.mli.output})))
-
-(rule
- (target t17.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t17.mli}))))
 
 (rule
  (targets t17.mli.output)
@@ -172,17 +112,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t17.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t17.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t17.mli.expected} %{dep:t17.mli.output})))
-
-(rule
- (target t18.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t18.mli}))))
 
 (rule
  (targets t18.mli.output)
@@ -190,17 +124,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t18.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t18.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t18.mli.expected} %{dep:t18.mli.output})))
-
-(rule
- (target t19.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t19.mli}))))
 
 (rule
  (targets t19.mli.output)
@@ -208,17 +136,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t19.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t19.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t19.mli.expected} %{dep:t19.mli.output})))
-
-(rule
- (target t2.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t2.mli}))))
 
 (rule
  (targets t2.mli.output)
@@ -226,17 +148,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t2.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t2.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t2.mli.expected} %{dep:t2.mli.output})))
-
-(rule
- (target t20.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t20.mli}))))
 
 (rule
  (targets t20.mli.output)
@@ -244,17 +160,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t20.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t20.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t20.mli.expected} %{dep:t20.mli.output})))
-
-(rule
- (target t21.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t21.mli}))))
 
 (rule
  (targets t21.mli.output)
@@ -262,17 +172,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t21.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t21.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t21.mli.expected} %{dep:t21.mli.output})))
-
-(rule
- (target t22.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t22.mli}))))
 
 (rule
  (targets t22.mli.output)
@@ -280,17 +184,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t22.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t22.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t22.mli.expected} %{dep:t22.mli.output})))
-
-(rule
- (target t23.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t23.mli}))))
 
 (rule
  (targets t23.mli.output)
@@ -298,17 +196,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t23.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t23.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t23.mli.expected} %{dep:t23.mli.output})))
-
-(rule
- (target t24.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t24.mli}))))
 
 (rule
  (targets t24.mli.output)
@@ -316,17 +208,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t24.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t24.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t24.mli.expected} %{dep:t24.mli.output})))
-
-(rule
- (target t25.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t25.mli}))))
 
 (rule
  (targets t25.mli.output)
@@ -334,17 +220,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t25.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t25.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t25.mli.expected} %{dep:t25.mli.output})))
-
-(rule
- (target t26.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t26.mli}))))
 
 (rule
  (targets t26.mli.output)
@@ -352,17 +232,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t26.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t26.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t26.mli.expected} %{dep:t26.mli.output})))
-
-(rule
- (target t27.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t27.mli}))))
 
 (rule
  (targets t27.mli.output)
@@ -370,17 +244,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t27.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t27.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t27.mli.expected} %{dep:t27.mli.output})))
-
-(rule
- (target t28.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t28.mli}))))
 
 (rule
  (targets t28.mli.output)
@@ -388,17 +256,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t28.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t28.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t28.mli.expected} %{dep:t28.mli.output})))
-
-(rule
- (target t29.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t29.mli}))))
 
 (rule
  (targets t29.mli.output)
@@ -406,17 +268,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t29.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t29.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t29.mli.expected} %{dep:t29.mli.output})))
-
-(rule
- (target t3.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t3.mli}))))
 
 (rule
  (targets t3.mli.output)
@@ -424,17 +280,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t3.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t3.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t3.mli.expected} %{dep:t3.mli.output})))
-
-(rule
- (target t30.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t30.mli}))))
 
 (rule
  (targets t30.mli.output)
@@ -442,17 +292,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t30.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t30.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t30.mli.expected} %{dep:t30.mli.output})))
-
-(rule
- (target t31.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t31.mli}))))
 
 (rule
  (targets t31.mli.output)
@@ -460,17 +304,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t31.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t31.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t31.mli.expected} %{dep:t31.mli.output})))
-
-(rule
- (target t32.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t32.mli}))))
 
 (rule
  (targets t32.mli.output)
@@ -478,17 +316,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t32.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t32.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t32.mli.expected} %{dep:t32.mli.output})))
-
-(rule
- (target t33.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t33.mli}))))
 
 (rule
  (targets t33.mli.output)
@@ -496,17 +328,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t33.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t33.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t33.mli.expected} %{dep:t33.mli.output})))
-
-(rule
- (target t34.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t34.mli}))))
 
 (rule
  (targets t34.mli.output)
@@ -514,17 +340,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t34.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t34.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t34.mli.expected} %{dep:t34.mli.output})))
-
-(rule
- (target t35.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t35.mli}))))
 
 (rule
  (targets t35.mli.output)
@@ -532,17 +352,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t35.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t35.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t35.mli.expected} %{dep:t35.mli.output})))
-
-(rule
- (target t36.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t36.mli}))))
 
 (rule
  (targets t36.mli.output)
@@ -550,17 +364,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t36.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t36.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t36.mli.expected} %{dep:t36.mli.output})))
-
-(rule
- (target t37.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t37.mli}))))
 
 (rule
  (targets t37.mli.output)
@@ -568,17 +376,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t37.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t37.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t37.mli.expected} %{dep:t37.mli.output})))
-
-(rule
- (target t38.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t38.mli}))))
 
 (rule
  (targets t38.mli.output)
@@ -586,17 +388,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t38.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t38.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t38.mli.expected} %{dep:t38.mli.output})))
-
-(rule
- (target t39.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t39.mli}))))
 
 (rule
  (targets t39.mli.output)
@@ -604,17 +400,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t39.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t39.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t39.mli.expected} %{dep:t39.mli.output})))
-
-(rule
- (target t4.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t4.mli}))))
 
 (rule
  (targets t4.mli.output)
@@ -622,17 +412,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t4.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t4.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t4.mli.expected} %{dep:t4.mli.output})))
-
-(rule
- (target t5.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t5.mli}))))
 
 (rule
  (targets t5.mli.output)
@@ -640,17 +424,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t5.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t5.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t5.mli.expected} %{dep:t5.mli.output})))
-
-(rule
- (target t6.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t6.mli}))))
 
 (rule
  (targets t6.mli.output)
@@ -658,17 +436,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t6.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t6.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t6.mli.expected} %{dep:t6.mli.output})))
-
-(rule
- (target t7.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t7.mli}))))
 
 (rule
  (targets t7.mli.output)
@@ -676,17 +448,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t7.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t7.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t7.mli.expected} %{dep:t7.mli.output})))
-
-(rule
- (target t8.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t8.mli}))))
 
 (rule
  (targets t8.mli.output)
@@ -694,17 +460,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t8.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t8.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:t8.mli.expected} %{dep:t8.mli.output})))
-
-(rule
- (target t9.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:t9.mli}))))
 
 (rule
  (targets t9.mli.output)
@@ -712,7 +472,7 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:t9.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:t9.mli}")))))
 
 (rule
  (alias runtest)

--- a/test/negative/t10.mli.expected
+++ b/test/negative/t10.mli.expected
@@ -10,28 +10,5 @@
 (*@ open Gospelstdlib *)
 
 (*@ open T9 *)
-
-*******************************
-********* Typed GOSPEL ********
-*******************************
-module t10.mli.pp
-
-  Namespace: t10.mli.pp
-    Type symbols
-      
-    Logic Symbols
-      
-    Exception Symbols
-      
-    Namespaces
-      
-    Type Namespaces
-      
-  Signatures
-    (*@ open Gospelstdlib *)
-    
-    (*@ open T9 *)
-
-
-*** OK ***
-
+File "_none_", line 1, characters 45-46:
+Error: Type mysmatch. Cannot match int with bool

--- a/test/negative/t39.mli.expected
+++ b/test/negative/t39.mli.expected
@@ -15,5 +15,5 @@ type 'a t1
 
 type t2 = t1
   
-File "t39.mli.pp", line 13, characters 10-12:
+File "t39.mli", line 13, characters 10-12:
 Error: Type t1 expects 1 arguments as opposed to 0

--- a/test/positive/FM19.mli.expected
+++ b/test/positive/FM19.mli.expected
@@ -225,9 +225,9 @@ val f : tt -> tt -> tt -> tt -> int -> (tt * tt * int)
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module FM19.mli.pp
+module FM19.mli
 
-  Namespace: FM19.mli.pp
+  Namespace: FM19.mli
     Type symbols
        elem
        rand_state

--- a/test/positive/a1.mli.expected
+++ b/test/positive/a1.mli.expected
@@ -15,9 +15,9 @@ type t
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module a1.mli.pp
+module a1.mli
 
-  Namespace: a1.mli.pp
+  Namespace: a1.mli
     Type symbols
        t
       

--- a/test/positive/a2.mli.expected
+++ b/test/positive/a2.mli.expected
@@ -18,9 +18,9 @@ type t2 = t
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module a2.mli.pp
+module a2.mli
 
-  Namespace: a2.mli.pp
+  Namespace: a2.mli
     Type symbols
        t2 [=t]
       

--- a/test/positive/a3.mli.expected
+++ b/test/positive/a3.mli.expected
@@ -19,9 +19,9 @@
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module a3.mli.pp
+module a3.mli
 
-  Namespace: a3.mli.pp
+  Namespace: a3.mli
     Type symbols
        t3 [=t]
        t4 [=t]

--- a/test/positive/abstract_functions.mli.expected
+++ b/test/positive/abstract_functions.mli.expected
@@ -86,9 +86,9 @@
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module abstract_functions.mli.pp
+module abstract_functions.mli
 
-  Namespace: abstract_functions.mli.pp
+  Namespace: abstract_functions.mli
     Type symbols
       
     Logic Symbols

--- a/test/positive/basic_functions_axioms.mli.expected
+++ b/test/positive/basic_functions_axioms.mli.expected
@@ -210,9 +210,9 @@ yy: int }
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module basic_functions_axioms.mli.pp
+module basic_functions_axioms.mli
 
-  Namespace: basic_functions_axioms.mli.pp
+  Namespace: basic_functions_axioms.mli
     Type symbols
       ('a) t1
       ('a) t2

--- a/test/positive/complex_vals.mli.expected
+++ b/test/positive/complex_vals.mli.expected
@@ -57,9 +57,9 @@ val f : int -> int -> int
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module complex_vals.mli.pp
+module complex_vals.mli
 
-  Namespace: complex_vals.mli.pp
+  Namespace: complex_vals.mli
     Type symbols
       
     Logic Symbols

--- a/test/positive/constants.mli.expected
+++ b/test/positive/constants.mli.expected
@@ -34,9 +34,9 @@ val g : char -> string
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module constants.mli.pp
+module constants.mli
 
-  Namespace: constants.mli.pp
+  Namespace: constants.mli
     Type symbols
       
     Logic Symbols

--- a/test/positive/dune.inc
+++ b/test/positive/dune.inc
@@ -1,26 +1,14 @@
 (rule
- (target FM19.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:FM19.mli}))))
-
-(rule
  (targets FM19.mli.output)
  (action
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:FM19.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:FM19.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:FM19.mli.expected} %{dep:FM19.mli.output})))
-
-(rule
- (target a.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:a.mli}))))
 
 (rule
  (targets a.mli.output)
@@ -28,17 +16,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:a.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:a.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:a.mli.expected} %{dep:a.mli.output})))
-
-(rule
- (target a1.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:a1.mli}))))
 
 (rule
  (targets a1.mli.output)
@@ -46,17 +28,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:a1.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:a1.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:a1.mli.expected} %{dep:a1.mli.output})))
-
-(rule
- (target a2.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:a2.mli}))))
 
 (rule
  (targets a2.mli.output)
@@ -64,17 +40,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:a2.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:a2.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:a2.mli.expected} %{dep:a2.mli.output})))
-
-(rule
- (target a3.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:a3.mli}))))
 
 (rule
  (targets a3.mli.output)
@@ -82,17 +52,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:a3.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:a3.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:a3.mli.expected} %{dep:a3.mli.output})))
-
-(rule
- (target abstract_functions.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:abstract_functions.mli}))))
 
 (rule
  (targets abstract_functions.mli.output)
@@ -100,17 +64,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:abstract_functions.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:abstract_functions.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:abstract_functions.mli.expected} %{dep:abstract_functions.mli.output})))
-
-(rule
- (target b.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:b.mli}))))
 
 (rule
  (targets b.mli.output)
@@ -118,17 +76,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:b.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:b.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:b.mli.expected} %{dep:b.mli.output})))
-
-(rule
- (target basic_functions_axioms.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:basic_functions_axioms.mli}))))
 
 (rule
  (targets basic_functions_axioms.mli.output)
@@ -136,17 +88,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:basic_functions_axioms.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:basic_functions_axioms.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:basic_functions_axioms.mli.expected} %{dep:basic_functions_axioms.mli.output})))
-
-(rule
- (target c.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:c.mli}))))
 
 (rule
  (targets c.mli.output)
@@ -154,17 +100,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:c.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:c.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:c.mli.expected} %{dep:c.mli.output})))
-
-(rule
- (target complex_vals.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:complex_vals.mli}))))
 
 (rule
  (targets complex_vals.mli.output)
@@ -172,17 +112,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:complex_vals.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:complex_vals.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:complex_vals.mli.expected} %{dep:complex_vals.mli.output})))
-
-(rule
- (target constants.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:constants.mli}))))
 
 (rule
  (targets constants.mli.output)
@@ -190,17 +124,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:constants.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:constants.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:constants.mli.expected} %{dep:constants.mli.output})))
-
-(rule
- (target exceptions.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:exceptions.mli}))))
 
 (rule
  (targets exceptions.mli.output)
@@ -208,17 +136,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:exceptions.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:exceptions.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:exceptions.mli.expected} %{dep:exceptions.mli.output})))
-
-(rule
- (target modules.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:modules.mli}))))
 
 (rule
  (targets modules.mli.output)
@@ -226,17 +148,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:modules.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:modules.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:modules.mli.expected} %{dep:modules.mli.output})))
-
-(rule
- (target more_types.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:more_types.mli}))))
 
 (rule
  (targets more_types.mli.output)
@@ -244,17 +160,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:more_types.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:more_types.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:more_types.mli.expected} %{dep:more_types.mli.output})))
-
-(rule
- (target pattern_matching.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:pattern_matching.mli}))))
 
 (rule
  (targets pattern_matching.mli.output)
@@ -262,17 +172,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:pattern_matching.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:pattern_matching.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:pattern_matching.mli.expected} %{dep:pattern_matching.mli.output})))
-
-(rule
- (target test.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:test.mli}))))
 
 (rule
  (targets test.mli.output)
@@ -280,17 +184,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:test.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:test.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:test.mli.expected} %{dep:test.mli.output})))
-
-(rule
- (target test1.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:test1.mli}))))
 
 (rule
  (targets test1.mli.output)
@@ -298,17 +196,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:test1.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:test1.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:test1.mli.expected} %{dep:test1.mli.output})))
-
-(rule
- (target test2.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:test2.mli}))))
 
 (rule
  (targets test2.mli.output)
@@ -316,17 +208,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:test2.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:test2.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:test2.mli.expected} %{dep:test2.mli.output})))
-
-(rule
- (target type_decl.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:type_decl.mli}))))
 
 (rule
  (targets type_decl.mli.output)
@@ -334,17 +220,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:type_decl.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:type_decl.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:type_decl.mli.expected} %{dep:type_decl.mli.output})))
-
-(rule
- (target vals.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:vals.mli}))))
 
 (rule
  (targets vals.mli.output)
@@ -352,7 +232,7 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:vals.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:vals.mli}")))))
 
 (rule
  (alias runtest)

--- a/test/positive/exceptions.mli.expected
+++ b/test/positive/exceptions.mli.expected
@@ -102,9 +102,9 @@ val f : 'a -> 'a
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module exceptions.mli.pp
+module exceptions.mli
 
-  Namespace: exceptions.mli.pp
+  Namespace: exceptions.mli
     Type symbols
       
     Logic Symbols

--- a/test/positive/modules.mli.expected
+++ b/test/positive/modules.mli.expected
@@ -95,9 +95,9 @@ val default : MF.ft -> MF.ft
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module modules.mli.pp
+module modules.mli
 
-  Namespace: modules.mli.pp
+  Namespace: modules.mli
     Type symbols
       
     Logic Symbols

--- a/test/positive/more_types.mli.expected
+++ b/test/positive/more_types.mli.expected
@@ -62,9 +62,9 @@ type ('a, 'b) t7 = 'a t6
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module more_types.mli.pp
+module more_types.mli
 
-  Namespace: more_types.mli.pp
+  Namespace: more_types.mli
     Type symbols
        t1
       ('a) t2 [=t1]

--- a/test/positive/pattern_matching.mli.expected
+++ b/test/positive/pattern_matching.mli.expected
@@ -39,9 +39,9 @@ val test1 : t -> t -> t
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module pattern_matching.mli.pp
+module pattern_matching.mli
 
-  Namespace: pattern_matching.mli.pp
+  Namespace: pattern_matching.mli
     Type symbols
        t
       

--- a/test/positive/test.mli.expected
+++ b/test/positive/test.mli.expected
@@ -15,9 +15,9 @@ type t
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module test.mli.pp
+module test.mli
 
-  Namespace: test.mli.pp
+  Namespace: test.mli
     Type symbols
        t
       

--- a/test/positive/test1.mli.expected
+++ b/test/positive/test1.mli.expected
@@ -14,9 +14,9 @@
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module test1.mli.pp
+module test1.mli
 
-  Namespace: test1.mli.pp
+  Namespace: test1.mli
     Type symbols
       
     Logic Symbols

--- a/test/positive/test2.mli.expected
+++ b/test/positive/test2.mli.expected
@@ -25,5 +25,5 @@ type t
 
 type int
   
-File "test2.mli.pp", line 13, characters 5-8:
+File "test2.mli", line 13, characters 5-8:
 Error: Multiple definitions of type int

--- a/test/positive/type_decl.mli.expected
+++ b/test/positive/type_decl.mli.expected
@@ -193,9 +193,9 @@ and u =
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module type_decl.mli.pp
+module type_decl.mli
 
-  Namespace: type_decl.mli.pp
+  Namespace: type_decl.mli
     Type symbols
        t1
        t10

--- a/test/positive/vals.mli.expected
+++ b/test/positive/vals.mli.expected
@@ -81,9 +81,9 @@ val f : x:('a -> 'b -> 'c) -> y:'a -> 'b -> 'c
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module vals.mli.pp
+module vals.mli
 
-  Namespace: vals.mli.pp
+  Namespace: vals.mli
     Type symbols
       
     Logic Symbols

--- a/test/pure/negative/dune.inc
+++ b/test/pure/negative/dune.inc
@@ -1,26 +1,14 @@
 (rule
- (target impure1.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:impure1.mli}))))
-
-(rule
  (targets impure1.mli.output)
  (action
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:impure1.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:impure1.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:impure1.mli.expected} %{dep:impure1.mli.output})))
-
-(rule
- (target impure2.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:impure2.mli}))))
 
 (rule
  (targets impure2.mli.output)
@@ -28,17 +16,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:impure2.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:impure2.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:impure2.mli.expected} %{dep:impure2.mli.output})))
-
-(rule
- (target impure3.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:impure3.mli}))))
 
 (rule
  (targets impure3.mli.output)
@@ -46,17 +28,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:impure3.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:impure3.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:impure3.mli.expected} %{dep:impure3.mli.output})))
-
-(rule
- (target impure4.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:impure4.mli}))))
 
 (rule
  (targets impure4.mli.output)
@@ -64,17 +40,11 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:impure4.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:impure4.mli}")))))
 
 (rule
  (alias runtest)
  (action (diff %{dep:impure4.mli.expected} %{dep:impure4.mli.output})))
-
-(rule
- (target not_pure.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:not_pure.mli}))))
 
 (rule
  (targets not_pure.mli.output)
@@ -82,7 +52,7 @@
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:not_pure.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:not_pure.mli}")))))
 
 (rule
  (alias runtest)

--- a/test/pure/positive/dune.inc
+++ b/test/pure/positive/dune.inc
@@ -1,16 +1,10 @@
 (rule
- (target pure.mli.pp)
- (action
-  (with-outputs-to %{target}
-     (run gospel_pps %{dep:pure.mli}))))
-
-(rule
  (targets pure.mli.output)
  (action
    (with-outputs-to %{targets}
       (with-accepted-exit-codes
        (or :standard 125)
-       (system "%{bin:gospel} tc --print-intermediate %{dep:pure.mli.pp}")))))
+       (system "%{bin:gospel} tc --print-intermediate %{dep:pure.mli}")))))
 
 (rule
  (alias runtest)

--- a/test/pure/positive/pure.mli.expected
+++ b/test/pure/positive/pure.mli.expected
@@ -24,9 +24,9 @@ val g : int -> int
 *******************************
 ********* Typed GOSPEL ********
 *******************************
-module pure.mli.pp
+module pure.mli
 
-  Namespace: pure.mli.pp
+  Namespace: pure.mli
     Type symbols
       
     Logic Symbols


### PR DESCRIPTION
- Removes `gospel_pps` executable
- Applies the preprocessor automatically to all parsed files
- Add a subcommand `gospel pps` (replaces former `gospel_pps`)