### PR TITLE
Remove some unused stdlib functions

### DIFF
--- a/src/stdlib/gospelstdlib.mli
+++ b/src/stdlib/gospelstdlib.mli
@@ -126,8 +126,6 @@ type int
 
 (** {1 Sequences} *)
 
-(*@ predicate (==) (s1 s2: 'a seq) *)
-
 (*@ function (++) (s s': 'a seq) : 'a seq *)
 (** [s ++ s'] is the sequence [s] followed by the sequence [s']. *)
 
@@ -194,9 +192,6 @@ module Seq : sig
 
   (*@ function set (s: 'a t) (i: integer) (x: 'a): 'a t *)
   (** [set s i x] is the sequence [s] where the [i]th element is [x]. *)
-
-  (*@ function ([<-]) (s: 'a seq) (i: integer) (x: 'a): 'a seq *)
-  (** [s\[i\] <- x] is [set s i x]. *)
 
   (*@ function rev (s: 'a seq) : 'a seq *)
   (** [rev s] is the sequence containing the same elements as [s], in reverse

--- a/test/positive/a3.mli.expected
+++ b/test/positive/a3.mli.expected
@@ -59,7 +59,6 @@ module a3.mli
               function infix / (_:integer) (_:integer) : integer
               predicate infix < (_:integer) (_:integer)
               predicate infix <= (_:integer) (_:integer)
-              predicate infix == (_:'a seq) (_:'a seq)
               predicate infix > (_:integer) (_:integer)
               predicate infix >= (_:integer) (_:integer)
               function integer_of_int (_:int) : integer
@@ -257,8 +256,6 @@ module a3.mli
                   function length_2 (_:'a seq) : integer
                   function map_3 (_:'a -> 'b) (_:'a seq) : 'b seq
                   predicate mem_3 (_:'a seq) (_:'a)
-                  function mixfix [<-]_1 (_:'a seq) (_:integer) (_:'a) : 'a 
-                  seq
                   function return (_:'a) : 'a seq
                   function rev_1 (_:'a seq) : 'a seq
                   function set_1 (_:'a seq) (_:integer) (_:'a) : 'a seq


### PR DESCRIPTION
- `==` is not necessary; it's just `=`, and it is also confusing. `==` should probably be the physical equality instead.
- `[<-]` over sequences: infixes inside modules are not a great idea IMO, since it forces you to open modules. Having it at the top-level conflicts with the function substitution.