### PR TITLE
Fix name clash errors

### DIFF
--- a/src/stdlib/gospelstdlib.mli
+++ b/src/stdlib/gospelstdlib.mli
@@ -31,242 +31,539 @@
    predicate (=) (x y: 'a)
 *)
 
-(** Arithmetic
+(*@ type 'a seq *)
+(** The type for finite sequences. *)
 
-   The type [integer] is built-in. This is the type of arbitrary
-   precision integers, not to be confused with OCaml's type [int]
-   (machine integers).
+(*@ type 'a bag *)
+(** The type for finite unordered multisets. *)
 
-   There is a coercion from type [int] to type [integer], so that
-   GOSPEL specifications can be written using type [integer] only, and
-   yet use OCaml's variables of type [int].  *)
+(*@ type 'a ref *)
+(** The type for references. *)
 
-(*@ function (+)               (x y: integer) : integer *)
-(*@ function (-)               (x y: integer) : integer *)
-(*@ function ( * )             (x y: integer) : integer *)
-(*@ function (/)               (x y: integer) : integer *)
-(*@ function mod               (x y: integer) : integer *)
-(*@ function pow               (x y: integer) : integer *)
-(*@ function logand            (x y: integer) : integer *)
-(*@ function logor             (x y: integer) : integer *)
-(*@ function logxor            (x y: integer) : integer *)
-(*@ function lognot            (x: integer)   : integer *)
+(*@ type 'a array *)
+(** The type for arrays. *)
 
-(*@ function shift_left        (x y: integer) : integer *)
-(* Shifts to the left, equivalent to a multiplication by a power of two *)
+(*@ type 'a set *)
+(** The type for finite unordered sets. *)
 
-(*@ function shift_right       (x y: integer) : integer *)
-(* Shifts to the right, equivalent to a multiplication by a power of two
-   with rounding toward -oo *)
+(** {1 Arithmetic}
+
+    The type [integer] is built-in. This is the type of arbitrary precision
+    integers, not to be confused with OCaml's type [int] (machine, bounded
+    integers). *)
+
+(*@ function succ (x: integer) : integer *)
+(*@ function pred (x: integer) : integer *)
+
+(*@ function (-_) (x: integer) : integer *)
+(*@ function (+) (x y: integer) : integer *)
+(*@ function (-) (x y: integer) : integer *)
+(*@ function ( * ) (x y: integer) : integer *)
+(*@ function (/) (x y: integer) : integer *)
+(*@ function mod (x y: integer) : integer *)
+
+(*@ function pow (x y: integer) : integer *)
+(*@ function abs (x:integer) : integer *)
+
+(*@ function min (x y : integer) : integer *)
+(*@ function max (x y : integer) : integer *)
+
+(** {2 Comparisons} *)
+
+(*@ predicate (>) (x y: integer) *)
+(*@ predicate (>=) (x y: integer) *)
+(*@ predicate (<) (x y: integer) *)
+(*@ predicate (<=) (x y: integer) *)
+
+(** {2 Bitwise operations} *)
+
+(*@ function logand (x y: integer) : integer *)
+(*@ function logor (x y: integer) : integer *)
+(*@ function logxor (x y: integer) : integer *)
+(*@ function lognot (x: integer) : integer *)
+
+(*@ function shift_left (x y: integer) : integer *)
+(** Shifts to the left, equivalent to a multiplication by a power of two *)
+
+(*@ function shift_right (x y: integer) : integer *)
+(** Shifts to the right, equivalent to a multiplication by a power of two with
+    rounding toward -oo *)
 
 (*@ function shift_right_trunc (x y: integer) : integer *)
-(* Shift to the right with truncation, equivalent to a multiplication
-   by a power of two with rounding toward 0 *)
+(** Shift to the right with truncation, equivalent to a multiplication by a
+    power of two with rounding toward 0 *)
 
-(*@ function (-_)              (x: integer)   : integer *)
-(*@ predicate (>)              (x y: integer) *)
-(*@ predicate (>=)             (x y: integer) *)
-(*@ predicate (<)              (x y: integer) *)
-(*@ predicate (<=)             (x y: integer) *)
+(** {2 Machine integers}
+
+    There is a coercion from type [int] to type [integer], so that Gospel
+    specifications can be written using type [integer] only, and yet use OCaml's
+    variables of type [int]. The Gospel typechecker will automatically apply
+    [integer_of_int] whenever necessary. *)
 
 type int
 
 (*@ function integer_of_int (x: int) : integer *)
 (*@ coercion *)
 
-(*@ function abs (x:integer) : integer = if x >= 0 then x else -x *)
-
-(*@ function min (x y : integer) : integer
-    = if x <= y then x else y *)
-
-(*@ function max (x y : integer) : integer
-    = if x <= y then y else x *)
-
-(*@ function succ (x: integer) : integer = x + 1 *)
-(*@ function pred (x: integer) : integer = x - 1 *)
-
 (*@ function max_int : integer *)
 (*@ function min_int : integer *)
 
-
-(** Tuples *)
+(** {1 Couples} *)
 
 (*@ function fst (p: 'a * 'b) : 'a *)
+(** [fst (x, y)] is [x]. *)
+
 (*@ function snd (p: 'a * 'b) : 'b *)
+(** [snd (x, y)] is [y]. *)
 
-(** References *)
+(** {1 References} *)
 
-type 'a ref
-(*@ ephemeral
-    mutable model contents: 'a *)
+(*@ function (!_) (r: 'a ref) : 'a *)
+(** Reference content access operator. *)
 
-(*@ function (!_) (r: 'a ref) : 'a = r.contents *)
+(*@ function ref (x: 'a) : 'a ref *)
+(** Reference creation. *)
 
-(** Sequences
+(** {1 Sequences} *)
 
-    They are used in the following to model lists and arrays, and possibly other
-    data structures (queues, etc.).
-*)
+(*@ predicate (==) (s1 s2: 'a seq) *)
 
-(*@ type 'a seq *)
+(*@ function (++) (s s': 'a seq) : 'a seq *)
+(** [s ++ s'] is the sequence [s] followed by the sequence [s']. *)
 
-(*@ function length (s: 'a seq): integer *)
-
-(*@ function ([_]) (s: 'a seq) (i:integer): 'a *)
-
-(*@ predicate (==) (s1 s2: 'a seq) =
-      length s1 = length s2 &&
-      forall i. 0 <= i < length s1 -> s1[i] = s2[i] *)
+(*@ function ([_]) (s: 'a seq) (i: integer): 'a *)
+(** [s\[i\]] is the [i]th element of the sequence [s]. *)
 
 (*@ function ([_.._]) (s: 'a seq) (i1: integer) (i2: integer): 'a seq *)
 (*@ function ([_..]) (s: 'a seq) (i: integer): 'a seq *)
 (*@ function ([.._]) (s: 'a seq) (i: integer): 'a seq *)
 
-(*@ function empty: 'a seq *)
-
-(*@ function (++) (s1: 'a seq) (s2: 'a seq): 'a seq *)
-
 module Seq : sig
+  (*@ type 'a t = 'a seq *)
+  (** An alias for {!'a seq} *)
 
-  (* re-export type t and functions length and [_], so that we can refer to them
-     using qualified identifiers (Seq.t, Seq.len, and Seq.get, respectively). *)
-  (*@ function len (s: 'a seq): integer = length s *)
-  (*@ function get (s: 'a seq) (i: integer) : 'a = s[i] *)
+  (*@ function length (s: 'a t): integer *)
+  (** [length s] is the length of the sequence [s]. *)
 
-  (*@ function create (x: integer) (f: integer -> 'a): 'a seq *)
-  (*@ axiom create_len : forall n, f. n >= 0 ->
-        length (create n f) = n *)
-  (*@ axiom create_def : forall n, f. n >= 0 ->
-        forall i. 0 <= i < n -> (create n f)[i] = f i *)
+  (*@ function empty : 'a t *)
+  (** [empty] is the empty sequence. *)
 
-  (* TODO : DO WE WANT SOMETHING LIKE THIS ? *)
-  (*@ function create (n: integer) (f: integer -> 'a) : 'a seq *)
-  (*@ requires 0 <= n
-      ensures  length result = n
-      ensures  forall i. 0 <= i < n -> result[i] = f i *)
+  (*@ function return (x: 'a) : 'a t *)
+  (** [return x] is the sequence containing only [x]. *)
+
+  (*@ function singleton (x: 'a) : 'a t *)
+  (** [singleton] is an alias for {!return}. *)
+
+  (*@ function init (n: integer) (f: integer -> 'a) : 'a seq *)
+  (** [init n f] is the sequence containing [f 0], [f 1], [...] , [f n]. *)
+
+  (*@ function cons (x: 'a) (s: 'a t): 'a t *)
+  (** [cons x s] is the sequence containing [x] followed by the elements of [s]. *)
+
+  (*@ function snoc (s: 'a seq) (x: 'a): 'a seq *)
+  (** [snoc s x] is the sequence containing the elements of [s] followed by [x]. *)
+
+  (*@ function hd (s: 'a t) : 'a *)
+  (** When [s] contains one or more elements, [hd s] is the first element of
+      [s]. *)
+
+  (*@ function tl (s: 'a t) : 'a t *)
+  (** When [s] contains one or more elements, [tl s] is the sequence of the
+      elements of [s], starting at position 2. *)
+
+  (*@ function append (s s': 'a t) : 'a t *)
+  (** [append s s'] is [s ++ s']. *)
+
+  (*@ predicate mem (s: 'a seq) (x: 'a) *)
+  (** [mem s x] holds iff [x] is in [s]. *)
+
+  (*@ function map (f: 'a -> 'b) (s: 'a t) : 'b t *)
+  (** [map f s] is a sequence whose elements are the elements of [s],
+      transformed by [f]. *)
+
+  (*@ function filter (f: 'a -> bool) (s: 'a t) : 'a t *)
+  (** [filter f s] is a sequence whose elements are the elements of [s], that
+      satisfy [f]. *)
+
+  (*@ function filter_map (f: 'a -> 'b option) (s: 'a t) : 'b t *)
+  (** [filter_map f s] is a sequence whose elements are the elements of [s],
+      transformed by [f]. An element [x] is dropped whenever [f x] is [None]. *)
+
+  (*@ function get (s: 'a t) (i: integer) : 'a *)
+  (** [get s i] is [s\[i\]]. *)
+
+  (*@ function set (s: 'a t) (i: integer) (x: 'a): 'a t *)
+  (** [set s i x] is the sequence [s] where the [i]th element is [x]. *)
 
   (*@ function ([<-]) (s: 'a seq) (i: integer) (x: 'a): 'a seq *)
+  (** [s\[i\] <- x] is [set s i x]. *)
 
-  (*@ function cons (x: 'a) (s: 'a seq): 'a seq *)
-  (*@ function snoc (s: 'a seq) (x: 'a): 'a seq *)
+  (*@ function rev (s: 'a seq) : 'a seq *)
+  (** [rev s] is the sequence containing the same elements as [s], in reverse
+      order. *)
 
-  (* FIXME singleton? *)
+  (*@ function rec fold_left (f: 'a -> 'b -> 'a) (acc: 'a) (s: 'b seq) : 'a *)
+  (** [fold_left f acc s] is [f (... (f (f acc s\[0\]) s\[1\]) ...) s\[n-1\]],
+      where [n] is the length of [s]. *)
 
-  (*@ predicate mem (s: 'a seq) (x: 'a) =
-        exists i. 0 <= i < length s && s[i] = x *)
-
-  (*@ predicate distinct (s: 'a seq) =
-        forall i j. 0 <= i < length s -> 0 <= j < length s ->
-        i <> j -> s[i] <> s[j] *)
-
-  (*@ function rev (s: 'a seq) : 'a seq =
-        create (length s) (fun i -> s[length s - 1 - i]) *)
-
-  (*@ function map (f: 'a -> 'b) (s: 'a seq) : 'b seq =
-        create (length s) (fun i -> f s[i]) *)
-
-  (*@ function rec fold_left (f: 'a -> 'b -> 'a) (acc: 'a) (s: 'b seq) : 'a =
-        if length s = 0 then acc
-        else fold_left f (f acc s[0]) s[1 ..] *)
-
-  (*@ function rec fold_right (f: 'a -> 'b -> 'b) (s: 'a seq) (acc: 'b) : 'b =
-        if length s = 0 then acc
-        else f s[0] (fold_right f s[1 ..] acc) *)
-
-  (*@ function hd (s: 'a seq) : 'a = s[0] *)
-  (*@ function tl (s: 'a seq) : 'a seq = s[1 ..] *)
-
-  (* Sorted sequences of int values *)
-  (*@ predicate sorted_sub (s: int seq) (l u: integer) =
-        forall i1 i2. l <= i1 <= i2 < u -> s[i1] <= s[i2] *)
-  (*@ predicate sorted (s: int seq) =
-        sorted_sub s 0 (length s) *)
-
-  (* hd, tl, rev, mem *)
-  (* higher-order: map, fold, exists, forall, find, partition *)
-  (* assoc, mem_assoc? split, combine? *)
-end
-
-module SeqPerm : sig
-
-  (*@ function occ (s1: 'a seq) (v: 'a) (l u: integer) : integer *)
-
-  (*@ axiom occ_base: forall s1 v l u.
-        u <= l -> occ s1 v l u = 0 *)
-
-  (*@ axiom occ_ind: forall s1 v l u. 0 <= l <= v < u <= length s1 ->
-        occ s1 v l u = (if v = s1[l] then 1 else 0) + occ s1 v (l+1) u *)
-
-  (*@ predicate permut (s1 s2: 'a seq) (l u: integer) =
-        length s1 = length s2 &&
-        forall x. occ x s1 l u = occ x s2 l u *)
-
-  (*@ predicate permut_all (s1 s2: 'a seq) =
-        permut s1 s2 0 (length s1) *)
-
+  (*@ function rec fold_right (f: 'a -> 'b -> 'b) (s: 'a seq) (acc: 'b) : 'b *)
+  (** [fold_right f s acc] is [f s\[1\] (f s\[2\] (... (f s\[n\] acc) ...))]
+     where [n] is the length of [s]. *)
 end
 
 (** Lists
 
-     Type 'a list, [] and (::) constructors are built-in *)
-
-(*@ function seq_of_list (l: 'a list): 'a seq *)
-(*@ coercion *)
+    The type ['a list] and the constructors [\[\]] and [(::)] are built-in. *)
 
 module List : sig
+  (*@ type 'a t = 'a list *)
+  (** An alias for ['a list]. *)
 
-  (*@ function nth (l: 'a list) (i: integer) : 'a = Seq.get l i *)
+  (*@ function length (l: 'a t) : integer *)
+  (** [length l] is the number of elements of [l]. *)
 
-  (*@ function length (l: 'a list) : integer = Seq.len l *)
+  (*@ function hd (l: 'a t) : 'a *)
+  (** When [l] contains one or more elements, [hd s] is the first element of
+      [l]. *)
 
-  (*@ function map (f: 'a -> 'b) (l: 'a list) : 'b list *)
+  (*@ function tl (l: 'a t) : 'a t *)
+  (** When [l] contains one or more elements, [tl l] is the list of the elements
+     of [l], starting at position 2. *)
 
+  (*@ function nth (l: 'a t) (i: integer) : 'a *)
+  (** [nth l i] is the [i]th element of [l]. *)
+
+  (*@ function nth_opt (l: 'a t) (i: integer) : 'a option *)
+  (** [nth l i] is the [i]th element of [l] if [i] is within the bounds of [l],
+      and [None] otherwise. *)
+
+  (*@ function rev (l: 'a t) : 'a t *)
+  (** [rev l] contains the same elements as [l] in a reverse order. *)
+
+  (*@ function init (n: integer) (f: integer -> 'a) : 'a t *)
+  (** [init n f] is a list of length [n], with element number [i] initialized
+      with [f i]. *)
+
+  (*@ function map (f: 'a -> 'b) (l: 'a t) : 'b t *)
+  (** [map f l] applies function [f] to all the elements of [l], and builds a
+      list with the results returned by [f] *)
+
+  (*@ function mapi (f: integer -> 'a -> 'b) (l: 'a t) : 'b t *)
+  (** Same as {!map}, but the function is applied to the index of the element as
+      first argument, and the element itself as second argument. *)
+
+  (*@ function fold_left (f: 'a -> 'b -> 'a) (init: 'a) (l: 'b t) : 'a *)
+  (** [fold_left f init t] is [f (... (f (f init a\[0\]) a\[1\]) ...) a\[n-1\]],
+      where [n] is the length of [t]. *)
+
+  (*@ function fold_right (f: 'b -> 'a -> 'a) (l: 'b t) (init: 'a) : 'a *)
+  (** [fold_right f t init] is
+      [f a\[0\] (f a\[1\] ( ... (f a\[n-1\] init) ...))], where [n] is the
+      length of [t]. *)
+
+  (*@ function map2 (f: 'a -> 'b -> 'c) (l: 'a t) (l': 'b t) : 'c t *)
+  (** [map2 f l l'] applies function [f] to all the elements of [l] and [l'],
+      and builds a list with the results returned by [f]. *)
+
+  (*@ predicate for_all (f: 'a -> bool) (l: 'a t) *)
+  (** [for_all f l] holds iff all elements of [l] satisfy the predicate [f]. *)
+
+  (*@ predicate _exists (f: 'a -> bool) (l: 'a t) *)
+  (** [_exists f l] holds iff at least one element of [l] satisfies [f]. *)
+
+  (*@ predicate for_all2 (f: 'a -> 'b -> bool) (l: 'a t) (l': 'b t) *)
+  (** Same as {!for_all}, but for a two-argument predicate. *)
+
+  (*@ predicate _exists2 (f: 'a -> 'b -> bool) (l: 'a t) (l': 'b t) *)
+  (** Same as {!_exists}, but for a two-argument predicate. *)
+
+  (*@ predicate mem (x: 'a) (l: 'a t) *)
+  (** [mem x l] holds iff [x] is equal to an element of [l] *)
+
+  (*@ function to_seq (s: 'a t) : 'a Seq.t *)
+  (*@ coercion *)
+
+  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
 end
 
-(** Arrays *)
-
-type 'a array
-(*@ ephemeral
-    mutable model contents: 'a seq
-    model array_length: integer
-    invariant array_length = length contents *)
-
-(*@ function elts (a: 'a array): 'a seq = a.contents *)
-(*@ coercion *)
+(** {1 Arrays} *)
 
 module Array : sig
+  (*@ type 'a t = 'a array *)
+  (** An alias for the type of arrays. *)
 
-  (* OCaml-like syntax a.(i) is mapped to Array.([_]) *)
-  (*@ function ([_]) (a: 'a array) (i: integer) : 'a = Seq.get a i *)
+  (*@ function length (a: 'a t) : integer *)
+  (** [length a] is the number of elements of [a]. *)
 
-  (*@ function length (a: 'a array) : integer = Seq.len a *)
+  (*@ function get (a: 'a t) (i: integer) : 'a *)
+  (** [get a i] is the element number [i] of array [a]. *)
+
+  (*@ function make (n: integer) (x: 'a) : 'a t *)
+  (** [make n x] is an array of length [n], initialized with [x]. *)
+
+  (*@ function init (n: integer) (f: integer -> 'a) : 'a t *)
+  (** [init n f] is an array of length [n], with element number [i] initialized
+      to the result of [f i]. *)
+
+  (*@ function append (a b: 'a t) : 'a t *)
+  (** [append v1 v2] returns an array containing the concatenation of [v1] and
+      [v2]. *)
+
+  (*@ function concat (a: 'a t list) : 'a t *)
+  (** Same as {!append}, but concatenates a list of arrays. *)
+
+  (*@ function sub (a: 'a t) (i len: integer) : 'a t *)
+  (** [sub a pos len] is the array of length [len], containing the elements
+      number [pos] to [pos + len - 1] of array [a]. *)
+
+  (*@ function map (f: 'a -> 'b) (a: 'a t) : 'b t *)
+  (** [map f a] applies function [f] to all the elements of [a], and builds an
+      array with the results returned by [f] *)
+
+  (*@ function mapi (f: integer -> 'a -> 'b) (a: 'a t) : 'b t *)
+  (** Same as {!map}, but the function is applied to the index of the element as
+      first argument, and the element itself as second argument. *)
+
+  (*@ function fold_left (f: 'a -> 'b -> 'a) (init: 'a) (a: 'b t) : 'a *)
+  (** [fold_left f init a] is [f (... (f (f init a\[0\]) a\[1\]) ...) a\[n-1\]],
+      where [n] is the length of [a]. *)
+
+  (*@ function fold_right (f: 'b -> 'a -> 'a) (a: 'b t) (init: 'a) : 'a *)
+  (** [fold_right f a init] is
+      [f a\[0\] (f a\[1\] ( ... (f a\[n-1\] init) ...))], where [n] is the
+      length of [a]. *)
+
+  (*@ function map2 (f: 'a -> 'b -> 'c) (a: 'a t) (b: 'b t) : 'c t *)
+  (** [map2 f a b] applies function [f] to all the elements of [a] and [b], and
+      builds an array with the results returned by [f]. *)
+
+  (*@ predicate for_all (f: 'a -> bool) (a: 'a t) *)
+  (** [for_all f a] holds iff all elements of [a] satisfy the predicate [f]. *)
+
+  (*@ predicate _exists (f: 'a -> bool) (a: 'a t) *)
+  (** [_exists f a] holds iff at least one element of [a] satisfies [f]. *)
+
+  (*@ predicate for_all2 (f: 'a -> 'b -> bool) (a: 'a t) (b: 'b t) *)
+  (** Same as {!for_all}, but for a two-argument predicate. *)
+
+  (*@ predicate _exists2 (f: 'a -> 'b -> bool) (a: 'a t) (b: 'b t) *)
+  (** Same as {!_exists}, but for a two-argument predicate. *)
+
+  (*@ predicate mem (x: 'a) (a: 'a t) *)
+  (** [mem x a] holds iff [x] is equal to an element of [a] *)
+
+  (*@ function to_list (a: 'a t) : 'a list *)
+  (*@ function of_list (l: 'a list) : 'a t *)
+
+  (*@ function to_seq (a: 'a t) : 'a Seq.t *)
+  (*@ coercion *)
+  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
+
+  (*@ function to_bag (a: 'a t) : 'a bag *)
+
+  (*@ predicate permut (a b: 'a array) *)
+  (*@ predicate permut_sub (a b: 'a array) (lo hi: integer) *)
 
 end
 
-module ArrayPermut : sig
+(** {1 Bags} *)
 
-  (*@ predicate permut_sub (a b: 'a array) (i j: integer) *)
-  (*@ predicate permut_all (a b: 'a array) *)
+module Bag : sig
+  (*@ type 'a t = 'a bag *)
+  (** An alias for ['a bag]. *)
+
+  (*@ function occurrences (x: 'a) (b: 'a t): integer *)
+  (** [occurrences x b] is the number of occurrences of [x] in [s]. *)
+
+  (*@ function compare (b b': 'a t) : int *)
+  (** A comparison function over bags. *)
+
+  (*@ function empty : 'a t *)
+  (** [empty] is the empty bag. *)
+
+  (*@ predicate is_empty (b: 'a t) *)
+  (** [is_empty b] is [b = empty]. *)
+
+  (*@ predicate mem (x: 'a) (b: 'a t) *)
+  (** [mem x b] holds iff [b] contains [x] at least once. *)
+
+  (*@ function add (x: 'a) (b: 'a t) : 'a t *)
+  (** [add x b] is [b] when an occurence of [x] was added. *)
+
+  (*@ function singleton (x: 'a) : 'a t *)
+  (** [singleton x] is a bag containing one occurence of [x]. *)
+
+  (*@ function remove (x: 'a) (b: 'a t) : 'a t *)
+  (** [remove x b] is [b] where an occurence of [x] was removed. *)
+
+  (*@ function union (b b': 'a t) : 'a t *)
+  (** [union b b'] is a bag where for all element [x], [occurences x b = max
+      (occurences x b1) (occurences x b2)]. *)
+
+  (*@ function sum (b b': 'a t) : 'a t *)
+  (** [sum b b'] is a bag where for all element [x], [occurences x b =
+      (occurences x b1) + (occurences x b2)]. *)
+
+  (*@ function inter (b b': 'a t) : 'a t *)
+  (** [inter b b'] is a bag where for all element [x], [occurences x b =
+      min (occurences x b1) (occurences x b2)]. *)
+
+  (*@ predicate disjoint (b b': 'a t) *)
+  (** [disjoint b b'] holds iff [b] and [b'] have no element in common. *)
+
+  (*@ function diff (b b': 'a t) : 'a t *)
+  (** [diff b b'] is a bag where for all element [x], [occurences x b =
+      max 0 (occurences x b1 - occurences x b2)]. *)
+
+  (*@ predicate subset (b b': 'a t) *)
+  (** [subset b b'] holds iff for all element [x], [occurences x b <= occurences
+      x b']. *)
+
+  (*@ function choose (b: 'a t) : integer *)
+  (** [choose b] is an arbitrary element of [b]. *)
+
+  (*@ function choose_opt (b: 'a t) : 'a option *)
+  (** [choose_opt b] is an arbitrary element of [b] or [None] if [b] is empty. *)
+
+  (*@ function map (f: 'a -> 'b) (b: 'a t) : 'b t *)
+  (** [map f b] is a fresh set which elements are [f x1 ... f xN], where
+      [x1 ...
+      xN] are the elements of [b]. *)
+
+  (*@ function fold (f: 'a -> 'b -> 'b) (b: 'a t) : 'b *)
+  (** [fold f b] is [(f xN ... (f x2 (f x1 a))...)], where [x1 ... xN] are the
+      elements of [b]. *)
+
+  (*@ predicate for_all (f: 'a -> bool) (b: 'a t) *)
+  (** [for_all f b] holds iff [f x] is [true] for all elements in [b]. *)
+
+  (*@ predicate _exists (f: 'a -> bool) (b: 'a t) *)
+  (** [for_all f b] holds iff [f x] is [true] for at least one element in [b]. *)
+
+  (*@ function filter (f: 'a -> bool) (b: 'a t) : 'a t *)
+  (** [filter f b] is the bag of all elements in [b] that satisfy [f]. *)
+
+  (*@ function filter_map (f: 'a -> 'a option) (b: 'a t) : 'a t *)
+  (** [filter_map f b] is the bag of all [v] such that [f x = Some v] for some
+      element [x] of [b]. *)
+
+  (*@ function partition (f: 'a -> bool) (b: 'a t) : ('a t * 'a t) *)
+  (** [partition f b] is the pair of bags [(b1, b2)], where [b1] is the bag of
+      all the elements of [b] that satisfy [f], and [b2] is the bag of all the
+      elements of [b] that do not satisfy [f]. *)
+
+  (*@ function cardinal (b: 'a t) : int *)
+  (** [cardinal b] is the number of distinct elements in [b]. *)
+
+  (*@ function elements (b: 'a t) : 'a list *)
+  (** [elements b] is the list of all elements in [b]. *)
+
+  (*@ function to_list (b: 'a t) : 'a list *)
+  (*@ function of_list (l: 'a list) : 'a t *)
+
+  (*@ function to_seq (b: 'a t) : 'a Seq.t *)
+  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
+
+  (*@ function of_array (a: 'a array) : 'a t *)
 
 end
 
-(** Other OCaml built-in stuff *)
+(** {1 Sets} *)
 
-exception Not_found
-exception Invalid_argument of string
+(*@ function ({}) : 'a set *)
+(** [\{\}] is the empty set. *)
 
-module Sys : sig
+module Set : sig
+  (*@ type 'a t = 'a set *)
+  (** An alias for ['a set]. *)
 
-  (*@ function word_size : integer *)
+  (*@ function compare (s s': 'a t) : int *)
+  (** A comparison function over sets. *)
 
-  (*@ function int_size : integer *)
+  (*@ function empty : 'a t *)
+  (** [empty] is [∅]. *)
 
-  (*@ function big_endian : bool *)
+  (*@ predicate is_empty (s: 'a t) *)
+  (** [is_empty s] is [s = ∅]. *)
 
-  (*@ function max_string_length : integer *)
+  (*@ predicate mem (x: 'a) (s: 'a t) *)
+  (** [mem x s] is [x ∈ s]. *)
 
-  (*@ function max_array_length : integer *)
+  (*@ function add (x: 'a) (s: 'a t) : 'a t *)
+  (** [add x s] is [s ∪ {x}]. *)
 
+  (*@ function singleton (x: 'a) : 'a t *)
+  (** [singleton x] is [{x}]. *)
+
+  (*@ function remove (x: 'a) (s: 'a t) : 'a t *)
+  (** [remove x s] is [s ∖ {x}]. *)
+
+  (*@ function union (s s': 'a t) : 'a t *)
+  (** [union s s'] is [s ∪ s']. *)
+
+  (*@ function inter (s s': 'a t) : 'a t *)
+  (** [inter s s'] is [s ∩ s']. *)
+
+  (*@ predicate disjoint (s s': 'a t) *)
+  (** [disjoint s s'] is [s ∩ s' = ∅]. *)
+
+  (*@ function diff (s s': 'a t) : 'a t *)
+  (** [diff s s'] is [s ∖ s']. *)
+
+  (*@ predicate subset (s s': 'a t) *)
+  (** [subset s s'] is [s ⊂ s']. *)
+
+  (*@ function cardinal (s: 'a t) : integer *)
+  (** [cardinal s] is the number of elements in [s]. *)
+
+  (*@ function choose (s: 'a t) : integer *)
+  (** [choose s] is an arbitrary element of [s]. *)
+
+  (*@ function choose_opt: 'a t -> 'a option *)
+  (** [choose_opt s] is an arbitrary element of [s] or [None] if [s] is empty. *)
+
+  (*@ function map (f: 'a -> 'b) (s: 'a t) : 'b t *)
+  (** [map f s] is a fresh set which elements are [f x1 ... f xN], where
+      [x1 ...
+      xN] are the elements of [s]. *)
+
+  (*@ function fold (f: 'a -> 'b -> 'b) (s: 'a t) (a: 'b) : 'b *)
+  (** [fold f s a] is [(f xN ... (f x2 (f x1 a))...)], where [x1 ... xN] are the
+      elements of [s]. *)
+
+  (*@ predicate for_all (f: 'a -> bool) (s: 'a t) *)
+  (** [for_all f s] holds iff [f x] is [true] for all elements in [s]. *)
+
+  (*@ predicate _exists (f: 'a -> bool) (s: 'a t) *)
+  (** [_exists f s] holds iff [f x] is [true] for at least one element in [s]. *)
+
+  (*@ function filter (f: 'a -> bool) (s: 'a t) : 'a t *)
+  (** [filter f s] is the set of all elements in [s] that satisfy [f]. *)
+
+  (*@ function filter_map (f: 'a -> 'a option) (s: 'a t) : 'a t *)
+  (** [filter_map f s] is the set of all [v] such that [f x = Some v] for some
+      element [x] of [s]. *)
+
+  (*@ function partition (f: 'a -> bool) (s: 'a t) : ('a t * 'a t) *)
+  (** [partition f s] is the pair of sets [(s1, s2)], where [s1] is the set of
+      all the elements of [s] that satisfy the predicate [f], and [s2] is the
+      set of all the elements of [s] that do not satisfy [f]. *)
+
+  (*@ function elements (s: 'a t) : 'a list *)
+  (** [elements s] is the list of all elements in [s]. *)
+
+  (*@ function to_list (s: 'a t) : 'a list *)
+  (*@ function of_list (l: 'a list) : 'a t *)
+
+  (*@ function to_seq (s: 'a t) : 'a Seq.t *)
+  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
+end
+
+(*@ function ( [<-] ) (m: 'a -> 'b) (x:'a) (y: 'b) : 'a -> 'b *)
+
+module Map : sig
+  (* the type ('a, 'b) map is defined internally in GOSPEL and can be
+     written as 'a -> 'b *)
 end
 
 module Order : sig
@@ -282,108 +579,20 @@ module Order : sig
 
 end
 
-module Bag : sig
+(** Other OCaml built-in stuff *)
 
-  (*@ type 'a bag *)
+exception Not_found
 
-  (*@ function nb_occ (x: 'a) (b: 'a bag): integer *)
+exception Invalid_argument of string
 
-  (*@ axiom occ_non_negative: forall b: 'a bag, x: 'a.
-        nb_occ x b >= 0 *)
+module Sys : sig
+  (*@ function word_size : integer *)
 
-  (*@ predicate mem (x: 'a) (b: 'a bag) =
-        nb_occ x b > 0 *)
+  (*@ function int_size : integer *)
 
-  (*@ predicate eq_bag (a b: 'a bag) =
-        forall x:'a. nb_occ x a = nb_occ x b *)
+  (*@ function big_endian : bool *)
 
-  (*@ axiom bag_extensionality: forall a b: 'a bag.
-        eq_bag a b -> a = b *)
+  (*@ function max_string_length : integer *)
 
-  (*@ function empty_bag: 'a bag *)
-
-  (*@ axiom occ_empty: forall x: 'a. nb_occ x empty_bag = 0 *)
-
-  (*@ function singleton (x: 'a) : 'a bag *)
-
-  (*@ axiom occ_singleton: forall x y: 'a.
-        nb_occ y (singleton x) = if x = y then 1 else 0 *)
-
-  (*@ function union (x:'a bag) (y:'a bag) : 'a bag *)
-
-  (* axiom occ_union: forall x: 'a, a b: 'a bag.
-      nb_occ x (union a b) = nb_occ x a + nb_occ x b *)
-
-    (** add operation *)
-
-  (*@ function add (x: 'a) (b: 'a bag) : 'a bag =
-        union (singleton x) b *)
-
-  (** cardinality of bags *)
-
-  (*@ function card (x:'a bag): integer *)
-
-  (*@ axiom card_nonneg: forall x: 'a bag.
-        card x >= 0 *)
-
-  (*@ axiom card_empty: card (empty_bag: 'a bag) = 0 *)
-
-  (*@ axiom card_zero_empty: forall x: 'a bag.
-        card x = 0 -> x = empty_bag *)
-
-  (*@ axiom card_singleton: forall x:'a.
-        card (singleton x) = 1 *)
-
-  (*@ axiom card_union: forall x y: 'a bag.
-        card (union x y) = card x + card y *)
-
-  (** bag difference *)
-
-  (*@ function diff (x: 'a bag) (y: 'a bag) : 'a bag *)
-
-  (*@ axiom diff_occ: forall b1 b2: 'a bag, x:'a.
-      nb_occ x (diff b1 b2) = max 0 (nb_occ x b1 - nb_occ x b2) *)
-
-  (** arbitrary element *)
-
-  (*@ function choose (b: 'a bag) : 'a *)
-
-  (*@ axiom choose_mem: forall b: 'a bag.
-        empty_bag <> b -> mem (choose b) b *)
-
-end
-
-module Set : sig
-
-  (*@ type 'a set *)
-
-  (*@ predicate mem (x: 'a) (s: 'a set) *)
-
-  (*@ function ( {} ) : 'a set *)
-
-  (*@ function ( {:_:} ) (x: 'a) : 'a set *)
-
-  (*@ function union (x:'a set) (y:'a set) : 'a set *)
-
-  (*@ function sum (f:'a -> integer) (x: 'a set) : integer *)
-
-end
-
-module Map : sig
-
-  (* the type ('a, 'b) map is defined internally in GOSPEL and can be
-     written as 'a -> 'b *)
-
-  (*@ function ( [<-] ) (m: 'a -> 'b) (x:'a) (y: 'b) : 'a -> 'b *)
-
-  (*@ function ( [_] ) (m: 'a -> 'b) (x: 'a) : 'b *)
-
-end
-
-module Peano : sig
-  type t
-  (*@ model v: integer *)
-
-  (*@ function int_of_peano (t: t) : integer = t.v *)
-  (*@ coercion *)
+  (*@ function max_array_length : integer *)
 end

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -17,89 +17,112 @@ open Tast
 
 (** Namespace *)
 
-module Mstr = Map.Make(String)
+module Mstr = Map.Make (String)
 
 type namespace = {
-    ns_ts  : tysymbol  Mstr.t;
-    ns_ls  : lsymbol   Mstr.t;
-    ns_xs  : xsymbol   Mstr.t;
-    ns_ns  : namespace Mstr.t;
-    ns_tns : namespace Mstr.t
+  ns_ts : tysymbol Mstr.t;
+  ns_ls : lsymbol Mstr.t;
+  ns_xs : xsymbol Mstr.t;
+  ns_ns : namespace Mstr.t;
+  ns_tns : namespace Mstr.t;
 }
 
-let empty_ns = {
-    ns_ts  = Mstr.empty;
-    ns_ls  = Mstr.empty;
-    ns_xs  = Mstr.empty;
-    ns_ns  = Mstr.empty;
-    ns_tns = Mstr.empty
+let empty_ns =
+  {
+    ns_ts = Mstr.empty;
+    ns_ls = Mstr.empty;
+    ns_xs = Mstr.empty;
+    ns_ns = Mstr.empty;
+    ns_tns = Mstr.empty;
   }
 
-exception TypeNameClash of string
+exception NameClash of string
 
-let ns_add_ts ns s ts =
-  if Mstr.mem s ns.ns_ts then
-    if ts_equal (Mstr.find s ns.ns_ts) ts
-    then ns else error ~loc:ts.ts_ident.id_loc (TypeNameClash s)
+let add ~allow_duplicate ~equal ~loc ns s x =
+  if allow_duplicate then Mstr.add s x ns
   else
-    {ns with ns_ts = Mstr.add s ts ns.ns_ts}
-let ns_add_ls ns s ls = {ns with ns_ls = Mstr.add s ls ns.ns_ls}
-let ns_add_xs ns s xs = {ns with ns_xs = Mstr.add s xs ns.ns_xs}
-let ns_add_ns ns s new_ns =
-  {ns with ns_ns = Mstr.add s new_ns ns.ns_ns}
-let ns_add_tns ns s tns =
-  {ns with ns_tns = Mstr.add s tns ns.ns_tns}
+    match Mstr.find s ns with
+    | t when not (equal t x) -> error ~loc (NameClash s)
+    | _ | exception Not_found -> Mstr.add s x ns
+
+let ns_add_ts ~allow_duplicate ns s ts =
+  let ns_ts =
+    add ~allow_duplicate ~equal:ts_equal ~loc:ts.ts_ident.id_loc ns.ns_ts s ts
+  in
+  { ns with ns_ts }
+
+let ns_add_ls ~allow_duplicate:_ ns s ls =
+  let ns_ls =
+    add ~allow_duplicate:true ~equal:ls_equal ~loc:ls.ls_name.id_loc ns.ns_ls s ls
+  in
+  { ns with ns_ls }
+
+let ns_add_xs ~allow_duplicate ns s xs =
+  let ns_xs =
+    add ~allow_duplicate ~equal:xs_equal ~loc:xs.xs_ident.id_loc ns.ns_xs s xs
+  in
+  { ns with ns_xs }
+
+(* FIXME: Adding multiple modules with the same name to the export should not be
+   allowed either. *)
+let ns_add_ns ~allow_duplicate:_ ns s new_ns = { ns with ns_ns = Mstr.add s new_ns ns.ns_ns }
+let ns_add_tns ~allow_duplicate:_ ns s tns = { ns with ns_tns = Mstr.add s tns ns.ns_tns }
 
 let merge_ns from_ns to_ns =
   let choose_fst _ x _ = Some x in
   let union m1 m2 = Mstr.union choose_fst m1 m2 in
-  { ns_ts  = union from_ns.ns_ts to_ns.ns_ts;
-    ns_ls  = union from_ns.ns_ls to_ns.ns_ls;
-    ns_xs  = union from_ns.ns_xs to_ns.ns_xs;
-    ns_ns  = union from_ns.ns_ns to_ns.ns_ns;
-    ns_tns = union from_ns.ns_tns to_ns.ns_tns;}
+  {
+    ns_ts = union from_ns.ns_ts to_ns.ns_ts;
+    ns_ls = union from_ns.ns_ls to_ns.ns_ls;
+    ns_xs = union from_ns.ns_xs to_ns.ns_xs;
+    ns_ns = union from_ns.ns_ns to_ns.ns_ns;
+    ns_tns = union from_ns.ns_tns to_ns.ns_tns;
+  }
 
 let rec ns_find get_map ns = function
   | [] -> assert false
-  | [x] -> Mstr.find x (get_map ns)
-  | x::xs -> ns_find get_map (Mstr.find x ns.ns_ns) xs
+  | [ x ] -> Mstr.find x (get_map ns)
+  | x :: xs -> ns_find get_map (Mstr.find x ns.ns_ns) xs
 
-let ns_find_ts ns s = ns_find (fun ns -> ns.ns_ts)   ns s
-let ns_find_ls ns s = ns_find (fun ns -> ns.ns_ls)   ns s
-let ns_find_xs ns s = ns_find (fun ns -> ns.ns_xs)   ns s
-let ns_find_ns ns s = ns_find (fun ns -> ns.ns_ns)   ns s
+let ns_find_ts ns s = ns_find (fun ns -> ns.ns_ts) ns s
+let ns_find_ls ns s = ns_find (fun ns -> ns.ns_ls) ns s
+let ns_find_xs ns s = ns_find (fun ns -> ns.ns_xs) ns s
+let ns_find_ns ns s = ns_find (fun ns -> ns.ns_ns) ns s
 let ns_find_tns ns s = ns_find (fun ns -> ns.ns_tns) ns s
-
 let ns_exists_ns ns s = Mstr.mem s ns.ns_ns
 
 let rec ns_rm_ts ns = function
   | [] -> assert false
-  | [x] -> {ns with ns_ts = Mstr.remove x ns.ns_ts}
+  | [ x ] -> { ns with ns_ts = Mstr.remove x ns.ns_ts }
   | x :: xs ->
-     let x_ns = ns_rm_ts (Mstr.find x ns.ns_ns) xs in
-     {ns with ns_ns = Mstr.add x x_ns ns.ns_ns}
+      let x_ns = ns_rm_ts (Mstr.find x ns.ns_ns) xs in
+      { ns with ns_ns = Mstr.add x x_ns ns.ns_ns }
 
-let rec ns_replace_ts new_ts sl ns = match sl with
+let rec ns_replace_ts new_ts sl ns =
+  match sl with
   | [] -> assert false
-  | [x] -> {ns with ns_ts = Mstr.add x new_ts ns.ns_ts}
+  | [ x ] -> { ns with ns_ts = Mstr.add x new_ts ns.ns_ts }
   | x :: xs ->
-     let ns_ns = Mstr.find x ns.ns_ns in
-     let ns_ns = ns_replace_ts new_ts xs ns_ns in
-     { ns with ns_ns = Mstr.add x ns_ns ns.ns_ns }
+      let ns_ns = Mstr.find x ns.ns_ns in
+      let ns_ns = ns_replace_ts new_ts xs ns_ns in
+      { ns with ns_ns = Mstr.add x ns_ns ns.ns_ns }
 
-let rec ns_subst_ts old_ns new_ts {ns_ts;ns_ls;ns_xs;ns_ns;ns_tns} =
-  {ns_ts = Mstr.map (ts_subst_ts old_ns new_ts) ns_ts;
-   ns_ls = Mstr.map (ls_subst_ts old_ns new_ts) ns_ls;
-   ns_xs = Mstr.map (xs_subst_ts old_ns new_ts) ns_xs;
-   ns_ns = Mstr.map (ns_subst_ts old_ns new_ts) ns_ns;
-   ns_tns = Mstr.map (ns_subst_ts old_ns new_ts) ns_tns}
+let rec ns_subst_ts old_ns new_ts { ns_ts; ns_ls; ns_xs; ns_ns; ns_tns } =
+  {
+    ns_ts = Mstr.map (ts_subst_ts old_ns new_ts) ns_ts;
+    ns_ls = Mstr.map (ls_subst_ts old_ns new_ts) ns_ls;
+    ns_xs = Mstr.map (xs_subst_ts old_ns new_ts) ns_xs;
+    ns_ns = Mstr.map (ns_subst_ts old_ns new_ts) ns_ns;
+    ns_tns = Mstr.map (ns_subst_ts old_ns new_ts) ns_tns;
+  }
 
-let rec ns_subst_ty old_ts new_ts ty {ns_ts;ns_ls;ns_xs;ns_ns;ns_tns} =
-  {ns_ts = Mstr.map (ts_subst_ty old_ts new_ts ty) ns_ts;
-   ns_ls = Mstr.map (ls_subst_ty old_ts new_ts ty) ns_ls;
-   ns_xs = Mstr.map (xs_subst_ty old_ts new_ts ty) ns_xs;
-   ns_ns = Mstr.map (ns_subst_ty old_ts new_ts ty) ns_ns;
-   ns_tns = Mstr.map (ns_subst_ty old_ts new_ts ty) ns_tns
+let rec ns_subst_ty old_ts new_ts ty { ns_ts; ns_ls; ns_xs; ns_ns; ns_tns } =
+  {
+    ns_ts = Mstr.map (ts_subst_ty old_ts new_ts ty) ns_ts;
+    ns_ls = Mstr.map (ls_subst_ty old_ts new_ts ty) ns_ls;
+    ns_xs = Mstr.map (xs_subst_ty old_ts new_ts ty) ns_xs;
+    ns_ns = Mstr.map (ns_subst_ty old_ts new_ts ty) ns_ns;
+    ns_tns = Mstr.map (ns_subst_ty old_ts new_ts ty) ns_tns;
   }
 
 (** Primitives types and functions *)
@@ -119,255 +142,300 @@ let ns_with_primitives =
         (2) as alternative, we could leave the type abstract and create
         function ([]) and (::). However, in this case these functions
         could not be used in pattern matching because they are not
-        constructors.  *)
+        constructors. *)
   let primitive_tys =
-    [ ("integer", ts_integer); ("string", ts_string); ("char", ts_char);
-      ("float", ts_float); ("bool", ts_bool); ("option",ts_option);
-      ("list", ts_list); ("unit", ts_unit)] in
-  let primitive_ps =
-    [ ps_equ.ls_name.id_str, ps_equ ] in
+    [
+      ("integer", ts_integer);
+      ("string", ts_string);
+      ("char", ts_char);
+      ("float", ts_float);
+      ("bool", ts_bool);
+      ("option", ts_option);
+      ("list", ts_list);
+      ("unit", ts_unit);
+    ]
+  in
+  let primitive_ps = [ (ps_equ.ls_name.id_str, ps_equ) ] in
   let primitive_ls =
-    [ (let tv = fresh_ty_var "a" in
-       none.id_str, fsymbol ~constr:true ~field:false none [] (ty_option tv));
+    [
       (let tv = fresh_ty_var "a" in
-       some.id_str, fsymbol ~constr:true ~field:false some [tv] (ty_option tv));
+       (none.id_str, fsymbol ~constr:true ~field:false none [] (ty_option tv)));
       (let tv = fresh_ty_var "a" in
-       nil.id_str, fsymbol ~constr:true ~field:false nil [] (ty_list tv));
+       ( some.id_str,
+         fsymbol ~constr:true ~field:false some [ tv ] (ty_option tv) ));
       (let tv = fresh_ty_var "a" in
-       cons.id_str, fsymbol ~constr:true ~field:false cons [tv; ty_app ts_list [tv]] (ty_list tv));
-    ] in
-  let ns = List.fold_left (fun ns (s,ts) ->
-               ns_add_ts ns s ts) empty_ns primitive_tys in
-  List.fold_left (fun ns (s,ls) ->
-      ns_add_ls ns s ls) ns (primitive_ls @ primitive_ps)
+       (nil.id_str, fsymbol ~constr:true ~field:false nil [] (ty_list tv)));
+      (let tv = fresh_ty_var "a" in
+       ( cons.id_str,
+         fsymbol ~constr:true ~field:false cons
+           [ tv; ty_app ts_list [ tv ] ]
+           (ty_list tv) ));
+    ]
+  in
+  let ns =
+    List.fold_left (fun ns (s, ts) -> ns_add_ts ~allow_duplicate:true ns s ts) empty_ns primitive_tys
+  in
+  List.fold_left
+    (fun ns (s, ls) -> ns_add_ls ~allow_duplicate:true ns s ls)
+    ns
+    (primitive_ls @ primitive_ps)
 
 (** Modules *)
 
-module Mid = Map.Make(struct type t = Ident.t let compare = compare end)
+module Mid = Map.Make (struct
+  type t = Ident.t
+
+  let compare = compare
+end)
 
 type known_ids = signature_item Mid.t
-
-type file = {
-    fl_nm     : Ident.t;
-    fl_sigs   : signature;
-    fl_export : namespace;
-  }
+type file = { fl_nm : Ident.t; fl_sigs : signature; fl_export : namespace }
 
 type module_uc = {
-    muc_nm     : Ident.t;
-    muc_sigs   : signature list;
-    muc_prefix : string    list; (* essential when closing namespaces *)
-    muc_import : namespace list;
-    muc_export : namespace list;
-    muc_files  : file Mstr.t;
-    muc_kid    : known_ids;
-    muc_crcm   : Coercion.t
+  muc_nm : Ident.t;
+  muc_sigs : signature list;
+  muc_prefix : string list;
+  (* essential when closing namespaces *)
+  muc_import : namespace list;
+  muc_export : namespace list;
+  muc_files : file Mstr.t;
+  muc_kid : known_ids;
+  muc_crcm : Coercion.t;
 }
 
-let muc_add ?(export=false) add muc s x =
-  match muc.muc_import, muc.muc_export with
+let muc_add ?(export = false) add muc s x =
+  match (muc.muc_import, muc.muc_export) with
   | i0 :: il, e0 :: el ->
-     let e = if export then add e0 s x else e0 in
-     {muc with muc_import = add i0 s x :: il;
-               muc_export = e :: el}
+    let i = add ~allow_duplicate:true i0 s x in
+    let e = if export then add ~allow_duplicate:false e0 s x else e0 in
+    { muc with muc_import = i :: il; muc_export = e :: el }
   | _ -> assert false
 
-let add_ts  ?(export=false) = muc_add ~export ns_add_ts
-let add_ls  ?(export=false) = muc_add ~export ns_add_ls
-let add_xs  ?(export=false) = muc_add ~export ns_add_xs
-let add_ns  ?(export=false) = muc_add ~export ns_add_ns
-let add_tns ?(export=false) = muc_add ~export ns_add_tns
-
-let add_file muc s file =
-  {muc with muc_files = Mstr.add s file muc.muc_files}
-
+let add_ts ?(export = false) = muc_add ~export ns_add_ts
+let add_ls ?(export = false) = muc_add ~export ns_add_ls
+let add_xs ?(export = false) = muc_add ~export ns_add_xs
+let add_ns ?(export = false) = muc_add ~export ns_add_ns
+let add_tns ?(export = false) = muc_add ~export ns_add_tns
+let add_file muc s file = { muc with muc_files = Mstr.add s file muc.muc_files }
 let get_file muc s = Mstr.find s muc.muc_files
-
-let add_kid muc id s =
-  {muc with muc_kid = Mid.add id s muc.muc_kid}
+let add_kid muc id s = { muc with muc_kid = Mid.add id s muc.muc_kid }
 
 let add_sig muc sig_ =
   match muc.muc_sigs with
-  | s0 :: sl ->
-     {muc with muc_sigs = (sig_ :: s0) :: sl}
+  | s0 :: sl -> { muc with muc_sigs = (sig_ :: s0) :: sl }
   | _ -> assert false
 
-let add_coer muc ls =
-  {muc with muc_crcm = Coercion.add muc.muc_crcm ls}
+let add_coer muc ls = { muc with muc_crcm = Coercion.add muc.muc_crcm ls }
 
-let add_ns_top ?(export=false) muc ns =
+let add_ns_top ?(export = false) muc ns =
   let add f muc map = Mstr.fold (fun s v muc -> f muc s v) map muc in
-  let muc = add (add_ts ~export)  muc ns.ns_ts in
-  let muc = add (add_ls ~export)  muc ns.ns_ls in
-  let muc = add (add_xs ~export)  muc ns.ns_xs in
-  let muc = add (add_ns ~export)  muc ns.ns_ns in
+  let muc = add (add_ts ~export) muc ns.ns_ts in
+  let muc = add (add_ls ~export) muc ns.ns_ls in
+  let muc = add (add_xs ~export) muc ns.ns_xs in
+  let muc = add (add_ns ~export) muc ns.ns_ns in
   let muc = add (add_tns ~export) muc ns.ns_tns in
   muc
 
 let muc_replace_ts muc new_ts sl =
-  match muc.muc_import, muc.muc_export with
+  match (muc.muc_import, muc.muc_export) with
   | i0 :: il, e0 :: el ->
-     {muc with muc_import = ns_replace_ts new_ts sl i0 :: il;
-               muc_export = ns_replace_ts new_ts sl e0 :: el}
+      {
+        muc with
+        muc_import = ns_replace_ts new_ts sl i0 :: il;
+        muc_export = ns_replace_ts new_ts sl e0 :: el;
+      }
   | _ -> assert false
 
 let muc_subst_ts muc old_ts new_ts =
-  match muc.muc_import, muc.muc_export with
+  match (muc.muc_import, muc.muc_export) with
   | i0 :: il, e0 :: el ->
-     {muc with
-       muc_import = ns_subst_ts old_ts new_ts i0 :: il;
-       muc_export = ns_subst_ts old_ts new_ts e0 :: el}
+      {
+        muc with
+        muc_import = ns_subst_ts old_ts new_ts i0 :: il;
+        muc_export = ns_subst_ts old_ts new_ts e0 :: el;
+      }
   | _ -> assert false
 
 let muc_subst_ty muc old_ts new_ts ty =
-  match muc.muc_import, muc.muc_export with
+  match (muc.muc_import, muc.muc_export) with
   | i0 :: il, e0 :: el ->
-     {muc with muc_import = ns_subst_ty old_ts new_ts ty i0 :: il;
-               muc_export = ns_subst_ty old_ts new_ts ty e0 :: el}
+      {
+        muc with
+        muc_import = ns_subst_ty old_ts new_ts ty i0 :: il;
+        muc_export = ns_subst_ty old_ts new_ts ty e0 :: el;
+      }
   | _ -> assert false
 
 let muc_rm_ts muc sl =
-  match muc.muc_import, muc.muc_export with
+  match (muc.muc_import, muc.muc_export) with
   | i0 :: il, e0 :: el ->
-     {muc with muc_import = ns_rm_ts i0 sl :: il;
-               muc_export = ns_rm_ts e0 sl :: el}
+      {
+        muc with
+        muc_import = ns_rm_ts i0 sl :: il;
+        muc_export = ns_rm_ts e0 sl :: el;
+      }
   | _ -> assert false
 
 let open_empty_module muc s =
-  {muc with muc_prefix = s :: muc.muc_prefix;
-            muc_sigs   = [] :: muc.muc_sigs;
-            muc_import = ns_with_primitives :: muc.muc_import;
-            muc_export = empty_ns :: muc.muc_export}
+  {
+    muc with
+    muc_prefix = s :: muc.muc_prefix;
+    muc_sigs = [] :: muc.muc_sigs;
+    muc_import = ns_with_primitives :: muc.muc_import;
+    muc_export = empty_ns :: muc.muc_export;
+  }
 
 let close_module_file muc =
-  match muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs with
+  match (muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs) with
   | _ :: i1 :: il, e0 :: e1 :: el, p0 :: pl, s0 :: sl ->
-     let file = { fl_nm = Ident.create p0;
-                  fl_sigs   = List.rev s0; fl_export = e0 } in
-     {muc with  muc_prefix = pl;
-                muc_import = ns_add_ns i1 p0 e0 :: il;
-                muc_export = e1 :: el;
-                muc_sigs   = sl;
-                muc_files  = Mstr.add p0 file muc.muc_files}
+      let file =
+        { fl_nm = Ident.create p0; fl_sigs = List.rev s0; fl_export = e0 }
+      in
+      {
+        muc with
+        muc_prefix = pl;
+        muc_import = ns_add_ns ~allow_duplicate:true i1 p0 e0 :: il;
+        muc_export = e1 :: el;
+        muc_sigs = sl;
+        muc_files = Mstr.add p0 file muc.muc_files;
+      }
   | _ -> assert false
 
 let open_module muc s =
   match muc.muc_import with
   | i0 :: _ ->
-     {muc with muc_prefix = s :: muc.muc_prefix;
-               muc_sigs   = [] :: muc.muc_sigs;
-               muc_import = i0 :: muc.muc_import;
-               muc_export = empty_ns :: muc.muc_export}
+      {
+        muc with
+        muc_prefix = s :: muc.muc_prefix;
+        muc_sigs = [] :: muc.muc_sigs;
+        muc_import = i0 :: muc.muc_import;
+        muc_export = empty_ns :: muc.muc_export;
+      }
   | _ -> assert false
 
 (* for module declarations *)
 let close_module muc =
-  match muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs with
+  match (muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs) with
   | _ :: i1 :: il, e0 :: e1 :: el, p0 :: pl, _ :: sl ->
-     {muc with muc_prefix = pl;
-               muc_import = ns_add_ns i1 p0 e0 :: il;
-               muc_export = ns_add_ns e1 p0 e0 :: el;
-               muc_sigs   = sl;}
+      {
+        muc with
+        muc_prefix = pl;
+        muc_import = ns_add_ns ~allow_duplicate:true i1 p0 e0 :: il;
+        muc_export = ns_add_ns ~allow_duplicate:true e1 p0 e0 :: el;
+        muc_sigs = sl;
+      }
   | _ -> assert false
 
 (* for functor arguments *)
 let close_module_functor muc =
-  match muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs with
+  match (muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs) with
   | _ :: i1 :: il, e0 :: e1 :: el, p0 :: pl, _ :: sl ->
-     {muc with muc_prefix = pl;
-               muc_import = ns_add_ns i1 p0 e0 :: il;
-               muc_export = e1 :: el;
-               muc_sigs   = sl;}
+      {
+        muc with
+        muc_prefix = pl;
+        muc_import = ns_add_ns ~allow_duplicate:true i1 p0 e0 :: il;
+        muc_export = e1 :: el;
+        muc_sigs = sl;
+      }
   | _ -> assert false
 
 (* for module types *)
 let close_module_type muc =
-  match muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs with
+  match (muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs) with
   | _ :: i1 :: il, e0 :: e1 :: el, p0 :: pl, _ :: sl ->
-     {muc with muc_prefix = pl;
-               muc_import = ns_add_tns i1 p0 e0 :: il;
-               muc_export = ns_add_tns e1 p0 e0 :: el;
-               muc_sigs   = sl;}
+      {
+        muc with
+        muc_prefix = pl;
+        muc_import = ns_add_tns ~allow_duplicate:true i1 p0 e0 :: il;
+        muc_export = ns_add_tns ~allow_duplicate:true e1 p0 e0 :: el;
+        muc_sigs = sl;
+      }
   | _ -> assert false
 
-let get_top_sigs muc = match muc.muc_sigs with
-  | s0 :: _ -> List.rev s0
-  | _ -> assert false
+let get_top_sigs muc =
+  match muc.muc_sigs with s0 :: _ -> List.rev s0 | _ -> assert false
 
-let get_top_import muc = match muc.muc_import with
-  | i0 :: _ -> i0
-  | _ -> assert false
+let get_top_import muc =
+  match muc.muc_import with i0 :: _ -> i0 | _ -> assert false
 
-let get_top_export muc = match muc.muc_export with
-  | e0 :: _ -> e0
-  | _ -> assert false
+let get_top_export muc =
+  match muc.muc_export with e0 :: _ -> e0 | _ -> assert false
 
 let add_sig_contents muc sig_ =
   let muc = add_sig muc sig_ in
   let get_cs_pjs = function
     | Pty_abstract -> []
-    | Pty_variant cdl ->
-       List.map (fun cd -> cd.cd_cs) cdl
-    | Pty_record rd ->
-       rd.rd_cs :: (List.map (fun ld -> ld.ld_field) rd.rd_ldl)
-    | _ -> assert false in
+    | Pty_variant cdl -> List.map (fun cd -> cd.cd_cs) cdl
+    | Pty_record rd -> rd.rd_cs :: List.map (fun ld -> ld.ld_field) rd.rd_ldl
+    | _ -> assert false
+  in
   match sig_.sig_desc with
-  | Sig_val ({vd_spec = Some sp} as v, _) when sp.sp_pure ->
+  | Sig_val (({ vd_spec = Some sp } as v), _) when sp.sp_pure ->
       let tyl = List.map ty_of_lb_arg sp.sp_args in
       let ty = ty_tuple (List.map ty_of_lb_arg sp.sp_ret) in
       let ls = lsymbol ~field:false v.vd_name tyl (Some ty) in
       let muc = add_ls ~export:true muc ls.ls_name.id_str ls in
       add_kid muc ls.ls_name sig_
   | Sig_function f ->
-     let muc = add_ls ~export:true muc f.fun_ls.ls_name.id_str f.fun_ls in
-     let muc = match f.fun_spec with
-       | Some spec when spec.fun_coer -> add_coer muc f.fun_ls
-       | _ -> muc
-     in
-     add_kid muc f.fun_ls.ls_name sig_
-  | Sig_type (_,tdl,_) ->
-     let add_td muc td =
-       let s = (ts_ident td.td_ts).id_str in
-       let muc = add_ts ~export:true muc s td.td_ts in
-       let csl = get_cs_pjs td.td_kind in
-       let muc = List.fold_left (fun muc cs ->
-         add_ls ~export:true muc cs.ls_name.id_str cs) muc csl in
-       let fields =
-         Option.fold
-           ~none:[] ~some:(fun spec -> List.map fst spec.ty_fields)
-           td.td_spec
-       in
-       let muc = List.fold_left (fun muc ls ->
-         add_ls ~export:true muc ls.ls_name.id_str ls) muc fields in
-       add_kid muc td.td_ts.ts_ident sig_  in
-     List.fold_left add_td muc tdl
+      let muc = add_ls ~export:true muc f.fun_ls.ls_name.id_str f.fun_ls in
+      let muc =
+        match f.fun_spec with
+        | Some spec when spec.fun_coer -> add_coer muc f.fun_ls
+        | _ -> muc
+      in
+      add_kid muc f.fun_ls.ls_name sig_
+  | Sig_type (_, tdl, _) ->
+      let add_td muc td =
+        let s = (ts_ident td.td_ts).id_str in
+        let muc = add_ts ~export:true muc s td.td_ts in
+        let csl = get_cs_pjs td.td_kind in
+        let muc =
+          List.fold_left
+            (fun muc cs -> add_ls ~export:true muc cs.ls_name.id_str cs)
+            muc csl
+        in
+        let fields =
+          Option.fold ~none:[]
+            ~some:(fun spec -> List.map fst spec.ty_fields)
+            td.td_spec
+        in
+        let muc =
+          List.fold_left
+            (fun muc ls -> add_ls ~export:true muc ls.ls_name.id_str ls)
+            muc fields
+        in
+        add_kid muc td.td_ts.ts_ident sig_
+      in
+      List.fold_left add_td muc tdl
   | Sig_exception te ->
-     let s = te.exn_constructor.ext_ident.id_str in
-     let xs = te.exn_constructor.ext_xs in
-     let muc = add_xs ~export:true muc s xs in
-     add_kid muc te.exn_constructor.ext_ident sig_
-  | Sig_open ({opn_id},_) ->
-     let nm = List.hd (List.rev opn_id) in
-     let ns = ns_find_ns (get_top_import muc) opn_id in
-     add_ns_top ~export:false (add_ns ~export:false muc nm ns) ns
-  | _ -> muc (* TODO *)
+      let s = te.exn_constructor.ext_ident.id_str in
+      let xs = te.exn_constructor.ext_xs in
+      let muc = add_xs ~export:true muc s xs in
+      add_kid muc te.exn_constructor.ext_ident sig_
+  | Sig_open ({ opn_id }, _) ->
+      let nm = List.hd (List.rev opn_id) in
+      let ns = ns_find_ns (get_top_import muc) opn_id in
+      add_ns_top ~export:false (add_ns ~export:false muc nm ns) ns
+  | _ -> muc
+(* TODO *)
 
 (** Module under construction with primitive types and functions *)
 
-let init_muc s = {
-    muc_nm      = Ident.create s;
-    muc_sigs    = [[]];
-    muc_prefix  = [s];
-    muc_import  = [ns_with_primitives];
-    muc_export  = [empty_ns];
-    muc_files   = Mstr.empty;
-    muc_kid     = Mid.empty;
-    muc_crcm    = Coercion.empty}
+let init_muc s =
+  {
+    muc_nm = Ident.create s;
+    muc_sigs = [ [] ];
+    muc_prefix = [ s ];
+    muc_import = [ ns_with_primitives ];
+    muc_export = [ empty_ns ];
+    muc_files = Mstr.empty;
+    muc_kid = Mid.empty;
+    muc_crcm = Coercion.empty;
+  }
 
 let wrap_up_muc muc =
-  match muc.muc_export, muc.muc_sigs with
-  | [e], [s] ->
-     { fl_nm = muc.muc_nm; fl_sigs = List.rev s; fl_export = e }
+  match (muc.muc_export, muc.muc_sigs) with
+  | [ e ], [ s ] -> { fl_nm = muc.muc_nm; fl_sigs = List.rev s; fl_export = e }
   | _ -> assert false
 
 (** Pretty printing *)
@@ -375,14 +443,13 @@ let wrap_up_muc muc =
 open Utils.Fmt
 
 let rec tree_ns f fmt ns =
-  Mstr.iter (fun s ns ->
-      if f ns = Mstr.empty then
-        pp fmt "@[%s@\n@]" s
-      else
-        pp fmt "@[%s:@\n@ @[%a@]@\n@]" s (tree_ns f) (f ns)) ns
+  Mstr.iter
+    (fun s ns ->
+      if f ns = Mstr.empty then pp fmt "@[%s@\n@]" s
+      else pp fmt "@[%s:@\n@ @[%a@]@\n@]" s (tree_ns f) (f ns))
+    ns
 
-let ns_names nsm =
-  List.map fst (Mstr.bindings nsm)
+let ns_names nsm = List.map fst (Mstr.bindings nsm)
 
 let print_mstr_vals printer fmt m =
   let print_elem e = pp fmt "@[%a@]@\n" printer e in
@@ -392,34 +459,35 @@ let rec print_nested_ns fmt ns =
   let print_elem nm e = pp fmt "@[%a@]@\n" (print_ns nm) e in
   Mstr.iter (fun nm ns -> print_elem nm ns) ns
 
-and print_ns nm fmt {ns_ts;ns_ls;ns_xs;ns_ns;ns_tns} =
-  pp fmt "@[@[<hv2>@[Namespace: %s@]@\n\
-          @[<hv2>Type symbols@\n%a@]@\n\
-          @[<hv2>Logic Symbols@\n%a@]@\n\
-          @[<hv2>Exception Symbols@\n%a@]@\n\
-          @[<hv2>Namespaces@\n%a@]@\n\
-          @[<hv2>Type Namespaces@\n%a@]\
-          @]\
-          @]"
-    nm
-    (print_mstr_vals print_ts) ns_ts
-    (print_mstr_vals print_ls_decl) ns_ls
-    (print_mstr_vals print_xs) ns_xs
-    print_nested_ns ns_ns
-    print_nested_ns ns_tns
-    (* (tree_ns (fun ns -> ns.ns_ns)) ns_ns
-     * (tree_ns (fun ns -> ns.ns_tns)) ns_tns *)
+and print_ns nm fmt { ns_ts; ns_ls; ns_xs; ns_ns; ns_tns } =
+  pp fmt
+    "@[@[<hv2>@[Namespace: %s@]@\n\
+     @[<hv2>Type symbols@\n\
+     %a@]@\n\
+     @[<hv2>Logic Symbols@\n\
+     %a@]@\n\
+     @[<hv2>Exception Symbols@\n\
+     %a@]@\n\
+     @[<hv2>Namespaces@\n\
+     %a@]@\n\
+     @[<hv2>Type Namespaces@\n\
+     %a@]@]@]"
+    nm (print_mstr_vals print_ts) ns_ts
+    (print_mstr_vals print_ls_decl)
+    ns_ls (print_mstr_vals print_xs) ns_xs print_nested_ns ns_ns print_nested_ns
+    ns_tns
+(* (tree_ns (fun ns -> ns.ns_ns)) ns_ns
+ * (tree_ns (fun ns -> ns.ns_tns)) ns_tns *)
 
-let print_file fmt {fl_nm;fl_sigs;fl_export} =
-  pp fmt "@[module %a@\n@[<h2>@\n%a@\n@[<hv2>Signatures@\n%a@]@]@]@."
-    Ident.pp fl_nm
-    (print_ns fl_nm.id_str) fl_export
-    print_signature fl_sigs
+let print_file fmt { fl_nm; fl_sigs; fl_export } =
+  pp fmt "@[module %a@\n@[<h2>@\n%a@\n@[<hv2>Signatures@\n%a@]@]@]@." Ident.pp
+    fl_nm (print_ns fl_nm.id_str) fl_export print_signature fl_sigs
 
 let () =
   let open Location.Error in
   register_error_of_exn (function
-      | TypeNameClash s ->
-        Fmt.kstr (fun str -> Some (make ~loc:Location.none ~sub:[] str))
-          "Multiple definitions of type %s" s
-      | _ -> None)
+    | NameClash s ->
+        Fmt.kstr
+          (fun str -> Some (make ~loc:Location.none ~sub:[] str))
+          "A declaration for `%s' already exists in this context" s
+    | _ -> None)

--- a/src/ttypes.ml
+++ b/src/ttypes.ml
@@ -223,6 +223,8 @@ type xsymbol = {
 
 let xsymbol id ty = {xs_ident = id; xs_type = ty}
 
+let xs_equal = (=)
+
 module Xs = struct
   type t = xsymbol
   let equal = (=)

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -395,7 +395,7 @@ let process_type_spec kid crcm ns ty spec =
     let f_ty = ty_of_pty ns f.f_pty in
     let ls = fsymbol ~field:true (Ident.of_preid f.f_preid) [ty] f_ty in
     let ls_inv = fsymbol ~field:true (Ident.of_preid f.f_preid) [] f_ty in
-    (ns_add_ls ns f.f_preid.pid_str ls_inv, (ls, f.f_mutable)::fields) in
+    (ns_add_ls ~allow_duplicate:true ns f.f_preid.pid_str ls_inv, (ls, f.f_mutable)::fields) in
   let (ns,fields) = List.fold_left field (ns,[]) spec.ty_field in
   let fields = List.rev fields in
   let env = Mstr.empty in
@@ -408,7 +408,7 @@ exception CyclicTypeDecl of string
 let type_type_declaration kid crcm ns tdl =
   let add_new tdm td =
     if Mstr.mem td.tname.txt tdm then
-      error ~loc:td.tname.loc (TypeNameClash td.tname.txt)
+      error ~loc:td.tname.loc (NameClash td.tname.txt)
     else
       Mstr.add td.tname.txt td tdm in
   let tdm = List.fold_left add_new Mstr.empty tdl in
@@ -477,7 +477,7 @@ let type_type_declaration kid crcm ns tdl =
         let field_inv = fsymbol ~field:true id [] ty_res in
         let mut = mutable_flag ld.pld_mutable in
         let ld = label_declaration field mut ld.pld_loc ld.pld_attributes in
-        ld :: ldl, ns_add_ls ns id.id_str field_inv
+        ld :: ldl, ns_add_ls ~allow_duplicate:true ns id.id_str field_inv
       in
       let rd_ldl, ns = List.fold_right mk_ld ldl ([], ns) in
       {rd_cs; rd_ldl}, ns
@@ -723,7 +723,7 @@ let process_function kid crcm ns f =
   let tyl = List.map (fun vs -> vs.vs_ty) params in
 
   let ls = lsymbol ~field:false (Ident.of_preid f.fun_name) tyl f_ty in
-  let ns = if f.fun_rec then ns_add_ls ns f.fun_name.pid_str ls else ns in
+  let ns = if f.fun_rec then ns_add_ls ~allow_duplicate:true ns f.fun_name.pid_str ls else ns in
 
   (* check that there is no duplicated parameters; we must do this
      here, before creating identifiers *)

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -32,7 +32,7 @@
   let id_anonymous loc = Preid.create "_" ~attrs:[] ~loc
 
   let array_get l =
-    Qdot (Qpreid (mk_pid "Array" l), mk_pid (mixfix "[_]") l)
+    Qdot (Qpreid (mk_pid "Array" l), mk_pid "get" l)
 
 (*
     sp_hd_ret = [];
@@ -150,7 +150,6 @@
 val_spec:
 | hd=val_spec_header? bd=val_spec_body EOF
   { { bd with sp_header = hd } }
-(* TODO: pure or diverges only *)
 ;
 
 axiom:

--- a/test/negative/t14.mli.expected
+++ b/test/negative/t14.mli.expected
@@ -27,4 +27,4 @@ type 'a t2 =
 
 (*@ function i ... *)
 File "t14.mli", line 17, characters 8-15:
-Error: This pattern has type 'a t1 but is expected to have type @194@ t2
+Error: This pattern has type 'a t1 but is expected to have type @42@ t2

--- a/test/negative/t31.mli.expected
+++ b/test/negative/t31.mli.expected
@@ -25,6 +25,5 @@ val f : 'a -> 'a
     with ...
      *)
 File "t31.mli", line 18, characters 13-20:
-Error: This pattern has type int * int but is expected to have type (@193@, @194@,
-                                                              @195@) 
-tuple3
+Error: This pattern has type int * int but is expected to have type (@41@, @42@,
+                                                              @43@) tuple3

--- a/test/negative/t32.mli.expected
+++ b/test/negative/t32.mli.expected
@@ -25,6 +25,6 @@ val f : 'a -> 'a
     with ...
      *)
 File "t32.mli", line 18, characters 13-18:
-Error: This pattern has type int * int * int but is expected to have type (@192@,
-                                                                    @193@) 
+Error: This pattern has type int * int * int but is expected to have type (@40@,
+                                                                    @41@) 
 tuple2

--- a/test/positive/FM19.mli
+++ b/test/positive/FM19.mli
@@ -18,22 +18,22 @@ val push: 'a -> 'a t -> unit
 
 val pop: 'a t -> 'a
 (*@ v = pop q
-    requires q.view <> empty
+    requires q.view <> Seq.empty
     modifies q
-    ensures  old q.view = q.view ++ (Seq.cons v empty) *)
+    ensures  old q.view = q.view ++ (Seq.cons v Seq.empty) *)
 
 val is_empty: 'a t -> bool
 (*@ b = is_empty q
-    ensures b <-> q.view = empty *)
+    ensures b <-> q.view = Seq.empty *)
 
 val create: unit -> 'a t
 (*@ q = create ()
-    ensures q.view = empty *)
+    ensures q.view = Seq.empty *)
 
 val in_place_concat: 'a t -> 'a t -> unit
 (*@ in_place_concat q1 q2
     modifies q1, q2
-    ensures  q1.view = empty
+    ensures  q1.view = Seq.empty
     ensures  q2.view = old q1.view ++ old q2.view *)
 
 val in_place_destructive_concat: 'a t -> 'a t -> unit
@@ -47,8 +47,8 @@ val nondestructive_concat: 'a t -> 'a t -> 'a t
 
 val map: ('a -> 'b) -> 'a t -> 'b t
 (*@ r = map f q
-    ensures length r.view = length q.view
-    ensures forall i. 0 <= i < length q.view ->
+    ensures Seq.length r.view = Seq.length q.view
+    ensures forall i. 0 <= i < Seq.length q.view ->
                       r.view[i] = f q.view[i] *)
 
 (*@ function power (x y: integer): integer *)
@@ -67,20 +67,18 @@ val random_int: rand_state -> int -> int
 (*@ n = random_int s m
     requires m > 0  modifies s  ensures  0 <= n < m *)
 
-(*@ open Set *)
-(*@ open Map *)
-
 type elem
+
 (*@ type uf_instance *)
 (*@ mutable model dom: elem set
     mutable model rep: elem -> elem
     mutable model internal: unit
-    invariant forall x. mem x dom -> mem (rep x) dom
-    invariant forall x. mem x dom -> rep (rep x) = rep x *)
+    invariant forall x. Set.mem x dom -> Set.mem (rep x) dom
+    invariant forall x. Set.mem x dom -> rep (rep x) = rep x *)
 
 val equiv: elem -> elem -> bool
 (*@ b = equiv [uf: uf_instance] e1 e2
-    requires mem e1 uf.dom && mem e2 uf.dom
+    requires Set.mem e1 uf.dom && Set.mem e2 uf.dom
     modifies uf.internal
     ensures  b <-> uf.rep e1 = uf.rep e2 *)
 
@@ -91,8 +89,8 @@ val equiv: elem -> elem -> bool
 val make: unit -> elem
 (*@ e = make [uf: uf_instance] ()
     modifies uf
-    ensures  not (mem e (old uf.dom))
-    ensures  uf.dom = union (old uf.dom) {:e:}
+    ensures  not (Set.mem e (old uf.dom))
+    ensures  uf.dom = Set.union (old uf.dom) (Set.singleton e)
     ensures  uf.rep = (old uf.rep)[e <- e] *)
 
 type type1

--- a/test/positive/FM19.mli.expected
+++ b/test/positive/FM19.mli.expected
@@ -9,19 +9,19 @@ val push : 'a -> 'a t -> unit[@@gospel
     ensures  q.view = Seq.cons v (old q.view) |}]
 val pop : 'a t -> 'a[@@gospel
                       {| v = pop q
-    requires q.view <> empty
+    requires q.view <> Seq.empty
     modifies q
-    ensures  old q.view = q.view ++ (Seq.cons v empty) |}]
+    ensures  old q.view = q.view ++ (Seq.cons v Seq.empty) |}]
 val is_empty : 'a t -> bool[@@gospel
                              {| b = is_empty q
-    ensures b <-> q.view = empty |}]
+    ensures b <-> q.view = Seq.empty |}]
 val create : unit -> 'a t[@@gospel
                            {| q = create ()
-    ensures q.view = empty |}]
+    ensures q.view = Seq.empty |}]
 val in_place_concat : 'a t -> 'a t -> unit[@@gospel
                                             {| in_place_concat q1 q2
     modifies q1, q2
-    ensures  q1.view = empty
+    ensures  q1.view = Seq.empty
     ensures  q2.view = old q1.view ++ old q2.view |}]
 val in_place_destructive_concat : 'a t -> 'a t -> unit[@@gospel
                                                         {| in_place_destructive_concat q1 q2
@@ -32,8 +32,8 @@ val nondestructive_concat : 'a t -> 'a t -> 'a t[@@gospel
     ensures q3.view = q1.view ++ q2.view |}]
 val map : ('a -> 'b) -> 'a t -> 'b t[@@gospel
                                       {| r = map f q
-    ensures length r.view = length q.view
-    ensures forall i. 0 <= i < length q.view ->
+    ensures Seq.length r.view = Seq.length q.view
+    ensures forall i. 0 <= i < Seq.length q.view ->
                       r.view[i] = f q.view[i] |}]
 [@@@gospel {| function power (x y: integer): integer |}]
 val power_2_below : int -> int[@@gospel
@@ -45,19 +45,17 @@ val random_init : int -> rand_state
 val random_int : rand_state -> int -> int[@@gospel
                                            {| n = random_int s m
     requires m > 0  modifies s  ensures  0 <= n < m |}]
-[@@@gospel {| open Set |}]
-[@@@gospel {| open Map |}]
 type elem
 [@@@gospel
   {| type uf_instance |}[@@gospel
                           {| mutable model dom: elem set
     mutable model rep: elem -> elem
     mutable model internal: unit
-    invariant forall x. mem x dom -> mem (rep x) dom
-    invariant forall x. mem x dom -> rep (rep x) = rep x |}]]
+    invariant forall x. Set.mem x dom -> Set.mem (rep x) dom
+    invariant forall x. Set.mem x dom -> rep (rep x) = rep x |}]]
 val equiv : elem -> elem -> bool[@@gospel
                                   {| b = equiv [uf: uf_instance] e1 e2
-    requires mem e1 uf.dom && mem e2 uf.dom
+    requires Set.mem e1 uf.dom && Set.mem e2 uf.dom
     modifies uf.internal
     ensures  b <-> uf.rep e1 = uf.rep e2 |}]
 [@@@gospel
@@ -67,8 +65,8 @@ val equiv : elem -> elem -> bool[@@gospel
 val make : unit -> elem[@@gospel
                          {| e = make [uf: uf_instance] ()
     modifies uf
-    ensures  not (mem e (old uf.dom))
-    ensures  uf.dom = union (old uf.dom) {:e:}
+    ensures  not (Set.mem e (old uf.dom))
+    ensures  uf.dom = Set.union (old uf.dom) (Set.singleton e)
     ensures  uf.rep = (old uf.rep)[e <- e] |}]
 type type1
 type type2
@@ -162,10 +160,6 @@ val random_int : rand_state -> int -> int
     ensures ...
     modifies ...
      *)
-
-(*@ open Set *)
-
-(*@ open Map *)
 
 type elem
   
@@ -339,10 +333,6 @@ module FM19.mli
                 n_1:int):integer < (integer_of_int  m:int):integer):prop
         writes s:rand_state*)
     
-    (*@ open Set *)
-    
-    (*@ open Map *)
-    
     type elem
          
     
@@ -389,7 +379,7 @@ module FM19.mli
     (*@ e:elem = make [uf_2:uf_instance: uf_instance] ()
         ensures not (mem  e:elem old ((uf_2:uf_instance).dom)):prop
                 ensures ((uf_2:uf_instance).dom = (union 
-                        old ((uf_2:uf_instance).dom) (mixfix {:_:} 
+                        old ((uf_2:uf_instance).dom) (singleton 
                         e:elem):elem set):elem set):prop
                 ensures ((uf_2:uf_instance).rep = (mixfix [<-] 
                         old ((uf_2:uf_instance).rep) e:elem e:elem):elem ->

--- a/test/positive/a3.mli.expected
+++ b/test/positive/a3.mli.expected
@@ -43,16 +43,14 @@ module a3.mli
           Namespace: Gospelstdlib
             Type symbols
               ('a) array
+              ('a) bag
                int
               ('a) ref
               ('a) seq
+              ('a) set
               
             Logic Symbols
               function abs (_:integer) : integer
-              function array_length (_:'a array) : integer
-              function contents (_:'a array) : 'a seq
-              function elts (_:'a array) : 'a seq
-              function empty  : 'a seq
               function fst (_:'a * 'b) : 'a
               function infix * (_:integer) (_:integer) : integer
               function infix + (_:integer) (_:integer) : integer
@@ -65,7 +63,6 @@ module a3.mli
               predicate infix > (_:integer) (_:integer)
               predicate infix >= (_:integer) (_:integer)
               function integer_of_int (_:int) : integer
-              function length (_:'a seq) : integer
               function logand (_:integer) (_:integer) : integer
               function lognot (_:integer) : integer
               function logor (_:integer) (_:integer) : integer
@@ -75,16 +72,18 @@ module a3.mli
               function min (_:integer) (_:integer) : integer
               function min_int  : integer
               function mixfix [.._] (_:'a seq) (_:integer) : 'a seq
+              function mixfix [<-] (_:'a -> 'b) (_:'a) (_:'b) : 'a -> 'b
               function mixfix [_..] (_:'a seq) (_:integer) : 'a seq
               function mixfix [_.._] (_:'a seq) (_:integer) (_:integer) : 'a 
               seq
               function mixfix [_] (_:'a seq) (_:integer) : 'a
+              function mixfix {}  : 'a set
               function mod (_:integer) (_:integer) : integer
               function pow (_:integer) (_:integer) : integer
               function pred (_:integer) : integer
               function prefix ! (_:'a ref) : 'a
               function prefix - (_:integer) : integer
-              function seq_of_list (_:'a list) : 'a seq
+              function ref_1 (_:'a) : 'a ref
               function shift_left (_:integer) (_:integer) : integer
               function shift_right (_:integer) (_:integer) : integer
               function shift_right_trunc (_:integer) (_:integer) : integer
@@ -98,24 +97,39 @@ module a3.mli
             Namespaces
               Namespace: Array
                 Type symbols
+                  ('a) t_1 [='a array]
                   
                 Logic Symbols
-                  function length_1 (_:'a array) : integer
-                  function mixfix [_]_1 (_:'a array) (_:integer) : 'a
-                  
-                Exception Symbols
-                  
-                Namespaces
-                  
-                Type Namespaces
-                  
-              Namespace: ArrayPermut
-                Type symbols
-                  
-                Logic Symbols
-                  predicate permut_all (_:'a array) (_:'a array)
+                  predicate _exists (_:'a -> bool) (_:'a array)
+                  predicate _exists2 (_:'a -> 'b -> bool) (_:'a array)
+                                     (_:'b array)
+                  function append (_:'a array) (_:'a array) : 'a array
+                  function concat (_:'a array list) : 'a array
+                  function fold_left (_:'a -> 'b -> 'a) (_:'a) (_:'b array) : 'a
+                  function fold_right (_:'b -> 'a -> 'a) (_:'b array) (_:'a) : 'a
+                  predicate for_all (_:'a -> bool) (_:'a array)
+                  predicate for_all2 (_:'a -> 'b -> bool) (_:'a array)
+                                     (_:'b array)
+                  function get (_:'a array) (_:integer) : 'a
+                  function init (_:integer) (_:integer -> 'a) : 'a array
+                  function length (_:'a array) : integer
+                  function make (_:integer) (_:'a) : 'a array
+                  function map (_:'a -> 'b) (_:'a array) : 'b array
+                  function map2 (_:'a -> 'b -> 'c) (_:'a array) (_:'b array) : 'c 
+                  array
+                  function mapi (_:integer -> 'a -> 'b) (_:'a array) : 'b 
+                  array
+                  predicate mem (_:'a) (_:'a array)
+                  function of_list (_:'a list) : 'a array
+                  function of_seq (_:'a seq) : 'a array
+                  predicate permut (_:'a array) (_:'a array)
                   predicate permut_sub (_:'a array) (_:'a array) (_:integer)
                                        (_:integer)
+                  function sub (_:'a array) (_:integer) (_:integer) : 'a 
+                  array
+                  function to_bag (_:'a array) : 'a bag
+                  function to_list (_:'a array) : 'a list
+                  function to_seq (_:'a array) : 'a seq
                   
                 Exception Symbols
                   
@@ -125,18 +139,39 @@ module a3.mli
                   
               Namespace: Bag
                 Type symbols
-                  ('a) bag
+                  ('a) t_2 [='a bag]
                   
                 Logic Symbols
+                  predicate _exists_1 (_:'a -> bool) (_:'a bag)
                   function add (_:'a) (_:'a bag) : 'a bag
-                  function card (_:'a bag) : integer
-                  function choose (_:'a bag) : 'a
+                  function cardinal (_:'a bag) : int
+                  function choose (_:'a bag) : integer
+                  function choose_opt (_:'a bag) : 'a option
+                  function compare (_:'a bag) (_:'a bag) : int
                   function diff (_:'a bag) (_:'a bag) : 'a bag
-                  function empty_bag  : 'a bag
-                  predicate eq_bag (_:'a bag) (_:'a bag)
-                  predicate mem (_:'a) (_:'a bag)
-                  function nb_occ (_:'a) (_:'a bag) : integer
+                  predicate disjoint (_:'a bag) (_:'a bag)
+                  function elements (_:'a bag) : 'a list
+                  function empty  : 'a bag
+                  function filter (_:'a -> bool) (_:'a bag) : 'a bag
+                  function filter_map (_:'a -> 'a option) (_:'a bag) : 'a bag
+                  function fold (_:'a -> 'b -> 'b) (_:'a bag) : 'b
+                  predicate for_all_1 (_:'a -> bool) (_:'a bag)
+                  function inter (_:'a bag) (_:'a bag) : 'a bag
+                  predicate is_empty (_:'a bag)
+                  function map_1 (_:'a -> 'b) (_:'a bag) : 'b bag
+                  predicate mem_1 (_:'a) (_:'a bag)
+                  function occurrences (_:'a) (_:'a bag) : integer
+                  function of_array (_:'a array) : 'a bag
+                  function of_list_1 (_:'a list) : 'a bag
+                  function of_seq_1 (_:'a seq) : 'a bag
+                  function partition (_:'a -> bool) (_:'a bag) : 'a bag *
+                                                                 'a bag
+                  function remove (_:'a) (_:'a bag) : 'a bag
                   function singleton (_:'a) : 'a bag
+                  predicate subset (_:'a bag) (_:'a bag)
+                  function sum (_:'a bag) (_:'a bag) : 'a bag
+                  function to_list_1 (_:'a bag) : 'a list
+                  function to_seq_1 (_:'a bag) : 'a seq
                   function union (_:'a bag) (_:'a bag) : 'a bag
                   
                 Exception Symbols
@@ -147,11 +182,32 @@ module a3.mli
                   
               Namespace: List
                 Type symbols
+                  ('a) t_3 [='a list]
                   
                 Logic Symbols
-                  function length_2 (_:'a list) : integer
-                  function map (_:'a -> 'b) (_:'a list) : 'b list
+                  predicate _exists_2 (_:'a -> bool) (_:'a list)
+                  predicate _exists2_1 (_:'a -> 'b -> bool) (_:'a list)
+                                       (_:'b list)
+                  function fold_left_1 (_:'a -> 'b -> 'a) (_:'a) (_:'b list) : 'a
+                  function fold_right_1 (_:'b -> 'a -> 'a) (_:'b list) (_:'a) : 'a
+                  predicate for_all_2 (_:'a -> bool) (_:'a list)
+                  predicate for_all2_1 (_:'a -> 'b -> bool) (_:'a list)
+                                       (_:'b list)
+                  function hd (_:'a list) : 'a
+                  function init_1 (_:integer) (_:integer -> 'a) : 'a list
+                  function length_1 (_:'a list) : integer
+                  function map_2 (_:'a -> 'b) (_:'a list) : 'b list
+                  function map2_1 (_:'a -> 'b -> 'c) (_:'a list) (_:'b list) : 'c 
+                  list
+                  function mapi_1 (_:integer -> 'a -> 'b) (_:'a list) : 'b 
+                  list
+                  predicate mem_2 (_:'a) (_:'a list)
                   function nth (_:'a list) (_:integer) : 'a
+                  function nth_opt (_:'a list) (_:integer) : 'a option
+                  function of_seq_2 (_:'a seq) : 'a list
+                  function rev (_:'a list) : 'a list
+                  function tl (_:'a list) : 'a list
+                  function to_seq_2 (_:'a list) : 'a seq
                   
                 Exception Symbols
                   
@@ -163,8 +219,6 @@ module a3.mli
                 Type symbols
                   
                 Logic Symbols
-                  function mixfix [<-] (_:'a -> 'b) (_:'a) (_:'b) : 'a -> 'b
-                  function mixfix [_]_2 (_:'a -> 'b) (_:'a) : 'b
                   
                 Exception Symbols
                   
@@ -184,57 +238,33 @@ module a3.mli
                   
                 Type Namespaces
                   
-              Namespace: Peano
-                Type symbols
-                   t_1
-                  
-                Logic Symbols
-                  function int_of_peano (_:t_1) : integer
-                  function v (_:t_1) : integer
-                  
-                Exception Symbols
-                  
-                Namespaces
-                  
-                Type Namespaces
-                  
               Namespace: Seq
                 Type symbols
+                  ('a) t_4 [='a seq]
                   
                 Logic Symbols
+                  function append_1 (_:'a seq) (_:'a seq) : 'a seq
                   function cons (_:'a) (_:'a seq) : 'a seq
-                  function create (_:integer) (_:integer -> 'a) : 'a seq
-                  predicate distinct (_:'a seq)
-                  function fold_left (_:'a -> 'b -> 'a) (_:'a) (_:'b seq) : 'a
-                  function fold_right (_:'a -> 'b -> 'b) (_:'a seq) (_:'b) : 'b
-                  function get (_:'a seq) (_:integer) : 'a
-                  function hd (_:'a seq) : 'a
-                  function len (_:'a seq) : integer
-                  function map_1 (_:'a -> 'b) (_:'a seq) : 'b seq
-                  predicate mem_1 (_:'a seq) (_:'a)
+                  function empty_1  : 'a seq
+                  function filter_1 (_:'a -> bool) (_:'a seq) : 'a seq
+                  function filter_map_1 (_:'a -> 'b option) (_:'a seq) : 'b 
+                  seq
+                  function fold_left_2 (_:'a -> 'b -> 'a) (_:'a) (_:'b seq) : 'a
+                  function fold_right_2 (_:'a -> 'b -> 'b) (_:'a seq) (_:'b) : 'b
+                  function get_1 (_:'a seq) (_:integer) : 'a
+                  function hd_1 (_:'a seq) : 'a
+                  function init_2 (_:integer) (_:integer -> 'a) : 'a seq
+                  function length_2 (_:'a seq) : integer
+                  function map_3 (_:'a -> 'b) (_:'a seq) : 'b seq
+                  predicate mem_3 (_:'a seq) (_:'a)
                   function mixfix [<-]_1 (_:'a seq) (_:integer) (_:'a) : 'a 
                   seq
-                  function rev (_:'a seq) : 'a seq
+                  function return (_:'a) : 'a seq
+                  function rev_1 (_:'a seq) : 'a seq
+                  function set_1 (_:'a seq) (_:integer) (_:'a) : 'a seq
+                  function singleton_1 (_:'a) : 'a seq
                   function snoc (_:'a seq) (_:'a) : 'a seq
-                  predicate sorted (_:int seq)
-                  predicate sorted_sub (_:int seq) (_:integer) (_:integer)
-                  function tl (_:'a seq) : 'a seq
-                  
-                Exception Symbols
-                  
-                Namespaces
-                  
-                Type Namespaces
-                  
-              Namespace: SeqPerm
-                Type symbols
-                  
-                Logic Symbols
-                  function occ (_:'a seq) (_:'a) (_:integer) (_:integer) : 
-                  integer
-                  predicate permut (_:'a seq) (_:'a seq) (_:integer)
-                                   (_:integer)
-                  predicate permut_all_1 (_:'a seq) (_:'a seq)
+                  function tl_1 (_:'a seq) : 'a seq
                   
                 Exception Symbols
                   
@@ -244,13 +274,39 @@ module a3.mli
                   
               Namespace: Set
                 Type symbols
-                  ('a) set
+                  ('a) t_5 [='a set]
                   
                 Logic Symbols
-                  predicate mem_2 (_:'a) (_:'a set)
-                  function mixfix {:_:} (_:'a) : 'a set
-                  function mixfix {}  : 'a set
-                  function sum (_:'a -> integer) (_:'a set) : integer
+                  predicate _exists_3 (_:'a -> bool) (_:'a set)
+                  function add_1 (_:'a) (_:'a set) : 'a set
+                  function cardinal_1 (_:'a set) : integer
+                  function choose_1 (_:'a set) : integer
+                  function choose_opt_1  : 'a set -> 'a option
+                  function compare_1 (_:'a set) (_:'a set) : int
+                  function diff_1 (_:'a set) (_:'a set) : 'a set
+                  predicate disjoint_1 (_:'a set) (_:'a set)
+                  function elements_1 (_:'a set) : 'a list
+                  function empty_2  : 'a set
+                  function filter_2 (_:'a -> bool) (_:'a set) : 'a set
+                  function filter_map_2 (_:'a -> 'a option) (_:'a set) : 'a 
+                  set
+                  function fold_1 (_:'a -> 'b -> 'b) (_:'a set) (_:'b) : 'b
+                  predicate for_all_3 (_:'a -> bool) (_:'a set)
+                  function inter_1 (_:'a set) (_:'a set) : 'a set
+                  predicate is_empty_1 (_:'a set)
+                  function map_4 (_:'a -> 'b) (_:'a set) : 'b set
+                  predicate mem_4 (_:'a) (_:'a set)
+                  function of_list_2 (_:'a list) : 'a set
+                  function of_seq_3 (_:'a seq) : 'a set
+                  function partition_1 (_:'a -> bool) (_:'a set) : 'a 
+                                                                   set *
+                                                                   'a 
+                                                                   set
+                  function remove_1 (_:'a) (_:'a set) : 'a set
+                  function singleton_2 (_:'a) : 'a set
+                  predicate subset_1 (_:'a set) (_:'a set)
+                  function to_list_2 (_:'a set) : 'a list
+                  function to_seq_3 (_:'a set) : 'a seq
                   function union_1 (_:'a set) (_:'a set) : 'a set
                   
                 Exception Symbols

--- a/test/positive/basic_functions_axioms.mli.expected
+++ b/test/positive/basic_functions_axioms.mli.expected
@@ -372,8 +372,8 @@ module basic_functions_axioms.mli
         end::'a
     *)
     
-    (*@ axiom ax1: forall x_15:'a218 t2 y_4:'a218 . (y_4:'a218 = (f_6 
-    x_15:'a218 t2):'a218):prop *)
+    (*@ axiom ax1: forall x_15:'a66 t2 y_4:'a66 . (y_4:'a66 = (f_6 
+    x_15:'a66 t2):'a66):prop *)
     
     val f_7 : int -> int -> int
     (*@ r:int = f_7 x_16:int y_5:int

--- a/test/positive/dune.inc
+++ b/test/positive/dune.inc
@@ -215,6 +215,18 @@
  (action (diff %{dep:no_header.mli.expected} %{dep:no_header.mli.output})))
 
 (rule
+ (targets open_existing_type.mli.output)
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:open_existing_type.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:open_existing_type.mli.expected} %{dep:open_existing_type.mli.output})))
+
+(rule
  (targets pattern_matching.mli.output)
  (action
    (with-outputs-to %{targets}

--- a/test/positive/logical.mli.expected
+++ b/test/positive/logical.mli.expected
@@ -78,8 +78,8 @@ module logical.mli
         forall i:integer j:integer . (0:integer <= i:integer):prop /\ (
         i:integer <= j:integer):prop /\ (j:integer < (length 
         a:int array):integer):prop -> ((integer_of_int 
-        (mixfix [_]  a:int array i:integer):int):integer <= (integer_of_int 
-        (mixfix [_]  a:int array j:integer):int):integer):prop
+        (get  a:int array i:integer):int):integer <= (integer_of_int 
+        (get  a:int array j:integer):int):integer):prop
     *)
     
     val merge : int array -> int array -> int array

--- a/test/positive/open_existing_type.mli
+++ b/test/positive/open_existing_type.mli
@@ -1,0 +1,4 @@
+type 'a t = 'a list
+
+(*@ open Set *)
+

--- a/test/positive/open_existing_type.mli.expected
+++ b/test/positive/open_existing_type.mli.expected
@@ -1,0 +1,43 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t = 'a list
+[@@@gospel {| open Set |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t = 'a list
+  
+
+(*@ open Set *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module open_existing_type.mli
+
+  Namespace: open_existing_type.mli
+    Type symbols
+      ('a) t [='a list]
+      
+    Logic Symbols
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    type 'a t = 'a list
+         
+    
+    (*@ open Set *)
+
+OK

--- a/test/positive/test2.mli.expected
+++ b/test/positive/test2.mli.expected
@@ -25,5 +25,72 @@ type t
 
 type int
   
-File "test2.mli", line 13, characters 5-8:
-Error: Multiple definitions of type int
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module test2.mli
+
+  Namespace: test2.mli
+    Type symbols
+       int
+       t
+      
+    Logic Symbols
+      
+    Exception Symbols
+      
+    Namespaces
+      Namespace: B
+        Type symbols
+          ('a) t_1 [='a t_2]
+          
+        Logic Symbols
+          
+        Exception Symbols
+          
+        Namespaces
+          
+        Type Namespaces
+          
+      
+    Type Namespaces
+      Namespace: TA
+        Type symbols
+          ('a) t_2
+          ('b) t2
+          
+        Logic Symbols
+          function f (_:'a t_2) : float
+          
+        Exception Symbols
+          
+        Namespaces
+          
+        Type Namespaces
+          
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    module type TA  =
+      sig
+        type 'a t_2
+             
+        type 'b t2
+             
+        (*@ function f (x:'a t_2): float *)
+      end
+    
+    module B : functor (A : TA) -> sig
+                                     type 'a t_1 = 'a t_2
+                                          
+                                   end
+    
+    type t
+         
+    
+    type int
+         
+
+OK

--- a/test/vocal/Arrays.mli
+++ b/test/vocal/Arrays.mli
@@ -16,10 +16,10 @@ val binary_search: ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int
     where [v] occurs, or raises [Not_found] if no such index exists. *)
 (*@ r = binary_search cmp a fromi toi v
       requires Order.is_pre_order cmp
-      requires 0 <= fromi <= toi <= length a
-      requires forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
-      ensures  fromi <= r < toi && cmp a[r] v = 0
-      raises   Not_found -> forall i. fromi <= i < toi -> cmp a[i] v <> 0 *)
+      requires 0 <= fromi <= toi <= Array.length a
+      requires forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
+      ensures  fromi <= r < toi && cmp a.(r) v = 0
+      raises   Not_found -> forall i. fromi <= i < toi -> cmp a.(i) v <> 0 *)
 
 val binary_search_left: ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int
 (** search for value [v] in array [a], between indices [fromi] inclusive
@@ -28,11 +28,11 @@ val binary_search_left: ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int
     of [v]. Otherwise, returns an index where to insert [v]. *)
 (*@ r = binary_search_left cmp a fromi toi v
       requires Order.is_pre_order cmp
-      requires 0 <= fromi <= toi <= length a
-      requires forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
+      requires 0 <= fromi <= toi <= Array.length a
+      requires forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
       ensures  fromi <= r <= toi
-      ensures  forall i. fromi <= i < r   -> cmp a[i] v <  0
-      ensures  forall i. r     <= i < toi -> cmp a[i] v >= 0 *)
+      ensures  forall i. fromi <= i < r   -> cmp a.(i) v <  0
+      ensures  forall i. r     <= i < toi -> cmp a.(i) v >= 0 *)
 
 val binary_search_right:
   ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int
@@ -42,11 +42,11 @@ val binary_search_right:
     of [v]. Otherwise, returns an index where to insert [v]. *)
 (*@ r = binary_search_right cmp a fromi toi v
       requires Order.is_pre_order cmp
-      checks   0 <= fromi <= toi <= length a
-      requires forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
+      checks   0 <= fromi <= toi <= Array.length a
+      requires forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
       ensures  fromi <= r <= toi
-      ensures  forall i. fromi <= i < r   -> cmp a[i] v <= 0
-      ensures  forall i. r     <= i < toi -> cmp a[i] v >  0 *)
+      ensures  forall i. fromi <= i < r   -> cmp a.(i) v <= 0
+      ensures  forall i. r     <= i < toi -> cmp a.(i) v >  0 *)
 
 val binary_sort: ('a -> 'a -> int) -> 'a array -> int -> int -> unit
 (** sort array [a] betweens indices [fromi] inclusive and [toi] exclusive
@@ -55,21 +55,21 @@ val binary_sort: ('a -> 'a -> int) -> 'a array -> int -> int -> unit
     linearithmic. *)
 (*@ binary_sort cmp a fromi toi
       requires Order.is_pre_order cmp
-      requires 0 <= fromi <= toi <= length a
+      requires 0 <= fromi <= toi <= Array.length a
       modifies a
-      ensures  forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
-      ensures  ArrayPermut.permut_sub (old a) a fromi toi *)
+      ensures  forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
+      ensures  Array.permut_sub (old a) a fromi toi *)
 
 val swap: 'a array -> int -> int -> unit
 (*@ swap a i j
-      requires 0 <= i < length a && 0 <= j < length a
+      requires 0 <= i < Array.length a && 0 <= j < Array.length a
       modifies a
-      ensures  a[i] = (old a)[j]
-      ensures  a[j] = (old a)[i]
-      ensures  forall k. 0 <= k < length a ->
-               k <> i -> k <> j -> a[k] = (old a)[k] *)
+      ensures  a.(i) = old a.(j)
+      ensures  a.(j) = old a.(i)
+      ensures  forall k. 0 <= k < Array.length a ->
+               k <> i -> k <> j -> a.(k) = old a.(k) *)
 
 val knuth_shuffle: 'a array -> unit
 (*@ knuth_shuffle a
       modifies a
-      ensures  ArrayPermut.permut_all (old a) a *)
+      ensures  Array.permut (old a) a *)

--- a/test/vocal/Arrays.mli.expected
+++ b/test/vocal/Arrays.mli.expected
@@ -7,48 +7,48 @@ val binary_search : ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int
 [@@gospel
   {| r = binary_search cmp a fromi toi v
       requires Order.is_pre_order cmp
-      requires 0 <= fromi <= toi <= length a
-      requires forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
-      ensures  fromi <= r < toi && cmp a[r] v = 0
-      raises   Not_found -> forall i. fromi <= i < toi -> cmp a[i] v <> 0 |}]
+      requires 0 <= fromi <= toi <= Array.length a
+      requires forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
+      ensures  fromi <= r < toi && cmp a.(r) v = 0
+      raises   Not_found -> forall i. fromi <= i < toi -> cmp a.(i) v <> 0 |}]
 val binary_search_left :
   ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int[@@gospel
                                                             {| r = binary_search_left cmp a fromi toi v
       requires Order.is_pre_order cmp
-      requires 0 <= fromi <= toi <= length a
-      requires forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
+      requires 0 <= fromi <= toi <= Array.length a
+      requires forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
       ensures  fromi <= r <= toi
-      ensures  forall i. fromi <= i < r   -> cmp a[i] v <  0
-      ensures  forall i. r     <= i < toi -> cmp a[i] v >= 0 |}]
+      ensures  forall i. fromi <= i < r   -> cmp a.(i) v <  0
+      ensures  forall i. r     <= i < toi -> cmp a.(i) v >= 0 |}]
 val binary_search_right :
   ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int[@@gospel
                                                             {| r = binary_search_right cmp a fromi toi v
       requires Order.is_pre_order cmp
-      checks   0 <= fromi <= toi <= length a
-      requires forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
+      checks   0 <= fromi <= toi <= Array.length a
+      requires forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
       ensures  fromi <= r <= toi
-      ensures  forall i. fromi <= i < r   -> cmp a[i] v <= 0
-      ensures  forall i. r     <= i < toi -> cmp a[i] v >  0 |}]
+      ensures  forall i. fromi <= i < r   -> cmp a.(i) v <= 0
+      ensures  forall i. r     <= i < toi -> cmp a.(i) v >  0 |}]
 val binary_sort : ('a -> 'a -> int) -> 'a array -> int -> int -> unit
 [@@gospel
   {| binary_sort cmp a fromi toi
       requires Order.is_pre_order cmp
-      requires 0 <= fromi <= toi <= length a
+      requires 0 <= fromi <= toi <= Array.length a
       modifies a
-      ensures  forall i j. fromi <= i <= j < toi -> cmp a[i] a[j] <= 0
-      ensures  ArrayPermut.permut_sub (old a) a fromi toi |}]
+      ensures  forall i j. fromi <= i <= j < toi -> cmp a.(i) a.(j) <= 0
+      ensures  Array.permut_sub (old a) a fromi toi |}]
 val swap : 'a array -> int -> int -> unit[@@gospel
                                            {| swap a i j
-      requires 0 <= i < length a && 0 <= j < length a
+      requires 0 <= i < Array.length a && 0 <= j < Array.length a
       modifies a
-      ensures  a[i] = (old a)[j]
-      ensures  a[j] = (old a)[i]
-      ensures  forall k. 0 <= k < length a ->
-               k <> i -> k <> j -> a[k] = (old a)[k] |}]
+      ensures  a.(i) = old a.(j)
+      ensures  a.(j) = old a.(i)
+      ensures  forall k. 0 <= k < Array.length a ->
+               k <> i -> k <> j -> a.(k) = old a.(k) |}]
 val knuth_shuffle : 'a array -> unit[@@gospel
                                       {| knuth_shuffle a
       modifies a
-      ensures  ArrayPermut.permut_all (old a) a |}]
+      ensures  Array.permut (old a) a |}]
 
 *******************************
 ****** GOSPEL translation *****
@@ -142,36 +142,35 @@ module Arrays.mli
                           fromi:int):integer <= (integer_of_int 
                           toi:int):integer):prop /\ ((integer_of_int 
                           toi:int):integer <= (length 
-                          (elts  a_1:'a array):'a seq):integer):prop
+                          a_1:'a array):integer):prop
                  requires forall i:integer j:integer . ((integer_of_int 
                           fromi:int):integer <= i:integer):prop /\ (i:integer <= 
                           j:integer):prop /\ (j:integer < (integer_of_int 
                           toi:int):integer):prop -> ((integer_of_int 
                           (apply 
                           (apply 
-                          cmp:'a -> 'a -> int (mixfix [_] 
-                          (elts  a_1:'a array):'a seq i:integer):'a):
-                          'a -> int (mixfix [_] 
-                          (elts  a_1:'a array):'a seq j:integer):'a):
-                          int):integer <= 0:integer):prop
+                          cmp:'a -> 'a -> int (get 
+                          a_1:'a array i:integer):'a):'a -> int (get 
+                          a_1:'a array j:integer):'a):int):integer <= 0:
+                          integer):prop
         ensures ((integer_of_int  fromi:int):integer <= (integer_of_int 
                 r:int):integer):prop /\ ((integer_of_int 
                 r:int):integer < (integer_of_int 
                 toi:int):integer):prop && ((integer_of_int 
                 (apply 
                 (apply 
-                cmp:'a -> 'a -> int (mixfix [_] 
-                (elts  a_1:'a array):'a seq (integer_of_int  r:int):integer):'a):
-                'a -> int v:'a):int):integer = 0:integer):prop
+                cmp:'a -> 'a -> int (get 
+                a_1:'a array (integer_of_int  r:int):integer):'a):'a -> int
+                v:'a):int):integer = 0:integer):prop
         raisesNot_found  -> forall i_1:integer . ((integer_of_int 
                             fromi:int):integer <= i_1:integer):prop /\ (
                             i_1:integer < (integer_of_int 
                             toi:int):integer):prop -> not ((integer_of_int 
                             (apply 
                             (apply 
-                            cmp:'a -> 'a -> int (mixfix [_] 
-                            (elts  a_1:'a array):'a seq i_1:integer):'a):
-                            'a -> int v:'a):int):integer = 0:integer):prop*)
+                            cmp:'a -> 'a -> int (get 
+                            a_1:'a array i_1:integer):'a):'a -> int v:'a):
+                            int):integer = 0:integer):prop*)
     
     val binary_search_left :
     ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int
@@ -183,18 +182,17 @@ module Arrays.mli
                           fromi_1:int):integer <= (integer_of_int 
                           toi_1:int):integer):prop /\ ((integer_of_int 
                           toi_1:int):integer <= (length 
-                          (elts  a_2:'a array):'a seq):integer):prop
+                          a_2:'a array):integer):prop
                  requires forall i_2:integer j_1:integer . ((integer_of_int 
                           fromi_1:int):integer <= i_2:integer):prop /\ (
                           i_2:integer <= j_1:integer):prop /\ (j_1:integer < (integer_of_int 
                           toi_1:int):integer):prop -> ((integer_of_int 
                           (apply 
                           (apply 
-                          cmp_1:'a -> 'a -> int (mixfix [_] 
-                          (elts  a_2:'a array):'a seq i_2:integer):'a):
-                          'a -> int (mixfix [_] 
-                          (elts  a_2:'a array):'a seq j_1:integer):'a):
-                          int):integer <= 0:integer):prop
+                          cmp_1:'a -> 'a -> int (get 
+                          a_2:'a array i_2:integer):'a):'a -> int (get 
+                          a_2:'a array j_1:integer):'a):int):integer <= 0:
+                          integer):prop
         ensures ((integer_of_int  fromi_1:int):integer <= (integer_of_int 
                 r_1:int):integer):prop /\ ((integer_of_int 
                 r_1:int):integer <= (integer_of_int  toi_1:int):integer):prop
@@ -204,17 +202,17 @@ module Arrays.mli
                         r_1:int):integer):prop -> ((integer_of_int 
                         (apply 
                         (apply 
-                        cmp_1:'a -> 'a -> int (mixfix [_] 
-                        (elts  a_2:'a array):'a seq i_3:integer):'a):
-                        'a -> int v_1:'a):int):integer < 0:integer):prop
+                        cmp_1:'a -> 'a -> int (get 
+                        a_2:'a array i_3:integer):'a):'a -> int v_1:'a):
+                        int):integer < 0:integer):prop
                 ensures forall i_4:integer . ((integer_of_int 
                         r_1:int):integer <= i_4:integer):prop /\ (i_4:integer < (integer_of_int 
                         toi_1:int):integer):prop -> ((integer_of_int 
                         (apply 
                         (apply 
-                        cmp_1:'a -> 'a -> int (mixfix [_] 
-                        (elts  a_2:'a array):'a seq i_4:integer):'a):
-                        'a -> int v_1:'a):int):integer >= 0:integer):prop*)
+                        cmp_1:'a -> 'a -> int (get 
+                        a_2:'a array i_4:integer):'a):'a -> int v_1:'a):
+                        int):integer >= 0:integer):prop*)
     
     val binary_search_right :
     ('a -> 'a -> int) -> 'a array -> int -> int -> 'a -> int
@@ -227,17 +225,15 @@ module Arrays.mli
                           toi_2:int):integer):prop -> ((integer_of_int 
                           (apply 
                           (apply 
-                          cmp_2:'a -> 'a -> int (mixfix [_] 
-                          (elts  a_3:'a array):'a seq i_5:integer):'a):
-                          'a -> int (mixfix [_] 
-                          (elts  a_3:'a array):'a seq j_2:integer):'a):
-                          int):integer <= 0:integer):prop
+                          cmp_2:'a -> 'a -> int (get 
+                          a_3:'a array i_5:integer):'a):'a -> int (get 
+                          a_3:'a array j_2:integer):'a):int):integer <= 0:
+                          integer):prop
         checks (0:integer <= (integer_of_int 
                fromi_2:int):integer):prop /\ ((integer_of_int 
                fromi_2:int):integer <= (integer_of_int 
                toi_2:int):integer):prop /\ ((integer_of_int 
-               toi_2:int):integer <= (length 
-               (elts  a_3:'a array):'a seq):integer):prop
+               toi_2:int):integer <= (length  a_3:'a array):integer):prop
                checks forall i_6:integer j_3:integer . ((integer_of_int 
                       fromi_2:int):integer <= i_6:integer):prop /\ (i_6:
                                                                     integer <= 
@@ -245,11 +241,10 @@ module Arrays.mli
                       toi_2:int):integer):prop -> ((integer_of_int 
                       (apply 
                       (apply 
-                      cmp_2:'a -> 'a -> int (mixfix [_] 
-                      (elts  a_3:'a array):'a seq i_6:integer):'a):'a -> int
-                      (mixfix [_] 
-                      (elts  a_3:'a array):'a seq j_3:integer):'a):int):
-                      integer <= 0:integer):prop
+                      cmp_2:'a -> 'a -> int (get 
+                      a_3:'a array i_6:integer):'a):'a -> int (get 
+                      a_3:'a array j_3:integer):'a):int):integer <= 0:
+                      integer):prop
         ensures ((integer_of_int  fromi_2:int):integer <= (integer_of_int 
                 r_2:int):integer):prop /\ ((integer_of_int 
                 r_2:int):integer <= (integer_of_int  toi_2:int):integer):prop
@@ -259,17 +254,17 @@ module Arrays.mli
                         r_2:int):integer):prop -> ((integer_of_int 
                         (apply 
                         (apply 
-                        cmp_2:'a -> 'a -> int (mixfix [_] 
-                        (elts  a_3:'a array):'a seq i_7:integer):'a):
-                        'a -> int v_2:'a):int):integer <= 0:integer):prop
+                        cmp_2:'a -> 'a -> int (get 
+                        a_3:'a array i_7:integer):'a):'a -> int v_2:'a):
+                        int):integer <= 0:integer):prop
                 ensures forall i_8:integer . ((integer_of_int 
                         r_2:int):integer <= i_8:integer):prop /\ (i_8:integer < (integer_of_int 
                         toi_2:int):integer):prop -> ((integer_of_int 
                         (apply 
                         (apply 
-                        cmp_2:'a -> 'a -> int (mixfix [_] 
-                        (elts  a_3:'a array):'a seq i_8:integer):'a):
-                        'a -> int v_2:'a):int):integer > 0:integer):prop*)
+                        cmp_2:'a -> 'a -> int (get 
+                        a_3:'a array i_8:integer):'a):'a -> int v_2:'a):
+                        int):integer > 0:integer):prop*)
     
     val binary_sort : ('a -> 'a -> int) -> 'a array -> int -> int -> unit
     (*@  binary_sort cmp_3:'a -> 'a -> int a_4:'a array fromi_3:int toi_3:int
@@ -279,17 +274,16 @@ module Arrays.mli
                           fromi_3:int):integer <= (integer_of_int 
                           toi_3:int):integer):prop /\ ((integer_of_int 
                           toi_3:int):integer <= (length 
-                          (elts  a_4:'a array):'a seq):integer):prop
+                          a_4:'a array):integer):prop
         ensures forall i_9:integer j_4:integer . ((integer_of_int 
                 fromi_3:int):integer <= i_9:integer):prop /\ (i_9:integer <= 
                 j_4:integer):prop /\ (j_4:integer < (integer_of_int 
                 toi_3:int):integer):prop -> ((integer_of_int 
                 (apply 
                 (apply 
-                cmp_3:'a -> 'a -> int (mixfix [_] 
-                (elts  a_4:'a array):'a seq i_9:integer):'a):'a -> int
-                (mixfix [_]  (elts  a_4:'a array):'a seq j_4:integer):'a):
-                int):integer <= 0:integer):prop
+                cmp_3:'a -> 'a -> int (get  a_4:'a array i_9:integer):'a):
+                'a -> int (get  a_4:'a array j_4:integer):'a):int):integer <= 0:
+                integer):prop
                 ensures (permut_sub 
                         old (a_4:'a array) a_4:'a array (integer_of_int 
                         fromi_3:int):integer (integer_of_int 
@@ -301,33 +295,27 @@ module Arrays.mli
         requires (0:integer <= (integer_of_int 
                  i_10:int):integer):prop /\ ((integer_of_int 
                  i_10:int):integer < (length 
-                 (elts  a_5:'a array):'a seq):integer):prop && (0:integer <= (integer_of_int 
+                 a_5:'a array):integer):prop && (0:integer <= (integer_of_int 
                  j_5:int):integer):prop /\ ((integer_of_int 
-                 j_5:int):integer < (length 
-                 (elts  a_5:'a array):'a seq):integer):prop
-        ensures ((mixfix [_] 
-                (elts  a_5:'a array):'a seq (integer_of_int 
-                i_10:int):integer):'a = (mixfix [_] 
-                (elts  old (a_5:'a array)):'a seq (integer_of_int 
-                j_5:int):integer):'a):prop
-                ensures ((mixfix [_] 
-                        (elts  a_5:'a array):'a seq (integer_of_int 
-                        j_5:int):integer):'a = (mixfix [_] 
-                        (elts  old (a_5:'a array)):'a seq (integer_of_int 
-                        i_10:int):integer):'a):prop
+                 j_5:int):integer < (length  a_5:'a array):integer):prop
+        ensures ((get 
+                a_5:'a array (integer_of_int  i_10:int):integer):'a = old ((get 
+                a_5:'a array (integer_of_int  j_5:int):integer):'a)):prop
+                ensures ((get 
+                        a_5:'a array (integer_of_int  j_5:int):integer):'a = old ((get 
+                        a_5:'a array (integer_of_int  i_10:int):integer):'a)):prop
                 ensures forall k:integer . (0:integer <= k:integer):prop /\ (
                         k:integer < (length 
-                        (elts  a_5:'a array):'a seq):integer):prop -> not (
-                        k:integer = (integer_of_int 
+                        a_5:'a array):integer):prop -> not (k:integer = (integer_of_int 
                         i_10:int):integer):prop -> not (k:integer = (integer_of_int 
-                        j_5:int):integer):prop -> ((mixfix [_] 
-                        (elts  a_5:'a array):'a seq k:integer):'a = (mixfix [_] 
-                        (elts  old (a_5:'a array)):'a seq k:integer):'a):prop
+                        j_5:int):integer):prop -> ((get 
+                        a_5:'a array k:integer):'a = old ((get 
+                        a_5:'a array k:integer):'a)):prop
         writes a_5:'a array*)
     
     val knuth_shuffle : 'a array -> unit
     (*@  knuth_shuffle a_6:'a array
-        ensures (permut_all  old (a_6:'a array) a_6:'a array):prop
+        ensures (permut  old (a_6:'a array) a_6:'a array):prop
         writes a_6:'a array*)
 
 OK

--- a/test/vocal/CountingSort.mli
+++ b/test/vocal/CountingSort.mli
@@ -8,25 +8,25 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ predicate k_values (k: int) (a: int seq) =
-      forall i: integer. 0 <= i < length a -> 0 <= a[i] < k *)
+(*@ predicate k_values (k: int) (a: int array) =
+      forall i. 0 <= i < Array.length a -> 0 <= a.(i) < k *)
 
-(*@ open Seq     *)
-(*@ open SeqPerm *)
+(*@ predicate sorted (a: int array) =
+      forall i j. 0 <= i <= j < Array.length a -> a.(i) <= a.(j) *)
 
 val counting_sort: int -> int array -> int array -> unit
 (*@ counting_sort k a b
       requires 0 < k
       requires k_values k a
-      requires length a = length b
+      requires Array.length a = Array.length b
       modifies b
-      ensures  Seq.sorted b
-      ensures  SeqPerm.permut_all a b *)
+      ensures  sorted b
+      ensures  Array.permut a b *)
 
 val in_place_counting_sort: int -> int array -> unit
 (*@ in_place_counting_sort k a
       requires 0 < k
       requires k_values k a
       modifies a
-      ensures  Seq.sorted a
-      ensures  SeqPerm.permut_all (old a) a *)
+      ensures  sorted a
+      ensures  Array.permut (old a) a *)

--- a/test/vocal/CountingSort.mli.expected
+++ b/test/vocal/CountingSort.mli.expected
@@ -3,25 +3,26 @@
 ********** Parsed file ********
 *******************************
 [@@@gospel
-  {| predicate k_values (k: int) (a: int seq) =
-      forall i: integer. 0 <= i < length a -> 0 <= a[i] < k |}]
-[@@@gospel {| open Seq     |}]
-[@@@gospel {| open SeqPerm |}]
+  {| predicate k_values (k: int) (a: int array) =
+      forall i. 0 <= i < Array.length a -> 0 <= a.(i) < k |}]
+[@@@gospel
+  {| predicate sorted (a: int array) =
+      forall i j. 0 <= i <= j < Array.length a -> a.(i) <= a.(j) |}]
 val counting_sort : int -> int array -> int array -> unit[@@gospel
                                                            {| counting_sort k a b
       requires 0 < k
       requires k_values k a
-      requires length a = length b
+      requires Array.length a = Array.length b
       modifies b
-      ensures  Seq.sorted b
-      ensures  SeqPerm.permut_all a b |}]
+      ensures  sorted b
+      ensures  Array.permut a b |}]
 val in_place_counting_sort : int -> int array -> unit[@@gospel
                                                        {| in_place_counting_sort k a
       requires 0 < k
       requires k_values k a
       modifies a
-      ensures  Seq.sorted a
-      ensures  SeqPerm.permut_all (old a) a |}]
+      ensures  sorted a
+      ensures  Array.permut (old a) a |}]
 
 *******************************
 ****** GOSPEL translation *****
@@ -30,9 +31,7 @@ val in_place_counting_sort : int -> int array -> unit[@@gospel
 
 (*@ predicate k_values ... *)
 
-(*@ open Seq *)
-
-(*@ open SeqPerm *)
+(*@ predicate sorted ... *)
 
 val counting_sort : int -> int array -> int array -> unit
 (*@  counting_sort k a b
@@ -62,7 +61,8 @@ module CountingSort.mli
     Type symbols
       
     Logic Symbols
-      predicate k_values (_:int) (_:int seq)
+      predicate k_values (_:int) (_:int array)
+      predicate sorted (_:int array)
       
     Exception Symbols
       
@@ -73,41 +73,38 @@ module CountingSort.mli
   Signatures
     (*@ open Gospelstdlib *)
     
-    (*@ predicate k_values (k:int) (a:int seq) =
+    (*@ predicate k_values (k:int) (a:int array) =
         forall i:integer . (0:integer <= i:integer):prop /\ (i:integer < (length 
-        a:int seq):integer):prop -> (0:integer <= (integer_of_int 
-        (mixfix [_]  a:int seq i:integer):int):integer):prop /\ ((integer_of_int 
-        (mixfix [_]  a:int seq i:integer):int):integer < (integer_of_int 
+        a:int array):integer):prop -> (0:integer <= (integer_of_int 
+        (get  a:int array i:integer):int):integer):prop /\ ((integer_of_int 
+        (get  a:int array i:integer):int):integer < (integer_of_int 
         k:int):integer):prop
     *)
     
-    (*@ open Seq *)
-    
-    (*@ open SeqPerm *)
+    (*@ predicate sorted (a_1:int array) =
+        forall i_1:integer j:integer . (0:integer <= i_1:integer):prop /\ (
+        i_1:integer <= j:integer):prop /\ (j:integer < (length 
+        a_1:int array):integer):prop -> ((integer_of_int 
+        (get  a_1:int array i_1:integer):int):integer <= (integer_of_int 
+        (get  a_1:int array j:integer):int):integer):prop
+    *)
     
     val counting_sort : int -> int array -> int array -> unit
-    (*@  counting_sort k_1:int a_1:int array b:int array
+    (*@  counting_sort k_1:int a_2:int array b:int array
         requires (0:integer < (integer_of_int  k_1:int):integer):prop
-                 requires (k_values 
-                          k_1:int (elts  a_1:int array):int seq):prop
-                 requires ((length 
-                          (elts  a_1:int array):int seq):integer = (length 
-                          (elts  b:int array):int seq):integer):prop
-        ensures (sorted  (elts  b:int array):int seq):prop
-                ensures (permut_all 
-                        (elts  a_1:int array):int seq (elts 
-                        b:int array):int seq):prop
+                 requires (k_values  k_1:int a_2:int array):prop
+                 requires ((length  a_2:int array):integer = (length 
+                          b:int array):integer):prop
+        ensures (sorted  b:int array):prop
+                ensures (permut  a_2:int array b:int array):prop
         writes b:int array*)
     
     val in_place_counting_sort : int -> int array -> unit
-    (*@  in_place_counting_sort k_2:int a_2:int array
+    (*@  in_place_counting_sort k_2:int a_3:int array
         requires (0:integer < (integer_of_int  k_2:int):integer):prop
-                 requires (k_values 
-                          k_2:int (elts  a_2:int array):int seq):prop
-        ensures (sorted  (elts  a_2:int array):int seq):prop
-                ensures (permut_all 
-                        (elts  old (a_2:int array)):int seq (elts 
-                        a_2:int array):int seq):prop
-        writes a_2:int array*)
+                 requires (k_values  k_2:int a_3:int array):prop
+        ensures (sorted  a_3:int array):prop
+                ensures (permut  old (a_3:int array) a_3:int array):prop
+        writes a_3:int array*)
 
 OK

--- a/test/vocal/HashTable.mli
+++ b/test/vocal/HashTable.mli
@@ -26,8 +26,6 @@ end
 
 module Make (K : HashedType) : sig
 
-  (*@ open Set *)
-
   type key = K.t
 
   type 'a table
@@ -59,7 +57,7 @@ module Make (K : HashedType) : sig
     ensures  forall k: key. view h2 k = view h1 k *)
 
   (*@ function pop (h: 'a t) : integer =
-    sum (fun k -> length (view h k)) (dom h) *)
+    Set.fold (fun k c -> List.length (view h k) + c) (dom h) 0 *)
 
   val population: 'a t -> int
   (*@ n = population h

--- a/test/vocal/HashTable.mli.expected
+++ b/test/vocal/HashTable.mli.expected
@@ -22,7 +22,6 @@ module type HashedType  =
 module Make :
 functor (K : HashedType) ->
   sig
-    [@@@gospel {| open Set |}]
     type key = K.t
     type 'a table[@@gospel
                    {| ephemeral
@@ -48,7 +47,7 @@ functor (K : HashedType) ->
     ensures  forall k: key. view h2 k = view h1 k |}]
     [@@@gospel
       {| function pop (h: 'a t) : integer =
-    sum (fun k -> length (view h k)) (dom h) |}]
+    Set.fold (fun k c -> List.length (view h k) + c) (dom h) 0 |}]
     val population : 'a t -> int[@@gospel
                                   {| n = population h
     ensures n = pop h |}]
@@ -118,7 +117,7 @@ module type HashedType  =
 
 module Make : functor (K : HashedType) ->
 sig
-  (*@ open Set *)type key = K.t
+  type key = K.t
     type 'a table
     (*@ ephemeral
         model ...
@@ -282,7 +281,6 @@ module HashTable.mli
     module Make :
     functor (K : HashedType) ->
       sig
-        (*@ open Set *)
         type key = t
              
         type 'a table
@@ -295,7 +293,7 @@ module HashTable.mli
                            x_8:t y_5:t):prop -> (x_8:t = y_5:t):propinvariant
                            forall k:t . not (mem 
                            k:t (dom_1 ):t set):prop -> ((apply 
-                           (view_1 ):t -> 'a196 list k:t):'a196 list = ([] ):'a196 
+                           (view_1 ):t -> 'a44 list k:t):'a44 list = ([] ):'a44 
                            list):prop *)
         type 'a t_1 = 'a table
              
@@ -320,10 +318,10 @@ module HashTable.mli
                     (h2:'a table).view k_4:t):'a list = (apply 
                     (h1:'a table).view k_4:t):'a list):prop*)
         (*@ function pop (h_4:'a table): integer =
-            (sum 
-            fun k_5:t . (length 
-            (seq_of_list  (apply  (h_4:'a table).view k_5:t):'a list):'a seq):
-            integer (h_4:'a table).dom):integer
+            (fold 
+            fun k_5:t c:integer . ((length 
+            (apply  (h_4:'a table).view k_5:t):'a list):integer + c:integer):
+            integer (h_4:'a table).dom 0:integer):integer
         *)
         val population : 'a t -> int
         (*@ n_1:int = population h_5:'a table
@@ -335,7 +333,7 @@ module HashTable.mli
                     h_6:'a table):integer):prop*)
         val iter : (key -> 'a -> unit) -> 'a t -> unit
         
-        val fold : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+        val fold_1 : (key -> 'a -> 'b -> 'b) -> 'a t -> 'b -> 'b
         
         type statistics = {num_bindings:int; num_buckets:int;
                            max_bucket_length:int; bucket_histogram:int 

--- a/test/vocal/Lists.mli
+++ b/test/vocal/Lists.mli
@@ -21,6 +21,7 @@
 
 val map: ('a -> 'b) -> 'a list -> 'b list
 (*@ r = map f l
-      ensures length r = length l
-      ensures forall i. 0 <= i < length l -> r[i] = f l[i]
+      ensures List.length r = List.length l
+      ensures forall i. 0 <= i < List.length l ->
+                List.nth r i = f (List.nth l i)
       equivalent "List.rev (List.map f (List.rev l))" *)

--- a/test/vocal/Lists.mli.expected
+++ b/test/vocal/Lists.mli.expected
@@ -6,8 +6,9 @@
   " Stack-safe and fast implementation of [List.map]\n\n    following antron's post\n    https://discuss.ocaml.org/t/a-new-list-map-that-is-both-stack-safe-and-fast/865\n\n    Important note: the function is applied to the elements starting from the\n    end of the list, thus not in the same order as with [List.map]. So if your\n    functions has side-effects, this is not equivalent to [List.map] but\n    rather to a combination of [List.rev] and [List.map] as stated below.\n "]
 val map : ('a -> 'b) -> 'a list -> 'b list[@@gospel
                                             {| r = map f l
-      ensures length r = length l
-      ensures forall i. 0 <= i < length l -> r[i] = f l[i]
+      ensures List.length r = List.length l
+      ensures forall i. 0 <= i < List.length l ->
+                List.nth r i = f (List.nth l i)
       equivalent "List.rev (List.map f (List.rev l))" |}]
 
 *******************************
@@ -49,14 +50,13 @@ module Lists.mli
     
     val map : ('a -> 'b) -> 'a list -> 'b list
     (*@ r:'b list = map f:'a -> 'b l:'a list
-        ensures ((length  (seq_of_list  r:'b list):'b seq):integer = (length 
-                (seq_of_list  l:'a list):'a seq):integer):prop
+        ensures ((length  r:'b list):integer = (length 
+                l:'a list):integer):prop
                 ensures forall i:integer . (0:integer <= i:integer):prop /\ (
                         i:integer < (length 
-                        (seq_of_list  l:'a list):'a seq):integer):prop -> ((mixfix [_] 
-                        (seq_of_list  r:'b list):'b seq i:integer):'b = (apply 
-                        f:'a -> 'b (mixfix [_] 
-                        (seq_of_list  l:'a list):'a seq i:integer):'a):'b):prop
+                        l:'a list):integer):prop -> ((nth 
+                        r:'b list i:integer):'b = (apply 
+                        f:'a -> 'b (nth  l:'a list i:integer):'a):'b):prop
         equivalent "List.rev (List.map f (List.rev l))"*)
 
 OK

--- a/test/vocal/Mjrty.mli
+++ b/test/vocal/Mjrty.mli
@@ -15,14 +15,14 @@
 (*@ axiom num_base:
       forall a v lo hi. hi <= lo -> num a v lo hi = 0 *)
 (*@ axiom num_ind:
-      forall a v lo hi. 0 <= lo < hi <= length a ->
+      forall a v lo hi. 0 <= lo < hi <= Seq.length a ->
       num a v lo hi = (if a[lo] = v then 1 else 0) + num a v (lo+1) hi *)
 
 val mjrty: string array -> string
 (** [mjrty a] returns the element of [a] with absolute majority, if any,
     or raises [Not_found] otherwise *)
 (*@ r = mjrty a
-      requires 1 <= length a
-      ensures  2 * num a r 0 (length a) > length a
-      raises   Not_found -> forall c. 2 * num a c 0 (length a) <= length a
-*)
+      requires 1 <= Array.length a
+      ensures  2 * num a r 0 (Array.length a) > Array.length a
+      raises   Not_found ->
+               forall c. 2 * num a c 0 (Array.length a) <= Array.length a *)

--- a/test/vocal/Mjrty.mli.expected
+++ b/test/vocal/Mjrty.mli.expected
@@ -9,14 +9,14 @@
       forall a v lo hi. hi <= lo -> num a v lo hi = 0 |}]
 [@@@gospel
   {| axiom num_ind:
-      forall a v lo hi. 0 <= lo < hi <= length a ->
+      forall a v lo hi. 0 <= lo < hi <= Seq.length a ->
       num a v lo hi = (if a[lo] = v then 1 else 0) + num a v (lo+1) hi |}]
 val mjrty : string array -> string[@@gospel
                                     {| r = mjrty a
-      requires 1 <= length a
-      ensures  2 * num a r 0 (length a) > length a
-      raises   Not_found -> forall c. 2 * num a c 0 (length a) <= length a
-|}]
+      requires 1 <= Array.length a
+      ensures  2 * num a r 0 (Array.length a) > Array.length a
+      raises   Not_found ->
+               forall c. 2 * num a c 0 (Array.length a) <= Array.length a |}]
 
 *******************************
 ****** GOSPEL translation *****
@@ -78,18 +78,15 @@ module Mjrty.mli
     
     val mjrty : string array -> string
     (*@ r:string = mjrty a_3:string array
-        requires (1:integer <= (length 
-                 (elts  a_3:string array):string seq):integer):prop
+        requires (1:integer <= (length_1  a_3:string array):integer):prop
         ensures ((2:integer * (num 
-                (elts  a_3:string array):string seq r:string 0:integer
-                (length  (elts  a_3:string array):string seq):integer):
-                integer):integer > (length 
-                (elts  a_3:string array):string seq):integer):prop
+                (to_seq  a_3:string array):string seq r:string 0:integer
+                (length_1  a_3:string array):integer):integer):integer > (length_1 
+                a_3:string array):integer):prop
         raisesNot_found  -> forall c:string . ((2:integer * (num 
-                            (elts  a_3:string array):string seq c:string
-                            0:integer (length 
-                            (elts  a_3:string array):string seq):integer):
-                            integer):integer <= (length 
-                            (elts  a_3:string array):string seq):integer):prop*)
+                            (to_seq  a_3:string array):string seq c:string
+                            0:integer (length_1  a_3:string array):integer):
+                            integer):integer <= (length_1 
+                            a_3:string array):integer):prop*)
 
 OK

--- a/test/vocal/PairingHeap.mli
+++ b/test/vocal/PairingHeap.mli
@@ -8,8 +8,6 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ open Bag   *)
-
 module Make (X: sig (* FIXME: use ComparableType.S instead *)
   type t
 
@@ -29,40 +27,40 @@ end) : sig
 
   val empty : unit -> t
   (*@ h = empty ()
-        ensures card h.bag = 0
-        ensures forall x. nb_occ x h.bag = 0 *)
+        ensures Bag.cardinal h.bag = 0
+        ensures forall x. Bag.occurrences x h.bag = 0 *)
 
   val is_empty : t -> bool
   (*@ b = is_empty h
-        ensures b <-> h.bag = empty_bag *)
+        ensures b <-> Bag.is_empty h.bag *)
 
   val merge : t -> t -> t
   (*@ h = merge h1 h2
-        ensures card h.bag = card h1.bag + card h2.bag
-        ensures forall x. nb_occ x h.bag = nb_occ x h1.bag + nb_occ x h2.bag *)
+        ensures Bag.cardinal h.bag = Bag.cardinal h1.bag + Bag.cardinal h2.bag
+        ensures forall x. Bag.occurrences x h.bag = Bag.occurrences x h1.bag + Bag.occurrences x h2.bag *)
 
   val insert : elt -> t -> t
   (*@ h' = insert x h
-        ensures nb_occ x h'.bag = nb_occ x h.bag + 1
-        ensures forall y. y <> x -> nb_occ y h'.bag = nb_occ y h.bag
-        ensures card h'.bag = card h.bag + 1 *)
+        ensures Bag.occurrences x h'.bag = Bag.occurrences x h.bag + 1
+        ensures forall y. y <> x -> Bag.occurrences y h'.bag = Bag.occurrences y h.bag
+        ensures Bag.cardinal h'.bag = Bag.cardinal h.bag + 1 *)
 
-  (*@ predicate mem        (x: elt) (h: t) = nb_occ x h.bag > 0 *)
+  (*@ predicate mem        (x: elt) (h: t) = Bag.occurrences x h.bag > 0 *)
   (*@ predicate is_minimum (x: elt) (h: t) =
         mem x h /\ forall e. mem e h -> X.cmp x e <= 0 *)
 
   (*@ function minimum (h: t) : elt *)
-  (*@ axiom min_def: forall h. 0 < card h.bag -> is_minimum (minimum h) h *)
+  (*@ axiom min_def: forall h. 0 < Bag.cardinal h.bag -> is_minimum (minimum h) h *)
 
   val find_min : t -> elt
   (*@ x = find_min h
-        requires card h.bag > 0
+        requires Bag.cardinal h.bag > 0
         ensures  x = minimum h *)
 
   val delete_min : t -> t
   (*@ h' = delete_min h
-        requires card h.bag > 0
-        ensures  let x = minimum h in nb_occ x h'.bag = nb_occ x h.bag - 1
-        ensures  forall y. y <> minimum h -> nb_occ y h'.bag = nb_occ y h.bag
-        ensures  card h'.bag = card h.bag - 1 *)
+        requires Bag.cardinal h.bag > 0
+        ensures  let x = minimum h in Bag.occurrences x h'.bag = Bag.occurrences x h.bag - 1
+        ensures  forall y. y <> minimum h -> Bag.occurrences y h'.bag = Bag.occurrences y h.bag
+        ensures  Bag.cardinal h'.bag = Bag.cardinal h.bag - 1 *)
 end

--- a/test/vocal/PairingHeap.mli.expected
+++ b/test/vocal/PairingHeap.mli.expected
@@ -2,7 +2,6 @@
 *******************************
 ********** Parsed file ********
 *******************************
-[@@@gospel {| open Bag   |}]
 module Make :
 functor (X :
   sig
@@ -18,46 +17,44 @@ functor (X :
     type t[@@gospel {| model bag : elt bag |}]
     val empty : unit -> t[@@gospel
                            {| h = empty ()
-        ensures card h.bag = 0
-        ensures forall x. nb_occ x h.bag = 0 |}]
+        ensures Bag.cardinal h.bag = 0
+        ensures forall x. Bag.occurrences x h.bag = 0 |}]
     val is_empty : t -> bool[@@gospel
                               {| b = is_empty h
-        ensures b <-> h.bag = empty_bag |}]
+        ensures b <-> Bag.is_empty h.bag |}]
     val merge : t -> t -> t[@@gospel
                              {| h = merge h1 h2
-        ensures card h.bag = card h1.bag + card h2.bag
-        ensures forall x. nb_occ x h.bag = nb_occ x h1.bag + nb_occ x h2.bag |}]
+        ensures Bag.cardinal h.bag = Bag.cardinal h1.bag + Bag.cardinal h2.bag
+        ensures forall x. Bag.occurrences x h.bag = Bag.occurrences x h1.bag + Bag.occurrences x h2.bag |}]
     val insert : elt -> t -> t[@@gospel
                                 {| h' = insert x h
-        ensures nb_occ x h'.bag = nb_occ x h.bag + 1
-        ensures forall y. y <> x -> nb_occ y h'.bag = nb_occ y h.bag
-        ensures card h'.bag = card h.bag + 1 |}]
+        ensures Bag.occurrences x h'.bag = Bag.occurrences x h.bag + 1
+        ensures forall y. y <> x -> Bag.occurrences y h'.bag = Bag.occurrences y h.bag
+        ensures Bag.cardinal h'.bag = Bag.cardinal h.bag + 1 |}]
     [@@@gospel
-      {| predicate mem        (x: elt) (h: t) = nb_occ x h.bag > 0 |}]
+      {| predicate mem        (x: elt) (h: t) = Bag.occurrences x h.bag > 0 |}]
     [@@@gospel
       {| predicate is_minimum (x: elt) (h: t) =
         mem x h /\ forall e. mem e h -> X.cmp x e <= 0 |}]
     [@@@gospel {| function minimum (h: t) : elt |}]
     [@@@gospel
-      {| axiom min_def: forall h. 0 < card h.bag -> is_minimum (minimum h) h |}]
+      {| axiom min_def: forall h. 0 < Bag.cardinal h.bag -> is_minimum (minimum h) h |}]
     val find_min : t -> elt[@@gospel
                              {| x = find_min h
-        requires card h.bag > 0
+        requires Bag.cardinal h.bag > 0
         ensures  x = minimum h |}]
     val delete_min : t -> t[@@gospel
                              {| h' = delete_min h
-        requires card h.bag > 0
-        ensures  let x = minimum h in nb_occ x h'.bag = nb_occ x h.bag - 1
-        ensures  forall y. y <> minimum h -> nb_occ y h'.bag = nb_occ y h.bag
-        ensures  card h'.bag = card h.bag - 1 |}]
+        requires Bag.cardinal h.bag > 0
+        ensures  let x = minimum h in Bag.occurrences x h'.bag = Bag.occurrences x h.bag - 1
+        ensures  forall y. y <> minimum h -> Bag.occurrences y h'.bag = Bag.occurrences y h.bag
+        ensures  Bag.cardinal h'.bag = Bag.cardinal h.bag - 1 |}]
   end
 
 *******************************
 ****** GOSPEL translation *****
 *******************************
 (*@ open Gospelstdlib *)
-
-(*@ open Bag *)
 
 module Make : functor (X :
 sig
@@ -145,8 +142,6 @@ module PairingHeap.mli
   Signatures
     (*@ open Gospelstdlib *)
     
-    (*@ open Bag *)
-    
     module Make :
     functor (X :
       sig
@@ -168,33 +163,38 @@ module PairingHeap.mli
                  model bag : t bag_1 *)
         val empty : unit -> t
         (*@ h:t_1 = empty ()
-            ensures ((card  (h:t_1).bag):integer = 0:integer):prop
-                    ensures forall x_1:t . ((nb_occ 
+            ensures ((integer_of_int 
+                    (cardinal  (h:t_1).bag):int):integer = 0:integer):prop
+                    ensures forall x_1:t . ((occurrences 
                             x_1:t (h:t_1).bag):integer = 0:integer):prop*)
         val is_empty : t -> bool
         (*@ b:bool = is_empty h_1:t_1
-            ensures (b:bool = (True ):bool):prop <-> ((h_1:t_1).bag = (empty_bag ):
-                    t bag_1):prop*)
+            ensures (b:bool = (True ):bool):prop <-> (is_empty_1 
+                    (h_1:t_1).bag):prop*)
         val merge : t -> t -> t
         (*@ h_2:t_1 = merge h1:t_1 h2:t_1
-            ensures ((card  (h_2:t_1).bag):integer = ((card 
-                    (h1:t_1).bag):integer + (card 
-                    (h2:t_1).bag):integer):integer):prop
-                    ensures forall x_2:t . ((nb_occ 
-                            x_2:t (h_2:t_1).bag):integer = ((nb_occ 
-                            x_2:t (h1:t_1).bag):integer + (nb_occ 
+            ensures ((integer_of_int 
+                    (cardinal  (h_2:t_1).bag):int):integer = ((integer_of_int 
+                    (cardinal  (h1:t_1).bag):int):integer + (integer_of_int 
+                    (cardinal  (h2:t_1).bag):int):integer):integer):prop
+                    ensures forall x_2:t . ((occurrences 
+                            x_2:t (h_2:t_1).bag):integer = ((occurrences 
+                            x_2:t (h1:t_1).bag):integer + (occurrences 
                             x_2:t (h2:t_1).bag):integer):integer):prop*)
         val insert : elt -> t -> t
         (*@ h':t_1 = insert x_3:t h_3:t_1
-            ensures ((nb_occ  x_3:t (h':t_1).bag):integer = ((nb_occ 
+            ensures ((occurrences 
+                    x_3:t (h':t_1).bag):integer = ((occurrences 
                     x_3:t (h_3:t_1).bag):integer + 1:integer):integer):prop
-                    ensures forall y_1:t . not (y_1:t = x_3:t):prop -> ((nb_occ 
-                            y_1:t (h':t_1).bag):integer = (nb_occ 
+                    ensures forall y_1:t . not (y_1:t = x_3:t):prop -> ((occurrences 
+                            y_1:t (h':t_1).bag):integer = (occurrences 
                             y_1:t (h_3:t_1).bag):integer):prop
-                    ensures ((card  (h':t_1).bag):integer = ((card 
-                            (h_3:t_1).bag):integer + 1:integer):integer):prop*)
+                    ensures ((integer_of_int 
+                            (cardinal  (h':t_1).bag):int):integer = ((integer_of_int 
+                            (cardinal  (h_3:t_1).bag):int):integer + 1:
+                            integer):integer):prop*)
         (*@ predicate mem (x_4:t) (h_4:t_1) =
-            ((nb_occ  x_4:t (h_4:t_1).bag):integer > 0:integer):prop
+            ((occurrences  x_4:t (h_4:t_1).bag):integer > 0:integer):prop
         *)
         (*@ predicate is_minimum (x_5:t) (h_5:t_1) =
             (mem  x_5:t h_5:t_1):prop /\ forall e:t . (mem 
@@ -203,25 +203,29 @@ module PairingHeap.mli
             integer <= 0:integer):prop
         *)
         (*@ function minimum (h_6:t_1): t *)
-        (*@ axiom min_def: forall h_7:t_1 . (0:integer < (card 
-        (h_7:t_1).bag):integer):prop -> (is_minimum 
+        (*@ axiom min_def: forall h_7:t_1 . (0:integer < (integer_of_int 
+        (cardinal  (h_7:t_1).bag):int):integer):prop -> (is_minimum 
         (minimum  h_7:t_1):t h_7:t_1):prop *)
         val find_min : t -> elt
         (*@ x_6:t = find_min h_8:t_1
-            requires ((card  (h_8:t_1).bag):integer > 0:integer):prop
+            requires ((integer_of_int 
+                     (cardinal  (h_8:t_1).bag):int):integer > 0:integer):prop
             ensures (x_6:t = (minimum  h_8:t_1):t):prop*)
         val delete_min : t -> t
         (*@ h'_1:t_1 = delete_min h_9:t_1
-            requires ((card  (h_9:t_1).bag):integer > 0:integer):prop
-            ensures let x_7:t = (minimum  h_9:t_1):t in ((nb_occ 
-                    x_7:t (h'_1:t_1).bag):integer = ((nb_occ 
+            requires ((integer_of_int 
+                     (cardinal  (h_9:t_1).bag):int):integer > 0:integer):prop
+            ensures let x_7:t = (minimum  h_9:t_1):t in ((occurrences 
+                    x_7:t (h'_1:t_1).bag):integer = ((occurrences 
                     x_7:t (h_9:t_1).bag):integer - 1:integer):integer):prop
                     ensures forall y_2:t . not (y_2:t = (minimum 
-                            h_9:t_1):t):prop -> ((nb_occ 
-                            y_2:t (h'_1:t_1).bag):integer = (nb_occ 
+                            h_9:t_1):t):prop -> ((occurrences 
+                            y_2:t (h'_1:t_1).bag):integer = (occurrences 
                             y_2:t (h_9:t_1).bag):integer):prop
-                    ensures ((card  (h'_1:t_1).bag):integer = ((card 
-                            (h_9:t_1).bag):integer - 1:integer):integer):prop*)
+                    ensures ((integer_of_int 
+                            (cardinal  (h'_1:t_1).bag):int):integer = ((integer_of_int 
+                            (cardinal  (h_9:t_1).bag):int):integer - 1:
+                            integer):integer):prop*)
       end
 
 OK

--- a/test/vocal/PriorityQueue.mli
+++ b/test/vocal/PriorityQueue.mli
@@ -8,8 +8,6 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ open Bag *)
-
 (** This module implements a priority queue based on a minimal binary heap.
 The heap is modelized by a dynamic array, taken from the module Vector **)
 
@@ -33,19 +31,19 @@ end) : sig
   (*@ mutable model bag : elt bag *)
   (*@ invariant card bag <= Sys.max_array_length *)
 
-  (*@ predicate mem (x: elt) (h: heap) = nb_occ x h.bag > 0 *)
+  (*@ predicate mem (x: elt) (h: heap) = Bag.occurrences x h.bag > 0 *)
 
   val create : unit -> heap
   (*@ h = create ()
-      ensures h.bag = empty_bag  *)
+      ensures h.bag = Bag.empty  *)
 
   val is_empty : heap -> bool
   (*@ b = is_empty h
-      ensures b <-> h.bag = empty_bag *)
+      ensures b <-> Bag.is_empty h.bag *)
 
   val size : heap -> int
   (*@ x = size h
-      ensures x = card h.bag *)
+      ensures x = Bag.cardinal h.bag *)
 
   (*@ function minimum (h: heap) : elt *)
 
@@ -53,38 +51,38 @@ end) : sig
         mem x h && forall e. mem e h -> X.cmp x e <= 0 *)
 
   (*@ axiom min_def:
-        forall h. 0 < card h.bag -> is_minimum (minimum h) h *)
+        forall h. 0 < Bag.cardinal h.bag -> is_minimum (minimum h) h *)
 
   val find_min : heap -> elt option
   (*@ r = find_min h
       ensures match r with
-      | None   -> card h.bag = 0
-      | Some x -> card h.bag > 0 && x = minimum h *)
+      | None   -> Bag.cardinal h.bag = 0
+      | Some x -> Bag.cardinal h.bag > 0 && x = minimum h *)
 
   exception Empty
 
   val find_min_exn : heap -> elt
   (*@ x = find_min_exn h
-      raises  Empty -> card h.bag = 0
-      ensures card h.bag > 0 && x = minimum h *)
+      raises  Empty -> Bag.cardinal h.bag = 0
+      ensures Bag.cardinal h.bag > 0 && x = minimum h *)
 
   val delete_min_exn : heap -> unit
   (*@ delete_min_exn h
       modifies h
-      raises  Empty -> card h.bag = 0 && h.bag = old h.bag
-      ensures (old h).bag = add (minimum (old h)) h.bag *)
+      raises  Empty -> Bag.cardinal h.bag = 0 && h.bag = old h.bag
+      ensures (old h).bag = Bag.add (minimum (old h)) h.bag *)
 
   val extract_min_exn : heap -> elt
   (*@ x = extract_min_exn h
       modifies h
-      raises  Empty -> card h.bag = 0 && h.bag = old h.bag
+      raises  Empty -> Bag.cardinal h.bag = 0 && h.bag = old h.bag
       ensures x = minimum (old h)
-      ensures (old h).bag = add x h.bag *)
+      ensures (old h).bag = Bag.add x h.bag *)
 
   val insert : elt -> heap -> unit
    (*@ insert x h
-       checks   card h.bag < Sys.max_array_length
+       checks   Bag.cardinal h.bag < Sys.max_array_length
        modifies h
-       ensures  h.bag = add x (old h).bag *)
+       ensures  h.bag = Bag.add x (old h).bag *)
 
 end

--- a/test/vocal/PriorityQueue.mli.expected
+++ b/test/vocal/PriorityQueue.mli.expected
@@ -2,7 +2,6 @@
 *******************************
 ********** Parsed file ********
 *******************************
-[@@@gospel {| open Bag |}]
 [@@@ocaml.text
   " This module implements a priority queue based on a minimal binary heap.\nThe heap is modelized by a dynamic array, taken from the module Vector *"]
 module Make :
@@ -20,57 +19,56 @@ functor (X :
     type elt = X.t
     type heap[@@gospel {| mutable model bag : elt bag |}][@@gospel
                                                            {| invariant card bag <= Sys.max_array_length |}]
-    [@@@gospel {| predicate mem (x: elt) (h: heap) = nb_occ x h.bag > 0 |}]
+    [@@@gospel
+      {| predicate mem (x: elt) (h: heap) = Bag.occurrences x h.bag > 0 |}]
     val create : unit -> heap[@@gospel
                                {| h = create ()
-      ensures h.bag = empty_bag  |}]
+      ensures h.bag = Bag.empty  |}]
     val is_empty : heap -> bool[@@gospel
                                  {| b = is_empty h
-      ensures b <-> h.bag = empty_bag |}]
+      ensures b <-> Bag.is_empty h.bag |}]
     val size : heap -> int[@@gospel
                             {| x = size h
-      ensures x = card h.bag |}]
+      ensures x = Bag.cardinal h.bag |}]
     [@@@gospel {| function minimum (h: heap) : elt |}]
     [@@@gospel
       {| predicate is_minimum (x: elt) (h: heap) =
         mem x h && forall e. mem e h -> X.cmp x e <= 0 |}]
     [@@@gospel
       {| axiom min_def:
-        forall h. 0 < card h.bag -> is_minimum (minimum h) h |}]
+        forall h. 0 < Bag.cardinal h.bag -> is_minimum (minimum h) h |}]
     val find_min : heap -> elt option[@@gospel
                                        {| r = find_min h
       ensures match r with
-      | None   -> card h.bag = 0
-      | Some x -> card h.bag > 0 && x = minimum h |}]
+      | None   -> Bag.cardinal h.bag = 0
+      | Some x -> Bag.cardinal h.bag > 0 && x = minimum h |}]
     exception Empty 
     val find_min_exn : heap -> elt[@@gospel
                                     {| x = find_min_exn h
-      raises  Empty -> card h.bag = 0
-      ensures card h.bag > 0 && x = minimum h |}]
+      raises  Empty -> Bag.cardinal h.bag = 0
+      ensures Bag.cardinal h.bag > 0 && x = minimum h |}]
     val delete_min_exn : heap -> unit[@@gospel
                                        {| delete_min_exn h
       modifies h
-      raises  Empty -> card h.bag = 0 && h.bag = old h.bag
-      ensures (old h).bag = add (minimum (old h)) h.bag |}]
+      raises  Empty -> Bag.cardinal h.bag = 0 && h.bag = old h.bag
+      ensures (old h).bag = Bag.add (minimum (old h)) h.bag |}]
     val extract_min_exn : heap -> elt[@@gospel
                                        {| x = extract_min_exn h
       modifies h
-      raises  Empty -> card h.bag = 0 && h.bag = old h.bag
+      raises  Empty -> Bag.cardinal h.bag = 0 && h.bag = old h.bag
       ensures x = minimum (old h)
-      ensures (old h).bag = add x h.bag |}]
+      ensures (old h).bag = Bag.add x h.bag |}]
     val insert : elt -> heap -> unit[@@gospel
                                       {| insert x h
-       checks   card h.bag < Sys.max_array_length
+       checks   Bag.cardinal h.bag < Sys.max_array_length
        modifies h
-       ensures  h.bag = add x (old h).bag |}]
+       ensures  h.bag = Bag.add x (old h).bag |}]
   end
 
 *******************************
 ****** GOSPEL translation *****
 *******************************
 (*@ open Gospelstdlib *)
-
-(*@ open Bag *)
 
 [@@@ocaml.text
   " This module implements a priority queue based on a minimal binary heap.\nThe heap is modelized by a dynamic array, taken from the module Vector *"]
@@ -172,8 +170,6 @@ module PriorityQueue.mli
   Signatures
     (*@ open Gospelstdlib *)
     
-    (*@ open Bag *)
-    
     [@@@ocaml.text
       " This module implements a priority queue based on a minimal binary heap.\nThe heap is modelized by a dynamic array, taken from the module Vector *"]
     
@@ -199,19 +195,18 @@ module PriorityQueue.mli
              (*@ ephemeral
                  mutable model bag : t bag_1 *)
         (*@ predicate mem (x_1:t) (h:heap) =
-            ((nb_occ  x_1:t (h:heap).bag):integer > 0:integer):prop
+            ((occurrences  x_1:t (h:heap).bag):integer > 0:integer):prop
         *)
         val create : unit -> heap
         (*@ h_1:heap = create ()
-            ensures ((h_1:heap).bag = (empty_bag ):t bag_1):prop*)
+            ensures ((h_1:heap).bag = (empty ):t bag_1):prop*)
         val is_empty : heap -> bool
         (*@ b:bool = is_empty h_2:heap
-            ensures (b:bool = (True ):bool):prop <-> ((h_2:heap).bag = (empty_bag ):
-                    t bag_1):prop*)
+            ensures (b:bool = (True ):bool):prop <-> (is_empty_1 
+                    (h_2:heap).bag):prop*)
         val size : heap -> int
         (*@ x_2:int = size h_3:heap
-            ensures ((integer_of_int  x_2:int):integer = (card 
-                    (h_3:heap).bag):integer):prop*)
+            ensures (x_2:int = (cardinal  (h_3:heap).bag):int):prop*)
         (*@ function minimum (h_4:heap): t *)
         (*@ predicate is_minimum (x_3:t) (h_5:heap) =
             (mem  x_3:t h_5:heap):prop && forall e:t . (mem 
@@ -219,49 +214,55 @@ module PriorityQueue.mli
             (apply  (apply  (cmp ):t -> t -> int x_3:t):t -> int e:t):int):
             integer <= 0:integer):prop
         *)
-        (*@ axiom min_def: forall h_6:heap . (0:integer < (card 
-        (h_6:heap).bag):integer):prop -> (is_minimum 
+        (*@ axiom min_def: forall h_6:heap . (0:integer < (integer_of_int 
+        (cardinal  (h_6:heap).bag):int):integer):prop -> (is_minimum 
         (minimum  h_6:heap):t h_6:heap):prop *)
         val find_min : heap -> elt option
         (*@ r_1:t option = find_min h_7:heap
             ensures (match r_1:t option with
-                    | None -> if ((card 
-                              (h_7:heap).bag):integer = 0:integer):prop then (True ):
-                              bool else (False ):bool
-                    | Some x_4:t -> if ((card 
-                                    (h_7:heap).bag):integer > 0:integer):prop && (
-                                    x_4:t = (minimum 
+                    | None -> if ((integer_of_int 
+                              (cardinal  (h_7:heap).bag):int):integer = 0:
+                              integer):prop then (True ):bool else (False ):
+                              bool
+                    | Some x_4:t -> if ((integer_of_int 
+                                    (cardinal  (h_7:heap).bag):int):integer > 0:
+                                    integer):prop && (x_4:t = (minimum 
                                     h_7:heap):t):prop then (True ):bool else (False ):
                                     bool
                     end::bool = (True ):bool):prop*)
         exception Empty
         val find_min_exn : heap -> elt
         (*@ x_5:t = find_min_exn h_8:heap
-            ensures ((card 
-                    (h_8:heap).bag):integer > 0:integer):prop && (x_5:t = (minimum 
-                    h_8:heap):t):prop
-            raisesEmpty  -> ((card  (h_8:heap).bag):integer = 0:integer):prop*)
+            ensures ((integer_of_int 
+                    (cardinal  (h_8:heap).bag):int):integer > 0:integer):prop && (
+                    x_5:t = (minimum  h_8:heap):t):prop
+            raisesEmpty  -> ((integer_of_int 
+                            (cardinal  (h_8:heap).bag):int):integer = 0:
+                            integer):prop*)
         val delete_min_exn : heap -> unit
         (*@  delete_min_exn h_9:heap
             ensures ((old (h_9:heap)).bag = (add 
                     (minimum  old (h_9:heap)):t (h_9:heap).bag):t bag_1):prop
-            raisesEmpty  -> ((card 
-                            (h_9:heap).bag):integer = 0:integer):prop && ((
-                            h_9:heap).bag = old ((h_9:heap).bag)):prop
+            raisesEmpty  -> ((integer_of_int 
+                            (cardinal  (h_9:heap).bag):int):integer = 0:
+                            integer):prop && ((h_9:heap).bag = old ((
+                            h_9:heap).bag)):prop
             writes h_9:heap*)
         val extract_min_exn : heap -> elt
         (*@ x_6:t = extract_min_exn h_10:heap
             ensures (x_6:t = (minimum  old (h_10:heap)):t):prop
                     ensures ((old (h_10:heap)).bag = (add 
                             x_6:t (h_10:heap).bag):t bag_1):prop
-            raisesEmpty  -> ((card 
-                            (h_10:heap).bag):integer = 0:integer):prop && ((
-                            h_10:heap).bag = old ((h_10:heap).bag)):prop
+            raisesEmpty  -> ((integer_of_int 
+                            (cardinal  (h_10:heap).bag):int):integer = 0:
+                            integer):prop && ((h_10:heap).bag = old ((
+                            h_10:heap).bag)):prop
             writes h_10:heap*)
         val insert : elt -> heap -> unit
         (*@  insert x_7:t h_11:heap
-            checks ((card 
-                   (h_11:heap).bag):integer < (max_array_length ):integer):prop
+            checks ((integer_of_int 
+                   (cardinal  (h_11:heap).bag):int):integer < (max_array_length ):
+                   integer):prop
             ensures ((h_11:heap).bag = (add 
                     x_7:t (old (h_11:heap)).bag):t bag_1):prop
             writes h_11:heap*)

--- a/test/vocal/Queue.mli
+++ b/test/vocal/Queue.mli
@@ -8,15 +8,13 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ open Seq *)
-
 type 'a t
 (*@ mutable model view: 'a seq *)
 
 val create : unit -> 'a t
 (** Return a new queue, initially empty. *)
 (*@ q = create ()
-      ensures q.view == empty *)
+      ensures q.view == Seq.empty *)
 
 val push : 'a -> 'a t -> unit
 (** [add x q] adds the element [x] at the end of the queue [q]. *)
@@ -27,19 +25,19 @@ val push : 'a -> 'a t -> unit
 val pop : 'a t -> 'a
 (** [pop q] removes and returns the first element in queue [q]. *)
 (*@ r = pop q
-      requires q.view <> empty
+      requires q.view <> Seq.empty
       modifies q
       ensures  old q.view == Seq.cons r q.view *)
 
 val is_empty : 'a t -> bool
 (** Return [true] if the given queue is empty, [false] otherwise. *)
 (*@ b = is_empty q
-      ensures b <-> q.view = empty *)
+      ensures b <-> q.view = Seq.empty *)
 
 val transfer : 'a t -> 'a t -> unit
 (** [transfer q1 q2] adds all of [q1]'s elements at the end of
     the queue [q2], then clears [q1]. *)
 (*@ transfer q1 q2
       modifies q1.view, q2.view
-      ensures  q1.view == empty
+      ensures  q1.view == Seq.empty
       ensures  q2.view == old q2.view ++ old q1.view *)

--- a/test/vocal/Queue.mli.expected
+++ b/test/vocal/Queue.mli.expected
@@ -2,35 +2,32 @@
 *******************************
 ********** Parsed file ********
 *******************************
-[@@@gospel {| open Seq |}]
 type 'a t[@@gospel {| mutable model view: 'a seq |}]
 val create : unit -> 'a t[@@gospel
                            {| q = create ()
-      ensures q.view == empty |}]
+      ensures q.view == Seq.empty |}]
 val push : 'a -> 'a t -> unit[@@gospel
                                {| push x q
       modifies q
       ensures  q.view == Seq.snoc (old q.view) x |}]
 val pop : 'a t -> 'a[@@gospel
                       {| r = pop q
-      requires q.view <> empty
+      requires q.view <> Seq.empty
       modifies q
       ensures  old q.view == Seq.cons r q.view |}]
 val is_empty : 'a t -> bool[@@gospel
                              {| b = is_empty q
-      ensures b <-> q.view = empty |}]
+      ensures b <-> q.view = Seq.empty |}]
 val transfer : 'a t -> 'a t -> unit[@@gospel
                                      {| transfer q1 q2
       modifies q1.view, q2.view
-      ensures  q1.view == empty
+      ensures  q1.view == Seq.empty
       ensures  q2.view == old q2.view ++ old q1.view |}]
 
 *******************************
 ****** GOSPEL translation *****
 *******************************
 (*@ open Gospelstdlib *)
-
-(*@ open Seq *)
 
 type 'a t
   (*@ ephemeral
@@ -88,8 +85,6 @@ module Queue.mli
       
   Signatures
     (*@ open Gospelstdlib *)
-    
-    (*@ open Seq *)
     
     type 'a t
          (*@ ephemeral

--- a/test/vocal/RingBuffer.mli.expected
+++ b/test/vocal/RingBuffer.mli.expected
@@ -144,7 +144,7 @@ module RingBuffer.mli
              mutable model sequence : 'a seq
              model capacity : integer
              invariant ((length 
-                       (sequence_1 ):'a191 seq):integer <= (capacity_1 ):
+                       (sequence_1 ):'a39 seq):integer <= (capacity_1 ):
                        integer):prop /\ ((capacity_1 ):integer <= (max_array_length ):
                        integer):prop *)
     

--- a/test/vocal/UnionFind.mli
+++ b/test/vocal/UnionFind.mli
@@ -12,7 +12,7 @@
 (*@ open Map *)
 
 type 'a elem
-  
+
 (*@ type 'a uf *)
 (*@ mutable model dom : 'a elem set
     mutable model rep : 'a elem -> 'a elem
@@ -33,7 +33,7 @@ val make : 'a -> 'a elem
       (* requires $ O(1) *)
       modifies uf
       ensures  not (mem e (old (dom uf)))
-      ensures  dom uf = old (dom uf) `union` {:e:}
+      ensures  dom uf = Set.add e (old (dom uf))
       ensures  rep uf = (old (rep uf))[e <- e]
       ensures  img uf = (old (img uf))[e <- v]
 *)

--- a/test/vocal/UnionFind.mli.expected
+++ b/test/vocal/UnionFind.mli.expected
@@ -25,7 +25,7 @@ val make : 'a -> 'a elem[@@gospel
       (* requires $ O(1) *)
       modifies uf
       ensures  not (mem e (old (dom uf)))
-      ensures  dom uf = old (dom uf) `union` {:e:}
+      ensures  dom uf = Set.add e (old (dom uf))
       ensures  rep uf = (old (rep uf))[e <- e]
       ensures  img uf = (old (img uf))[e <- v]
 |}]
@@ -279,9 +279,8 @@ module UnionFind.mli
     val make : 'a -> 'a elem
     (*@ e:'a elem = make [uf_3:'a uf: 'a uf] v:'a
         ensures not (mem  e:'a elem old ((uf_3:'a uf).dom)):prop
-                ensures ((uf_3:'a uf).dom = old ((union 
-                        (uf_3:'a uf).dom (mixfix {:_:} 
-                        e:'a elem):'a elem set):'a elem set)):prop
+                ensures ((uf_3:'a uf).dom = (add 
+                        e:'a elem old ((uf_3:'a uf).dom)):'a elem set):prop
                 ensures ((uf_3:'a uf).rep = (mixfix [<-] 
                         old ((uf_3:'a uf).rep) e:'a elem e:'a elem):'a 
                                                                     elem ->
@@ -340,8 +339,8 @@ module UnionFind.mli
                         (uf_7:'a uf).img x_4:'a elem):'a)):prop
         writes uf_7:'a uf*)
     
-    val union_1 : 'a elem -> 'a elem -> unit
-    (*@  union_1 [uf_8:'a uf: 'a uf] e1_1:'a elem e2_1:'a elem
+    val union : 'a elem -> 'a elem -> unit
+    (*@  union [uf_8:'a uf: 'a uf] e1_1:'a elem e2_1:'a elem
         requires (mem  e1_1:'a elem (uf_8:'a uf).dom):prop
                  requires (mem  e2_1:'a elem (uf_8:'a uf).dom):prop
         ensures ((uf_8:'a uf).dom = old ((uf_8:'a uf).dom)):prop
@@ -366,7 +365,7 @@ module UnionFind.mli
     (*@
     val join : 'a uf -> 'a uf -> unit
     (*@  join uf1:'a uf uf2:'a uf
-        ensures ((uf1:'a uf).dom = old ((union 
+        ensures ((uf1:'a uf).dom = old ((union_1 
                 (uf1:'a uf).dom old ((uf2:'a uf).dom)):'a elem set)):prop
                 ensures forall x_6:'a elem . ((apply 
                         (uf1:'a uf).rep x_6:'a elem):'a elem = if (mem 

--- a/test/vocal/Vector.mli
+++ b/test/vocal/Vector.mli
@@ -30,13 +30,11 @@
     {!Vector.push} has overall complexity O(n) i.e. each insertion has
     amortized constant time complexity. *)
 
-(*@ open Seq *)
-
 type 'a t
 (** The polymorphic type of vectors.
     This is a mutable data type. *)
 (*@ mutable model view: 'a seq *)
-(*@ invariant length view <= Sys.max_array_length *)
+(*@ invariant Seq.length view <= Sys.max_array_length *)
 
 (** {2 Operations proper to vectors, or with a different type and/or
     semantics than those of module [Array]} *)
@@ -50,7 +48,7 @@ val create: ?capacity:int -> dummy:'a -> 'a t
       requires let capacity = match capacity with
                  | None -> 0 | Some c -> c in
                0 <= capacity <= Sys.max_array_length
-      ensures  length a.view = 0 *)
+      ensures  Seq.length a.view = 0 *)
 
 val make: ?dummy:'a -> int -> 'a -> 'a t
 (** [make dummy n x] returns a fresh vector of length [n] with all elements
@@ -58,7 +56,7 @@ val make: ?dummy:'a -> int -> 'a -> 'a t
     dummy value for this vector. *)
 (*@ a = make ?dummy n x
       requires 0 <= n <= Sys.max_array_length
-      ensures  length a.view = n
+      ensures  Seq.length a.view = n
       ensures  forall i: integer. 0 <= i < n -> a.view[i] = x *)
 
 val init: dummy:'a -> int -> (int -> 'a) -> 'a t
@@ -70,7 +68,7 @@ val init: dummy:'a -> int -> (int -> 'a) -> 'a t
    Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length]. *)
 (*@ a = init ~dummy n f
       requires 0 <= n <= Sys.max_array_length
-      ensures  length a.view = n
+      ensures  Seq.length a.view = n
       ensures  forall i: int. 0 <= i < n -> a.view[i] = f i *)
 
 val resize: 'a t -> int -> unit
@@ -84,8 +82,8 @@ val resize: 'a t -> int -> unit
 (*@ resize a n
       checks   0 <= n <= Sys.max_array_length
       modifies a
-      ensures  length a.view = n
-      ensures  forall i. 0 <= i < min (length (old a.view)) n ->
+      ensures  Seq.length a.view = n
+      ensures  forall i. 0 <= i < min (Seq.length (old a.view)) n ->
                  a.view[i] = (old a.view)[i] *)
 
 (** {2 Array interface} *)
@@ -95,18 +93,18 @@ val clear: 'a t -> unit
     This is equivalent to setting the size to 0 with [resize]. *)
 (*@ clear a
       modifies a
-      ensures length a.view = 0 *)
+      ensures Seq.length a.view = 0 *)
 
 val is_empty: 'a t -> bool
 (** Return [true] if the given vector is empty, [false] otherwise. *)
 (*@ r = is_empty a
-      ensures r <-> length a.view = 0 *)
+      ensures r <-> Seq.length a.view = 0 *)
 
 val length: 'a t -> int
 (** Return the length (number of elements) of the given vector.
     Note: the number of memory words occupied by the vector can be larger. *)
 (*@ n = length a
-      ensures n = length a.view *)
+      ensures n = Seq.length a.view *)
 
 val get: 'a t -> int -> 'a
 (** [get a n] returns the element number [n] of vector [a].
@@ -116,7 +114,7 @@ val get: 'a t -> int -> 'a
     Raise [Invalid_argument "Vector.get"]
     if [n] is outside the range [0] to [length a - 1]. *)
 (*@ x = get a i
-      requires 0 <= i < length a.view
+      requires 0 <= i < Seq.length a.view
       ensures  x = a.view[i] *)
 
 val set: 'a t -> int -> 'a -> unit
@@ -126,19 +124,19 @@ val set: 'a t -> int -> 'a -> unit
     Raise [Invalid_argument "Vector.set"]
     if [n] is outside the range 0 to [length a - 1]. *)
 (*@ set a i x
-      requires 0 <= i < length a.view
+      requires 0 <= i < Seq.length a.view
       modifies a
-      ensures length a.view = length (old a).view
+      ensures Seq.length a.view = Seq.length (old a).view
       ensures  a.view[i] = x
-      ensures  forall j. 0 <= j < length a.view -> j <> i ->
+      ensures  forall j. 0 <= j < Seq.length a.view -> j <> i ->
                  a.view[j] = (old a).view[j] *)
 
 val sub: 'a t -> int -> int -> 'a t
 (** [sub a start len] returns a fresh vector of length [len], containing
     the elements number [start] to [start + len - 1] of vector [a]. *)
 (*@ r = sub a ofs n
-      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= length a.view
-      ensures  length r.view = n
+      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Seq.length a.view
+      ensures  Seq.length r.view = n
       ensures  forall i. 0 <= i < n -> r.view[i] = a.view[ofs + i] *)
 
 val fill : 'a t -> int -> int -> 'a -> unit
@@ -148,9 +146,9 @@ val fill : 'a t -> int -> int -> 'a -> unit
     Raise [Invalid_argument "Vector.fill"] if [ofs] and [len] do not
     designate a valid subvector of [a]. *)
 (*@ fill a ofs n x
-      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= length a.view
+      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Seq.length a.view
       modifies a
-      ensures  forall i. (0 <= i < ofs \/ ofs + n <= i < length a.view) ->
+      ensures  forall i. (0 <= i < ofs \/ ofs + n <= i < Seq.length a.view) ->
                  a.view[i] = (old a).view[i]
       ensures  forall i. ofs <= i < ofs + n -> a.view[i] = x *)
 
@@ -166,10 +164,10 @@ val blit : 'a t -> int -> 'a t -> int -> int -> unit
    designate a valid subvector of [a2]. *)
 (*@ blit a1 ofs1 a2 ofs2 n
       requires 0 <= n
-      requires 0 <= ofs1 /\ ofs1 + n <= length a1.view
-      requires 0 <= ofs2 /\ ofs2 + n <= length a2.view
+      requires 0 <= ofs1 /\ ofs1 + n <= Seq.length a1.view
+      requires 0 <= ofs2 /\ ofs2 + n <= Seq.length a2.view
       modifies a2
-      ensures  forall i. (0 <= i < ofs2 \/ ofs2 + n <= i < length a2.view) ->
+      ensures  forall i. (0 <= i < ofs2 \/ ofs2 + n <= i < Seq.length a2.view) ->
                          a2.view[i] = (old a2).view[i]
       ensures  forall i. ofs2 <= i < ofs2 + n ->
                          a2.view[i] = (old a1).view[ofs1 + i - ofs2] *)
@@ -180,24 +178,24 @@ val append: 'a t -> 'a t -> 'a t
 
     It works correctly even if [a1] and [a2] are the same vector. *)
 (*@ a3 = append a1 a2
-      requires length a1.view + length a2.view <= Sys.max_array_length
-      ensures  length a3.view = length a1.view + length a2.view
-      ensures  forall i. 0 <= i < length a1.view -> a3.view[i] = a1.view[i]
-      ensures  forall i. 0 <= i < length a2.view ->
-                 a3.view[length a1.view + i] = a2.view[i] *)
+      requires Seq.length a1.view + Seq.length a2.view <= Sys.max_array_length
+      ensures  Seq.length a3.view = Seq.length a1.view + Seq.length a2.view
+      ensures  forall i. 0 <= i < Seq.length a1.view -> a3.view[i] = a1.view[i]
+      ensures  forall i. 0 <= i < Seq.length a2.view ->
+                 a3.view[Seq.length a1.view + i] = a2.view[i] *)
 
 val merge_right: 'a t -> 'a t -> unit
 (** [merge_right a1 a2] moves all elements of [a2] to the end
     of [a1]. Empties [a2]. Assumes [a1] and [a2] to be disjoint. *)
 (*@ merge_right a1 a2
-      requires length a1.view + length a2.view <= Sys.max_array_length
+      requires Seq.length a1.view + Seq.length a2.view <= Sys.max_array_length
       modifies a1, a2
-      ensures  length a2.view = 0
-      ensures  length a1.view = length (old a1).view + length (old a2).view
-      ensures  forall i. 0 <= i < length (old a1).view ->
+      ensures  Seq.length a2.view = 0
+      ensures  Seq.length a1.view = Seq.length (old a1).view + Seq.length (old a2).view
+      ensures  forall i. 0 <= i < Seq.length (old a1).view ->
                  a1.view[i] = (old a1).view[i]
-      ensures  forall i. 0 <= i < length (old a2).view ->
-                 a1.view[length (old a1).view + i] = (old a2).view[i] *)
+      ensures  forall i. 0 <= i < Seq.length (old a2).view ->
+                 a1.view[Seq.length (old a1).view + i] = (old a2).view[i] *)
 
 (* requires disjoint a1 a2 FIXME: disjoint is undefined *)
 
@@ -210,8 +208,8 @@ val map : dummy:'b -> 'a t -> ('a -> 'b) -> 'b t
    first create a new vector and then fill it with the value
    [f (get a 0)], [f (get a 1)], etc. *)
 (*@ a2 = map ~dummy a1 f
-      ensures  length a2.view = length a1.view
-      ensures  forall i. 0 <= i < length a1.view -> a2.view[i] = f a1.view[i] *)
+      ensures  Seq.length a2.view = Seq.length a1.view
+      ensures  forall i. 0 <= i < Seq.length a1.view -> a2.view[i] = f a1.view[i] *)
 
 val mapi : dummy:'b -> 'a t -> (int -> 'a -> 'b) -> 'b t
 (** Same as {!Vector.map}, but the
@@ -221,16 +219,16 @@ val mapi : dummy:'b -> 'a t -> (int -> 'a -> 'b) -> 'b t
    Note: the dummy value of the returned vector is obtained by applying
    [f 0] to the dummy value of [a].  *)
 (*@ a2 = mapi ~dummy a1 f
-      ensures  length a2.view = length a1.view
-      ensures  forall i: int. 0 <= i < length a1.view ->
+      ensures  Seq.length a2.view = Seq.length a1.view
+      ensures  forall i: int. 0 <= i < Seq.length a1.view ->
                a2.view[i] = f i a1.view[i] *)
 
 val copy: 'a t -> 'a t
 (** [copy a] returns a copy of [a], that is, a fresh vector containing
     the same elements as [a]. *)
 (*@ a2 = copy a1
-      ensures  length a2.view = length a1.view
-      ensures  forall i. 0 <= i < length a1.view -> a2.view[i] = a1.view[i] *)
+      ensures  Seq.length a2.view = Seq.length a1.view
+      ensures  forall i. 0 <= i < Seq.length a1.view -> a2.view[i] = a1.view[i] *)
 
 val fold_left : 'b t -> ('a -> 'b -> 'a) -> 'a -> 'a
 (** [fold_left f x a] computes
@@ -249,7 +247,7 @@ val fold_right : 'b t -> ('b -> 'a -> 'a) -> 'a -> 'a
 (* val iter : ('a -> unit) -> 'a t -> unit
  * (\** [iter f a] applies function [f] in turn to all
  *    the elements of [a].  It is equivalent to
- *    [f (get a 0); f (get a 1); ...; f (get a (length a - 1))]. *\)
+ *    [f (get a 0); f (get a 1); ...; f (get a (Seq.length a - 1))]. *\)
  * (\*@ iter f a
  *       equivalent "for i = 0 to length a - 1 do f (get a i) done" *\)
  *
@@ -272,11 +270,11 @@ val push: 'a t -> 'a -> unit
 
     Note: the order of the arguments is not that of {!Stack.push}. *)
 (*@ push a x
-      requires length a.view < Sys.max_array_length
+      requires Seq.length a.view < Sys.max_array_length
       modifies a
-      ensures  length a.view = length (old a.view) + 1
-      ensures  a.view[length a.view - 1] = x
-      ensures  forall i. 0 <= i < length (old a.view) ->
+      ensures  Seq.length a.view = Seq.length (old a.view) + 1
+      ensures  a.view[Seq.length a.view - 1] = x
+      ensures  forall i. 0 <= i < Seq.length (old a.view) ->
                  a.view[i] = (old a).view[i] *)
 
 exception Empty
@@ -286,10 +284,10 @@ val pop: 'a t -> 'a
     or raises [Empty] if the stack is empty. *)
 (*@ x = pop a
       modifies a
-      raises   Empty -> length a.view = length (old a).view = 0
-      ensures  length a.view = length (old a).view - 1
-      ensures  x = (old a).view[length a.view]
-      ensures  forall i. 0 <= i < length a.view ->
+      raises   Empty -> Seq.length a.view = Seq.length (old a).view = 0
+      ensures  Seq.length a.view = Seq.length (old a).view - 1
+      ensures  x = (old a).view[Seq.length a.view]
+      ensures  forall i. 0 <= i < Seq.length a.view ->
                  a.view[i] = (old a).view[i] *)
 
 val pop_opt: 'a t -> 'a option
@@ -297,25 +295,25 @@ val pop_opt: 'a t -> 'a option
 (*@ r = pop_opt a
       modifies a
       ensures  match r with
-               | None   -> length a.view = length (old a).view = 0
-               | Some x -> length a.view = length (old a).view - 1 /\
-                           x = (old a).view[length a.view] /\
-                           forall i. 0 <= i < length a.view ->
+               | None   -> Seq.length a.view = Seq.length (old a).view = 0
+               | Some x -> Seq.length a.view = Seq.length (old a).view - 1 /\
+                           x = (old a).view[Seq.length a.view] /\
+                           forall i. 0 <= i < Seq.length a.view ->
                                      a.view[i] = (old a).view[i] *)
 
 val top: 'a t -> 'a
 (** [top a] returns the rightmost element in vector [a],
     or raises [Empty] if the vector is empty. *)
 (*@ x = top a
-      requires 0 < length a.view
-      ensures  x = a.view[length a.view - 1] *)
+      requires 0 < Seq.length a.view
+      ensures  x = a.view[Seq.length a.view - 1] *)
 
 val top_opt: 'a t -> 'a option
 (** similar to [top], but with an option instead of an exception *)
 (*@ r = top_opt a
       ensures  match r with
-               | None   -> length a.view = 0
-               | Some x -> x = a.view[length a.view - 1] *)
+               | None   -> Seq.length a.view = 0
+               | Some x -> x = a.view[Seq.length a.view - 1] *)
 
 (** {2 Conversions to/from arrays and lists} *)
 

--- a/test/vocal/Vector.mli.expected
+++ b/test/vocal/Vector.mli.expected
@@ -4,9 +4,8 @@
 *******************************
 [@@@ocaml.text
   " Vectors (aka resizable arrays, growing arrays, dynamic arrays, etc.)\n\n    This module implements arrays that automatically expand as necessary.\n    Its implementation uses a traditional array and replaces it with a\n    larger array when needed (and elements are copied from the old array\n    to the new one). The current implementation doubles the capacity when\n    growing the array (and shrinks it whenever the number of elements\n    comes to one fourth of the capacity).\n\n    The unused part of the internal array is filled with a dummy value,\n    which is user-provided at creation time (and referred to below\n    as ``the dummy value''). Consequently, vectors do not retain pointers\n    to values that are not used anymore after a shrinking.\n\n    Vectors provide an efficient implementation of stacks, with a\n    better locality of reference than list-based implementations (such\n    as standard library {!Stack}). A stack interface is provided,\n    similar to that of {!Stack} (though {!Vector.push} have arguments\n    in the other way round). Inserting [n] elements with\n    {!Vector.push} has overall complexity O(n) i.e. each insertion has\n    amortized constant time complexity. "]
-[@@@gospel {| open Seq |}]
 type 'a t[@@gospel {| mutable model view: 'a seq |}][@@gospel
-                                                      {| invariant length view <= Sys.max_array_length |}]
+                                                      {| invariant Seq.length view <= Sys.max_array_length |}]
 [@@@ocaml.text
   " {2 Operations proper to vectors, or with a different type and/or\n    semantics than those of module [Array]} "]
 val create : ?capacity:int -> dummy:'a -> 'a t[@@gospel
@@ -14,99 +13,99 @@ val create : ?capacity:int -> dummy:'a -> 'a t[@@gospel
       requires let capacity = match capacity with
                  | None -> 0 | Some c -> c in
                0 <= capacity <= Sys.max_array_length
-      ensures  length a.view = 0 |}]
+      ensures  Seq.length a.view = 0 |}]
 val make : ?dummy:'a -> int -> 'a -> 'a t[@@gospel
                                            {| a = make ?dummy n x
       requires 0 <= n <= Sys.max_array_length
-      ensures  length a.view = n
+      ensures  Seq.length a.view = n
       ensures  forall i: integer. 0 <= i < n -> a.view[i] = x |}]
 val init : dummy:'a -> int -> (int -> 'a) -> 'a t[@@gospel
                                                    {| a = init ~dummy n f
       requires 0 <= n <= Sys.max_array_length
-      ensures  length a.view = n
+      ensures  Seq.length a.view = n
       ensures  forall i: int. 0 <= i < n -> a.view[i] = f i |}]
 val resize : 'a t -> int -> unit[@@gospel
                                   {| resize a n
       checks   0 <= n <= Sys.max_array_length
       modifies a
-      ensures  length a.view = n
-      ensures  forall i. 0 <= i < min (length (old a.view)) n ->
+      ensures  Seq.length a.view = n
+      ensures  forall i. 0 <= i < min (Seq.length (old a.view)) n ->
                  a.view[i] = (old a.view)[i] |}]
 [@@@ocaml.text " {2 Array interface} "]
 val clear : 'a t -> unit[@@gospel
                           {| clear a
       modifies a
-      ensures length a.view = 0 |}]
+      ensures Seq.length a.view = 0 |}]
 val is_empty : 'a t -> bool[@@gospel
                              {| r = is_empty a
-      ensures r <-> length a.view = 0 |}]
+      ensures r <-> Seq.length a.view = 0 |}]
 val length : 'a t -> int[@@gospel
                           {| n = length a
-      ensures n = length a.view |}]
+      ensures n = Seq.length a.view |}]
 val get : 'a t -> int -> 'a[@@gospel
                              {| x = get a i
-      requires 0 <= i < length a.view
+      requires 0 <= i < Seq.length a.view
       ensures  x = a.view[i] |}]
 val set : 'a t -> int -> 'a -> unit[@@gospel
                                      {| set a i x
-      requires 0 <= i < length a.view
+      requires 0 <= i < Seq.length a.view
       modifies a
-      ensures length a.view = length (old a).view
+      ensures Seq.length a.view = Seq.length (old a).view
       ensures  a.view[i] = x
-      ensures  forall j. 0 <= j < length a.view -> j <> i ->
+      ensures  forall j. 0 <= j < Seq.length a.view -> j <> i ->
                  a.view[j] = (old a).view[j] |}]
 val sub : 'a t -> int -> int -> 'a t[@@gospel
                                       {| r = sub a ofs n
-      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= length a.view
-      ensures  length r.view = n
+      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Seq.length a.view
+      ensures  Seq.length r.view = n
       ensures  forall i. 0 <= i < n -> r.view[i] = a.view[ofs + i] |}]
 val fill : 'a t -> int -> int -> 'a -> unit[@@gospel
                                              {| fill a ofs n x
-      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= length a.view
+      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Seq.length a.view
       modifies a
-      ensures  forall i. (0 <= i < ofs \/ ofs + n <= i < length a.view) ->
+      ensures  forall i. (0 <= i < ofs \/ ofs + n <= i < Seq.length a.view) ->
                  a.view[i] = (old a).view[i]
       ensures  forall i. ofs <= i < ofs + n -> a.view[i] = x |}]
 val blit : 'a t -> int -> 'a t -> int -> int -> unit[@@gospel
                                                       {| blit a1 ofs1 a2 ofs2 n
       requires 0 <= n
-      requires 0 <= ofs1 /\ ofs1 + n <= length a1.view
-      requires 0 <= ofs2 /\ ofs2 + n <= length a2.view
+      requires 0 <= ofs1 /\ ofs1 + n <= Seq.length a1.view
+      requires 0 <= ofs2 /\ ofs2 + n <= Seq.length a2.view
       modifies a2
-      ensures  forall i. (0 <= i < ofs2 \/ ofs2 + n <= i < length a2.view) ->
+      ensures  forall i. (0 <= i < ofs2 \/ ofs2 + n <= i < Seq.length a2.view) ->
                          a2.view[i] = (old a2).view[i]
       ensures  forall i. ofs2 <= i < ofs2 + n ->
                          a2.view[i] = (old a1).view[ofs1 + i - ofs2] |}]
 val append : 'a t -> 'a t -> 'a t[@@gospel
                                    {| a3 = append a1 a2
-      requires length a1.view + length a2.view <= Sys.max_array_length
-      ensures  length a3.view = length a1.view + length a2.view
-      ensures  forall i. 0 <= i < length a1.view -> a3.view[i] = a1.view[i]
-      ensures  forall i. 0 <= i < length a2.view ->
-                 a3.view[length a1.view + i] = a2.view[i] |}]
+      requires Seq.length a1.view + Seq.length a2.view <= Sys.max_array_length
+      ensures  Seq.length a3.view = Seq.length a1.view + Seq.length a2.view
+      ensures  forall i. 0 <= i < Seq.length a1.view -> a3.view[i] = a1.view[i]
+      ensures  forall i. 0 <= i < Seq.length a2.view ->
+                 a3.view[Seq.length a1.view + i] = a2.view[i] |}]
 val merge_right : 'a t -> 'a t -> unit[@@gospel
                                         {| merge_right a1 a2
-      requires length a1.view + length a2.view <= Sys.max_array_length
+      requires Seq.length a1.view + Seq.length a2.view <= Sys.max_array_length
       modifies a1, a2
-      ensures  length a2.view = 0
-      ensures  length a1.view = length (old a1).view + length (old a2).view
-      ensures  forall i. 0 <= i < length (old a1).view ->
+      ensures  Seq.length a2.view = 0
+      ensures  Seq.length a1.view = Seq.length (old a1).view + Seq.length (old a2).view
+      ensures  forall i. 0 <= i < Seq.length (old a1).view ->
                  a1.view[i] = (old a1).view[i]
-      ensures  forall i. 0 <= i < length (old a2).view ->
-                 a1.view[length (old a1).view + i] = (old a2).view[i] |}]
+      ensures  forall i. 0 <= i < Seq.length (old a2).view ->
+                 a1.view[Seq.length (old a1).view + i] = (old a2).view[i] |}]
 val map : dummy:'b -> 'a t -> ('a -> 'b) -> 'b t[@@gospel
                                                   {| a2 = map ~dummy a1 f
-      ensures  length a2.view = length a1.view
-      ensures  forall i. 0 <= i < length a1.view -> a2.view[i] = f a1.view[i] |}]
+      ensures  Seq.length a2.view = Seq.length a1.view
+      ensures  forall i. 0 <= i < Seq.length a1.view -> a2.view[i] = f a1.view[i] |}]
 val mapi : dummy:'b -> 'a t -> (int -> 'a -> 'b) -> 'b t[@@gospel
                                                           {| a2 = mapi ~dummy a1 f
-      ensures  length a2.view = length a1.view
-      ensures  forall i: int. 0 <= i < length a1.view ->
+      ensures  Seq.length a2.view = Seq.length a1.view
+      ensures  forall i: int. 0 <= i < Seq.length a1.view ->
                a2.view[i] = f i a1.view[i] |}]
 val copy : 'a t -> 'a t[@@gospel
                          {| a2 = copy a1
-      ensures  length a2.view = length a1.view
-      ensures  forall i. 0 <= i < length a1.view -> a2.view[i] = a1.view[i] |}]
+      ensures  Seq.length a2.view = Seq.length a1.view
+      ensures  forall i. 0 <= i < Seq.length a1.view -> a2.view[i] = a1.view[i] |}]
 val fold_left : 'b t -> ('a -> 'b -> 'a) -> 'a -> 'a[@@gospel
                                                       {| r = fold_left a f acc
       ensures  r = Seq.fold_left f acc a.view |}]
@@ -117,39 +116,39 @@ val fold_right : 'b t -> ('b -> 'a -> 'a) -> 'a -> 'a[@@gospel
   " {2 Stack interface}\n\n    Contrary to standard library's {!Stack}, module {!Vector} uses less space\n    (between N and 2N words, instead of 3N) and has better data locality. "]
 val push : 'a t -> 'a -> unit[@@gospel
                                {| push a x
-      requires length a.view < Sys.max_array_length
+      requires Seq.length a.view < Sys.max_array_length
       modifies a
-      ensures  length a.view = length (old a.view) + 1
-      ensures  a.view[length a.view - 1] = x
-      ensures  forall i. 0 <= i < length (old a.view) ->
+      ensures  Seq.length a.view = Seq.length (old a.view) + 1
+      ensures  a.view[Seq.length a.view - 1] = x
+      ensures  forall i. 0 <= i < Seq.length (old a.view) ->
                  a.view[i] = (old a).view[i] |}]
 exception Empty 
 val pop : 'a t -> 'a[@@gospel
                       {| x = pop a
       modifies a
-      raises   Empty -> length a.view = length (old a).view = 0
-      ensures  length a.view = length (old a).view - 1
-      ensures  x = (old a).view[length a.view]
-      ensures  forall i. 0 <= i < length a.view ->
+      raises   Empty -> Seq.length a.view = Seq.length (old a).view = 0
+      ensures  Seq.length a.view = Seq.length (old a).view - 1
+      ensures  x = (old a).view[Seq.length a.view]
+      ensures  forall i. 0 <= i < Seq.length a.view ->
                  a.view[i] = (old a).view[i] |}]
 val pop_opt : 'a t -> 'a option[@@gospel
                                  {| r = pop_opt a
       modifies a
       ensures  match r with
-               | None   -> length a.view = length (old a).view = 0
-               | Some x -> length a.view = length (old a).view - 1 /\
-                           x = (old a).view[length a.view] /\
-                           forall i. 0 <= i < length a.view ->
+               | None   -> Seq.length a.view = Seq.length (old a).view = 0
+               | Some x -> Seq.length a.view = Seq.length (old a).view - 1 /\
+                           x = (old a).view[Seq.length a.view] /\
+                           forall i. 0 <= i < Seq.length a.view ->
                                      a.view[i] = (old a).view[i] |}]
 val top : 'a t -> 'a[@@gospel
                       {| x = top a
-      requires 0 < length a.view
-      ensures  x = a.view[length a.view - 1] |}]
+      requires 0 < Seq.length a.view
+      ensures  x = a.view[Seq.length a.view - 1] |}]
 val top_opt : 'a t -> 'a option[@@gospel
                                  {| r = top_opt a
       ensures  match r with
-               | None   -> length a.view = 0
-               | Some x -> x = a.view[length a.view - 1] |}]
+               | None   -> Seq.length a.view = 0
+               | Some x -> x = a.view[Seq.length a.view - 1] |}]
 [@@@ocaml.text " {2 Conversions to/from arrays and lists} "]
 [@@@ocaml.text " {2 Only if you know what you are doing...} "]
 
@@ -161,9 +160,7 @@ val top_opt : 'a t -> 'a option[@@gospel
 [@@@ocaml.text
   " Vectors (aka resizable arrays, growing arrays, dynamic arrays, etc.)\n\n    This module implements arrays that automatically expand as necessary.\n    Its implementation uses a traditional array and replaces it with a\n    larger array when needed (and elements are copied from the old array\n    to the new one). The current implementation doubles the capacity when\n    growing the array (and shrinks it whenever the number of elements\n    comes to one fourth of the capacity).\n\n    The unused part of the internal array is filled with a dummy value,\n    which is user-provided at creation time (and referred to below\n    as ``the dummy value''). Consequently, vectors do not retain pointers\n    to values that are not used anymore after a shrinking.\n\n    Vectors provide an efficient implementation of stacks, with a\n    better locality of reference than list-based implementations (such\n    as standard library {!Stack}). A stack interface is provided,\n    similar to that of {!Stack} (though {!Vector.push} have arguments\n    in the other way round). Inserting [n] elements with\n    {!Vector.push} has overall complexity O(n) i.e. each insertion has\n    amortized constant time complexity. "]
 
-(*@ open Seq *)
-
-type 'a t[@@gospel {| invariant length view <= Sys.max_array_length |}]
+type 'a t[@@gospel {| invariant Seq.length view <= Sys.max_array_length |}]
   (*@ ephemeral
       model ...
        *)
@@ -371,8 +368,6 @@ module Vector.mli
     
     [@@@ocaml.text
       " Vectors (aka resizable arrays, growing arrays, dynamic arrays, etc.)\n\n    This module implements arrays that automatically expand as necessary.\n    Its implementation uses a traditional array and replaces it with a\n    larger array when needed (and elements are copied from the old array\n    to the new one). The current implementation doubles the capacity when\n    growing the array (and shrinks it whenever the number of elements\n    comes to one fourth of the capacity).\n\n    The unused part of the internal array is filled with a dummy value,\n    which is user-provided at creation time (and referred to below\n    as ``the dummy value''). Consequently, vectors do not retain pointers\n    to values that are not used anymore after a shrinking.\n\n    Vectors provide an efficient implementation of stacks, with a\n    better locality of reference than list-based implementations (such\n    as standard library {!Stack}). A stack interface is provided,\n    similar to that of {!Stack} (though {!Vector.push} have arguments\n    in the other way round). Inserting [n] elements with\n    {!Vector.push} has overall complexity O(n) i.e. each insertion has\n    amortized constant time complexity. "]
-    
-    (*@ open Seq *)
     
     type 'a t
          (*@ ephemeral

--- a/test/vocal/ZipperList.mli
+++ b/test/vocal/ZipperList.mli
@@ -8,27 +8,25 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ open Seq *)
-
 (** Zippers for lists *)
 
 type 'a t
 (*@ model seq: 'a seq
     model idx: integer
-    invariant 0 <= idx <= length seq *)
+    invariant 0 <= idx <= Seq.length seq *)
 
 val empty : unit -> 'a t
 (*@ z = empty ()
-    ensures z.seq == empty
+    ensures z.seq == Seq.empty
     ensures z.idx = 0 *) (* could be deduced from invariant *)
 
 val is_empty : 'a t -> bool
 (*@ b = is_empty z
-    ensures b <-> z.seq == empty *)
+    ensures b <-> z.seq == Seq.empty *)
 
 val length : 'a t -> int
 (*@ r = length z
-    ensures r = length z.seq *)
+    ensures r = Seq.length z.seq *)
 
 val to_list : 'a t -> 'a list
 (*@ l = to_list z
@@ -63,32 +61,32 @@ val move_all_left : 'a t -> 'a t
 
 val move_right : 'a t -> 'a t
 (*@ r = move_right z
-    requires z.idx < length z.seq
+    requires z.idx < Seq.length z.seq
     ensures  r.seq == z.seq
     ensures  r.idx = z.idx + 1 *)
 
 val insert_right : 'a -> 'a t -> 'a t
 (*@ r = insert_right x z
-    ensures  r.seq == z.seq[.. z.idx] ++ cons x z.seq[z.idx ..]
+    ensures  r.seq == z.seq[.. z.idx] ++ Seq.cons x z.seq[z.idx ..]
     ensures  r.idx = z.idx *)
 
 val remove_right : 'a t -> 'a t
 (*@ r = remove_right z
-    requires z.idx < length z.seq
+    requires z.idx < Seq.length z.seq
     ensures  r.seq == z.seq[.. z.idx] ++ z.seq[z.idx + 1 ..]
     ensures  r.idx = z.idx *)
 
 val move_all_right : 'a t -> 'a t
 (*@ r = move_all_right z
     ensures r.seq == z.seq
-    ensures r.idx = length z.seq *)
+    ensures r.idx = Seq.length z.seq *)
 
 val is_focused : 'a t -> bool
 (*@ b = is_focused z
-    ensures b <-> z.idx < length z.seq *)
+    ensures b <-> z.idx < Seq.length z.seq *)
 
 val focused : 'a t -> 'a option
 (*@ r = focused z
     ensures match r with
-            | None   -> z.idx = length z.seq
-            | Some x -> z.idx < length z.seq /\ x = z.seq[z.idx] *)
+            | None   -> z.idx = Seq.length z.seq
+            | Some x -> z.idx < Seq.length z.seq /\ x = z.seq[z.idx] *)

--- a/test/vocal/ZipperList.mli.expected
+++ b/test/vocal/ZipperList.mli.expected
@@ -2,22 +2,21 @@
 *******************************
 ********** Parsed file ********
 *******************************
-[@@@gospel {| open Seq |}]
 [@@@ocaml.text " Zippers for lists "]
 type 'a t[@@gospel
            {| model seq: 'a seq
     model idx: integer
-    invariant 0 <= idx <= length seq |}]
+    invariant 0 <= idx <= Seq.length seq |}]
 val empty : unit -> 'a t[@@gospel
                           {| z = empty ()
-    ensures z.seq == empty
+    ensures z.seq == Seq.empty
     ensures z.idx = 0 |}]
 val is_empty : 'a t -> bool[@@gospel
                              {| b = is_empty z
-    ensures b <-> z.seq == empty |}]
+    ensures b <-> z.seq == Seq.empty |}]
 val length : 'a t -> int[@@gospel
                           {| r = length z
-    ensures r = length z.seq |}]
+    ensures r = Seq.length z.seq |}]
 val to_list : 'a t -> 'a list[@@gospel
                                {| l = to_list z
     ensures z.seq == l |}]
@@ -45,37 +44,35 @@ val move_all_left : 'a t -> 'a t[@@gospel
       ensures r.idx = 0 |}]
 val move_right : 'a t -> 'a t[@@gospel
                                {| r = move_right z
-    requires z.idx < length z.seq
+    requires z.idx < Seq.length z.seq
     ensures  r.seq == z.seq
     ensures  r.idx = z.idx + 1 |}]
 val insert_right : 'a -> 'a t -> 'a t[@@gospel
                                        {| r = insert_right x z
-    ensures  r.seq == z.seq[.. z.idx] ++ cons x z.seq[z.idx ..]
+    ensures  r.seq == z.seq[.. z.idx] ++ Seq.cons x z.seq[z.idx ..]
     ensures  r.idx = z.idx |}]
 val remove_right : 'a t -> 'a t[@@gospel
                                  {| r = remove_right z
-    requires z.idx < length z.seq
+    requires z.idx < Seq.length z.seq
     ensures  r.seq == z.seq[.. z.idx] ++ z.seq[z.idx + 1 ..]
     ensures  r.idx = z.idx |}]
 val move_all_right : 'a t -> 'a t[@@gospel
                                    {| r = move_all_right z
     ensures r.seq == z.seq
-    ensures r.idx = length z.seq |}]
+    ensures r.idx = Seq.length z.seq |}]
 val is_focused : 'a t -> bool[@@gospel
                                {| b = is_focused z
-    ensures b <-> z.idx < length z.seq |}]
+    ensures b <-> z.idx < Seq.length z.seq |}]
 val focused : 'a t -> 'a option[@@gospel
                                  {| r = focused z
     ensures match r with
-            | None   -> z.idx = length z.seq
-            | Some x -> z.idx < length z.seq /\ x = z.seq[z.idx] |}]
+            | None   -> z.idx = Seq.length z.seq
+            | Some x -> z.idx < Seq.length z.seq /\ x = z.seq[z.idx] |}]
 
 *******************************
 ****** GOSPEL translation *****
 *******************************
 (*@ open Gospelstdlib *)
-
-(*@ open Seq *)
 
 [@@@ocaml.text " Zippers for lists "]
 
@@ -196,8 +193,6 @@ module ZipperList.mli
   Signatures
     (*@ open Gospelstdlib *)
     
-    (*@ open Seq *)
-    
     [@@@ocaml.text " Zippers for lists "]
     
     type 'a t
@@ -205,8 +200,7 @@ module ZipperList.mli
              model seq : 'a seq_1
              model idx : integer
              invariant (0:integer <= (idx_1 ):integer):prop /\ ((idx_1 ):
-                       integer <= (length 
-                       (seq_2 ):'a191 seq_1):integer):prop *)
+                       integer <= (length  (seq_2 ):'a39 seq_1):integer):prop *)
     
     val empty : unit -> 'a t
     (*@ z:'a t = empty ()
@@ -225,11 +219,11 @@ module ZipperList.mli
     
     val to_list : 'a t -> 'a list
     (*@ l:'a list = to_list z_3:'a t
-        ensures ((z_3:'a t).seq == (seq_of_list  l:'a list):'a seq_1):prop*)
+        ensures ((z_3:'a t).seq == (to_seq  l:'a list):'a seq_1):prop*)
     
     val make : 'a list -> 'a t
     (*@ z_4:'a t = make l_1:'a list
-        ensures ((z_4:'a t).seq == (seq_of_list  l_1:'a list):'a seq_1):prop
+        ensures ((z_4:'a t).seq == (to_seq  l_1:'a list):'a seq_1):prop
                 ensures ((z_4:'a t).idx = 0:integer):prop*)
     
     val move_left : 'a t -> 'a t


### PR DESCRIPTION
When `open`ing a module, it should still be possible to define a type (or exception) symbol that is exposed in the opened module.
On top of #6.