### PR TITLE
Language specification tweaks

### DIFF
--- a/docs/docs/language/constants-specifications.md
+++ b/docs/docs/language/constants-specifications.md
@@ -2,10 +2,10 @@
 sidebar_position: 5
 ---
 
-# Constants specifications
+# Constant specifications
 
-OCaml constants specifications are simple. They consist in a list of clauses
-starting with the `ensures` keyword, and followed by a formula.
+OCaml constant specifications are simple. They consist of a list of clauses
+starting with the `ensures` keyword followed by a formula.
 
 ```ebnf title="Constant specification syntax"
 constant_specification = ("ensures" expr)*
@@ -18,4 +18,4 @@ val argv : string array
 (*@ ensures Array.length argv >= 1 *)
 ```
 
-These clauses hold at the end of the evaluation of the module.
+These clauses hold at the end of evaluating the surrounding module.

--- a/docs/docs/language/formulae.md
+++ b/docs/docs/language/formulae.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 # Terms and Formulae
 
 Gospel features terms (e.g. `x+1`) and formulae (e.g. `forall i. f i > 0`). This
-distinction is made during the type-checking, and not at the syntax level. In
+distinction is made during type checking, and not at the syntax level. In
 the following, `expr` stands for a Gospel expression, be it a term or a formula.
 
 ## Type expressions
@@ -14,15 +14,15 @@ Type expressions follow the OCaml syntax.
 
 ```ebnf
 typexpr = lname
-        | "'", lident
-        | "(", typexpr, ")"
-        | typexpr, lpath
-        | typexpr, { ",", typexpr }
-        | (?"?, lident, ":")?, typexpr, "->", typexpr
-        | typexpr, ("*", typexpr)+
-lpath = (upath, ".")?, lident
+        | "'" lident
+        | "(" typexpr ")"
+        | typexpr lpath
+        | typexpr, { "," typexpr }
+        | (?"? lident ":")? typexpr "->" typexpr
+        | typexpr ("*" typexpr)+
+lpath = (upath ".")? lident
 upath = uident
-      | upath, ".", uident
+      | upath "." uident
 ```
 
 ## Expressions

--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -27,7 +27,7 @@ A function contract is composed of two parts:
    In the absence of a contract attached to a function declaration, you cannot
    make any assumptions about its behaviour.
 
-   Post-Conditions may not hold, the function may diverge, raise unlisted
+   Post-conditions may not hold, the function may diverge, raise unlisted
    exceptions, modify mutable states. However, **it still cannot break any type
    invariant.**
 
@@ -63,7 +63,7 @@ parameter = "()" | identifier | "~" identifier | "?" identifier
 ##  Default behaviour
 
 To avoid boilerplate for usual properties, Gospel applies a default contract
-whenever a function contains has a specification attached. Of course, any
+whenever a function has a specification attached. Of course, any
 explicitly declared clause overrides this implicit contract.
 
 When a function has a contract attached, the default contract contains the
@@ -77,16 +77,16 @@ following properties:
 
 ## Pre-conditions
 
-Pre-conditions are **properties that hold at the function entry**. You can use
+Pre-conditions are **properties that must hold at the function entry**. You can use
 them to describe requirements on the function's inputs, but also possibly on a
 global state that exists outside of the function arguments.
 
-You can expressed them using the keyword `requires` or `checks`, followed by a
+You can express pre-conditions using the keyword `requires` or `checks`, followed by a
 formula.
 
 ### `requires`
 
-A `requires` clause states under which conditions specified function has a
+A `requires` clause states under which conditions a specified function has a
 well-specified behaviour.
 
 Whenever a `requires` pre-condition is violated, its behaviour becomes
@@ -94,7 +94,7 @@ unspecified, and the call should be considered faulty. Even if the function
 execution terminates, any other information provided by the contract
 (post-conditions, exceptions, effects, ...) cannot be assumed.
 
-In our example, the function requires `y` to be positive to behave correctly.
+For example, the following function requires `y` to be positive to behave correctly.
 
 ```ocaml {3}
 val eucl_division: int -> int -> int * int
@@ -112,8 +112,9 @@ pre-state does not meet such a pre-condition: the function fails by raising an
 OCaml `Invalid_argument` exception, and does not modify any existing state. The
 call is not faulty, but the caller is now in charge of handling the exception.
 
-The same function contract, where `requires` is replaced with `checks`, states
-that the function raises `Invalid_argument` whenever `y <= 0`.
+For example, if we change the function contract of `eucl_division`
+above by replacing `requires` with `checks`, it now states that the
+function raises `Invalid_argument` whenever `y <= 0`.
 
 :::note Combining multiple pre-conditions
 
@@ -156,7 +157,7 @@ is equivalent to:
 
 Specification formulas can often be written using few clauses, but splitting the
 specification into several smaller clauses leads to better readability and
-maintainability and is encouraged.
+maintainability and is therefore encouraged.
 
 :::
 
@@ -253,7 +254,7 @@ this case).
 
 :::note Combining multiple exceptional post-conditions
 
-When multiple exceptional post-conditions exist, they are hold independently of
+When multiple exceptional post-conditions exist, they hold independently of
 each other, meaning that the raised exception is matched against each `raises`'s
 case list, and each matching post-condition must hold in conjunction. For
 instance, the contract:
@@ -278,7 +279,7 @@ Complementary to other specification clauses, Gospel allows you to talk about
 *code equivalence* in the function contract. It consists in a string containing
 the OCaml code the function behaves like, preceded by the `equivalent` keyword.
 
-This is useful when specifying functions which behaviour can hardly be expressed
+This is useful when specifying functions whose behaviour can hardly be expressed
 in pure logic:
 
 ```ocaml
@@ -303,7 +304,7 @@ inside the `equivalent` clauses, and will take it as-is.
 
 ## Non termination
 
-By default, OCaml functions with attached contract implicitly terminate.
+By default, OCaml functions with an attached contract implicitly terminate.
 
 If a function is allowed to not terminate (e.g. a server main loop, a function
 waiting for a signal or event, etc.), one can add this information to the
@@ -336,7 +337,7 @@ If the function only modifies a few models of a value, these may be explicitly
 added to the clause.
 
 
-If a specific model is not mentioned, the whole data-structure and its mutable
+If a specific model is not mentioned, the whole data structure and its mutable
 models are potentially mutated.
 
 ```ocaml {3}
@@ -386,14 +387,23 @@ in specifications.
 
 Gospel provides a specific syntax to specify that some data has been consumed by
 the function, and should be considered dirty — that is, not be used anymore — in
-the rest of the program.
+the rest of the program. This is expressed with the `consumes`
+keyword:
+
+```ocaml
+val destructive_transfer: 'a t -> 'a t -> unit
+(*@ destructive_transfer src dst
+    consumes src
+    ... *)
+```
+
 
 ## Ghost parameters
 
 Functions can take or return ghost values to ease the writing of function
 contracts. Such values appear within brackets in the contract header.
 
-Let us consider the following `log2` function:
+Consider the following `log2` function:
 
 ```ocaml
 val log2: int -> int
@@ -404,7 +414,7 @@ val log2: int -> int
 ```
 
 In this contract, the ghost parameter `i` is used in both the pre- and
-postcondition. By introducing it as a ghost value, we avoid using quantifiers to
+post-conditions. By introducing it as a ghost value, we avoid using quantifiers to
 state the existence of `i`.
 
 :::note

--- a/docs/docs/language/lexical-conventions.md
+++ b/docs/docs/language/lexical-conventions.md
@@ -4,9 +4,11 @@ sidebar_position: 2
 
 # Lexical conventions
 
-Gospel borrows most [OCaml lexical
-conventions](https://caml.inria.fr/pub/docs/manual-ocaml/lex.html), with the
-following exceptions:
+Gospel borrows most of [OCaml's lexical
+conventions](https://caml.inria.fr/pub/docs/manual-ocaml/lex.html).
+This means that the whitespace rules are the same, that the same kind
+of variable names are allowed, that integers are written the same way,
+etc. There are however a number of exceptions:
 
 - There are reserved keywords:
   ```
@@ -15,7 +17,7 @@ following exceptions:
   exists    forall    invariant   predicate
   ```
 
-- there are reserved symbols:
+- There are reserved symbols:
   ```
   <->    /\    \/
   ```

--- a/docs/docs/language/locations.md
+++ b/docs/docs/language/locations.md
@@ -28,7 +28,7 @@ inside module signatures:
 Specification bits which are semantically attached to OCaml declarations (e.g.
 [function contracts](function-contracts.md) or [type
 specifications](type-specifications.md)) should be written in an attached
-attribute, following OCaml's attachement rules:
+attribute, following OCaml's attachment rules:
 
 ```ocaml
 val f: int -> int
@@ -59,12 +59,12 @@ starting with the `@` character[^1]:
 
 ```ocaml
 val f: int -> int           (* An OCaml value declaration *)
-(*@ y = f x         
+(*@ y = f x
     ensures x > 0 *)        (* Its Gospel specification   *)
 
 (*@ type t *)               (* A ghost type declaration   *)
-(*@ ephemeral         
-    model size: int *)      (* Its Gospel specification   *)      
+(*@ ephemeral
+    model size: int *)      (* Its Gospel specification   *)
 ```
 
 Although the preprocessor is available via the `gospel pps` command, it is also
@@ -87,7 +87,7 @@ comments, *e.g.* as follows:
 ```ocaml
 val eucl_division: int -> int -> int * int
 (** this is an implementation of Euclidean division *)
-(*@ q, r = eucl_division x y 
+(*@ q, r = eucl_division x y
     ... *)
 ```
 

--- a/docs/docs/language/logical.md
+++ b/docs/docs/language/logical.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 ## Functions and Predicates
 
-It is often convenient to introduce shortcuts for terms and formulas and avoid
+It is often convenient to introduce shortcuts for terms and formulas to avoid
 repetitions. *Predicates* let you write named formulae definitions in Gospel
 comments. Here is a typical example:
 
@@ -17,7 +17,7 @@ comments. Here is a typical example:
 ```
 
 We can then reuse the predicate `is_sorted` inside any Gospel annotations such
-as function contracts.
+as function contracts:
 
 ```ocaml
 val merge: int array -> int array -> int array
@@ -33,8 +33,8 @@ Similarly, one can define a shortcut for terms using Gospel's *functions*.
 (*@ function powm (x y m: integer) : integer = mod (pow x y) m *)
 ```
 
-Such a definition may be recursive. In this case, the `rec` keyword is
-necessary.
+Both predicate definitions and function definitions may be
+recursive. A recursive definition requires the `rec` keyword like in OCaml:
 
 ```ocaml
 (*@ predicate rec is_sorted_list (l: int list) = match l with
@@ -65,13 +65,13 @@ follows:
 ```ocaml
 (*@ function fibonacci (n: integer) : integer *)
 
-(*@ axiom fibonacci_def : forall n. n >= 0 -> 
-      fibonacci n = 
-        if n <= 1 then n 
+(*@ axiom fibonacci_def : forall n. n >= 0 ->
+      fibonacci n =
+        if n <= 1 then n
         else fibonacci (n-2) + fibonacci (n-1) *)
 ```
 
-Logical symbols can also come with postconditions. For instance, we can assert
+Logical symbols can also come with post-conditions. For instance, we can assert
 that Fibonacci numbers are non-negative:
 
 ```ocaml {4}
@@ -86,18 +86,18 @@ that Fibonacci numbers are non-negative:
 Note that as opposed to OCaml function contracts, logical function contracts do
 not have a header. Consequently, a variable called `result` is automatically
 introduced in the context by Gospel to refer to the value returned by the
-function in a postcondition.
+function in a post-condition.
 
 :::
 
-The postcondition of `fibonacci` is equivalent to adding an axiom along with an
+The post-condition of `fibonacci` is equivalent to adding an axiom along with an
 uninterpreted counterpart.
 
 ```ocaml
 (*@ axiom fibonacci_post : forall n. n >= 0 -> fibonacci n >= 0 *)
 ```
 
-Note that the postcondition holds only when the precondition holds.
+Note that the post-condition holds only when the pre-condition holds.
 
 :::danger
 

--- a/docs/docs/language/type-specifications.md
+++ b/docs/docs/language/type-specifications.md
@@ -2,7 +2,7 @@
 sidebar_position: 4
 ---
 
-# Types specifications
+# Type specifications
 
 OCaml types can be annotated with Gospel specifications in order to model their
 contents and express invariants. Consider the following example of a container
@@ -20,12 +20,12 @@ The specification of this type contains three elements:
    domain. `capacity` is an immutable model of type `int` representing the
    maximum length of the data-structure, and `contents` is a mutable set
    representing its contents. Note that `Set.t` references a logical set
-   provided by Gospel standard library. Models do not give any information on
-   the actual implementation of `t`.
+   provided by Gospel's [standard library](../stdlib). Models do not
+   give any information on the actual implementation of `t`.
  - the last line is a clause denoting a type invariant. At all times, values of
    type `t` should contain less elements that their maximum capacity.
 
-Types specifications can contain models, invariants, and mutability information.
+Type specifications can contain models, invariants, and mutability information.
 
 ```ebnf title="Type specification syntax"
 type_specification = type-specification-clause*
@@ -39,7 +39,7 @@ type_specification_clause =
 
 Type models are logical projections of OCaml types. They help specify the type
 invariants and contents at several locations of the program, without actually
-exposing them and leaking implementations details.
+exposing them and leaking implementation details.
 
 The keyword `model` is used to introduce a new model. It may be preceded by the
 keyword `mutable` to denote that the model may be mutated during the execution
@@ -70,7 +70,7 @@ Of course, a type that has a mutable model is considered mutable, so the
 ## Invariants
 
 Type annotations may also contain invariants that hold at every entry and exit
-point of every fonction that manipulates their values. Formulae expressing these
+point of every function that manipulates their values. Formulae expressing these
 properties may be added after the `invariant` keyword:
 
 ```ocaml {4}


### PR DESCRIPTION
Here's another round of tweaks, this time for the language specification
- Again most of it is just minor English language tweaking
- At a few places I elaborated a bit more
- In `formulae.md` I was puzzled to find commas in typexpr's ebnf when they are not used in the other.
  I'm guessing they are a left-over from some other type-setting. The PR therefore removes them.