### PR TITLE
remove dead code

### DIFF
--- a/src/tterm.ml
+++ b/src/tterm.ml
@@ -16,7 +16,6 @@ module Ident = Identifier.Ident
 type pattern = {
   p_node : pattern_node;
   p_ty : ty;
-  p_vars : Svs.t; [@printer fun fmt _ -> fprintf fmt "<Svs.t>"]
   p_loc : Location.t option; [@printer fun fmt _ -> fprintf fmt "<Location.t>"]
 }
 [@@deriving show]

--- a/src/tterm_helper.ml
+++ b/src/tterm_helper.ml
@@ -98,28 +98,19 @@ let ls_app_inst ls tl ty =
 
 (** Pattern constructors *)
 
-let mk_pattern p_node p_ty p_vars = { p_node; p_ty; p_vars; p_loc = None }
+let mk_pattern p_node p_ty = { p_node; p_ty; p_loc = None }
 
-exception PDuplicatedVar of vsymbol
 exception EmptyCase
 
-let p_wild ty = mk_pattern Pwild ty Svs.empty
-let p_var vs = mk_pattern (Pvar vs) vs.vs_ty (Svs.singleton vs)
-
-let p_app ls pl ty =
-  let add v vars =
-    if Svs.mem v vars then raise (PDuplicatedVar v);
-    Svs.add v vars
-  in
-  let merge vars p = Svs.fold add vars p.p_vars in
-  let vars = List.fold_left merge Svs.empty pl in
-  mk_pattern (Papp (ls, pl)) ty vars
+let p_wild ty = mk_pattern Pwild ty
+let p_var vs = mk_pattern (Pvar vs) vs.vs_ty
+let p_app ls pl ty = mk_pattern (Papp (ls, pl)) ty
 
 (* CHECK ty matchs ls.ls_value *)
-let p_or p1 p2 = mk_pattern (Por (p1, p2)) p1.p_ty p1.p_vars
+let p_or p1 p2 = mk_pattern (Por (p1, p2)) p1.p_ty
 
 (* CHECK vars p1 = vars p2 *)
-let p_as p vs = mk_pattern (Pas (p, vs)) p.p_ty p.p_vars
+let p_as p vs = mk_pattern (Pas (p, vs)) p.p_ty
 (* CHECK type vs = type p *)
 
 (** Terms constructors *)

--- a/src/tterm_helper.mli
+++ b/src/tterm_helper.mli
@@ -32,7 +32,7 @@ exception FunctionSymbolExpected of lsymbol
 
 val ls_arg_inst : lsymbol -> term list -> ty Mtv.t
 val ls_app_inst : lsymbol -> term list -> ty option -> ty Mtv.t
-val mk_pattern : pattern_node -> ty -> Svs.t -> pattern
+val mk_pattern : pattern_node -> ty -> pattern
 val p_wild : ty -> pattern
 val p_var : vsymbol -> pattern
 val p_app : lsymbol -> pattern list -> ty -> pattern

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -32,8 +32,6 @@ and labelled_arg =
 
 (* Patterns *)
 
-type ghost = bool
-
 type pattern = { pat_desc : pat_desc; pat_loc : Location.t }
 
 and pat_desc =


### PR DESCRIPTION
- type `ghost` in `uast.mli`, so that merlin does not call every bool a ghost.
- field `p_vars` of pattern (never accessed except for constructing pattern from patterns).