### PR TITLE
Add a new `equality` clause

### DIFF
--- a/src/tast.ml
+++ b/src/tast.ml
@@ -35,6 +35,7 @@ type val_spec = {
   sp_cs : term list;  (** Consumes *)
   sp_diverge : bool;  (** Diverges *)
   sp_pure : bool;  (** Pure *)
+  sp_equality : bool;  (** Equality *)
   sp_equiv : string list;  (** Equivalent *)
   sp_text : string;
       (** String containing the original specificaion as written by the user *)

--- a/src/tast_helper.ml
+++ b/src/tast_helper.ml
@@ -16,7 +16,7 @@ let ty_of_lb_arg = function
   | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> vs.vs_ty
 
 let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
-    sp_diverge sp_pure sp_equiv sp_text sp_loc =
+    sp_diverge sp_pure sp_equality sp_equiv sp_text sp_loc =
   {
     sp_args;
     sp_ret;
@@ -28,6 +28,7 @@ let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
     sp_cs;
     sp_diverge;
     sp_pure;
+    sp_equality;
     sp_equiv;
     sp_text;
     sp_loc;
@@ -35,12 +36,9 @@ let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
 
 (* Checks the following:
    1 - no duplicated args
-   2 - pre and post of type prop
-
-   TODO:
-   1 - check what to do with writes
-   2 - sp_xpost sp_reads sp_alias *)
-let mk_val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc =
+   2 - pre and post of type prop *)
+let mk_val_spec args ret pre checks post xpost wr cs dv pure equality equiv txt
+    loc =
   let add args = function
     | Lunit -> args
     | a ->
@@ -53,7 +51,7 @@ let mk_val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc =
   List.iter (ty_check None) pre;
   List.iter (ty_check None) checks;
   List.iter (ty_check None) post;
-  val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc
+  val_spec args ret pre checks post xpost wr cs dv pure equality equiv txt loc
 
 let mk_val_description vd_name vd_type vd_prim vd_attrs vd_args vd_ret vd_spec
     vd_loc =

--- a/src/tast_helper.mli
+++ b/src/tast_helper.mli
@@ -29,6 +29,7 @@ val mk_val_spec :
   term list ->
   bool ->
   bool ->
+  bool ->
   string list ->
   string ->
   Location.t ->

--- a/src/tast_printer.ml
+++ b/src/tast_printer.ml
@@ -108,19 +108,23 @@ let print_xposts f xposts =
     in
     List.iter print_xpost xposts
 
+let print_diverges f d = if not d then () else pp f "@\n@[diverges@]"
+let print_pure f d = if not d then () else pp f "@\n@[pure@]"
+let print_equality f d = if not d then () else pp f "@\n@[equality@]"
+
 let print_vd_spec val_id fmt spec =
   let print_term f t = pp f "@[%a@]" print_term t in
-  let print_diverges f d = if not d then () else pp f "@\n@[diverges@]" in
   match spec with
   | None -> ()
   | Some vs ->
-      pp fmt "(*@@ @[%a%s@ %a@ %a@]%a%a%a%a%a%a%a%a*)"
+      pp fmt "(*@@ @[%a%s@ %a@ %a@]%a%a%a%a%a%a%a%a%a%a*)"
         (list ~sep:comma print_lb_arg)
         vs.sp_ret
         (if vs.sp_ret = [] then "" else " =")
         Ident.pp val_id
         (list ~sep:sp print_lb_arg)
-        vs.sp_args print_diverges vs.sp_diverge
+        vs.sp_args print_diverges vs.sp_diverge print_pure vs.sp_pure
+        print_equality vs.sp_equality
         (list
            ~first:(newline ++ const string "requires ")
            ~sep:(newline ++ const string "requires ")

--- a/src/ttypes.ml
+++ b/src/ttypes.ml
@@ -66,6 +66,11 @@ let rec ty_equal x y =
       ts_equal tsx tsy && List.for_all2 ty_equal tylx tyly
   | _ -> false
 
+let rec ty_vars ty =
+  match ty.ty_node with
+  | Tyvar _ -> [ ty ]
+  | Tyapp (_, l) -> List.fold_left (fun acc ty -> ty_vars ty @ acc) l []
+
 module Ts = struct
   type t = tysymbol
 

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -763,8 +763,15 @@ let process_val_spec kid crcm ns id args ret vs =
     if wr <> [] then error_report ~loc "a pure function cannot have writes";
     if xpost <> [] || checks <> [] then
       error_report ~loc "a pure function cannot raise exceptions");
+  (if vs.sp_equality then
+   match (args, ret) with
+   | [ t1; t2 ], [ b ]
+     when ty_equal (ty_of_lb_arg t1) (ty_of_lb_arg t2)
+          && ty_equal (ty_of_lb_arg b) ty_bool ->
+       ()
+   | _, _ -> error_report ~loc "type is incompatible with equality clause");
   mk_val_spec args ret pre checks post xpost wr cs vs.sp_diverge vs.sp_pure
-    vs.sp_equiv vs.sp_text vs.sp_loc
+    vs.sp_equality vs.sp_equiv vs.sp_text vs.sp_loc
 
 let empty_spec preid ret args =
   {
@@ -777,6 +784,7 @@ let empty_spec preid ret args =
     sp_consumes = [];
     sp_diverge = false;
     sp_pure = false;
+    sp_equality = false;
     sp_equiv = [];
     sp_text = "";
     sp_loc = Location.none;

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -98,6 +98,7 @@ type val_spec = {
   sp_consumes : term list;
   sp_diverge : bool;
   sp_pure : bool;
+  sp_equality : bool;
   sp_equiv : string list;
   sp_text : string;
   sp_loc : Location.t;

--- a/src/ulexer.mll
+++ b/src/ulexer.mll
@@ -75,6 +75,7 @@
         "checks", CHECKS;
         "diverges", DIVERGES;
         "pure", PURE;
+        "equality", EQUALITY;
         "ephemeral", EPHEMERAL;
         "model", MODEL;
       ]

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -50,6 +50,7 @@
     sp_consumes= [];
     sp_diverge = false;
     sp_pure = false;
+    sp_equality = false;
     sp_equiv = [];
     sp_text = "";
     sp_loc = Location.none;
@@ -103,7 +104,7 @@
 %token COERCION
 %token IF IN
 %token OLD NOT RAISES
-%token THEN TRUE MODIFIES EQUIVALENT CHECKS DIVERGES PURE
+%token THEN TRUE MODIFIES EQUIVALENT CHECKS DIVERGES PURE EQUALITY
 
 %token AS
 %token LET MATCH PREDICATE
@@ -227,6 +228,8 @@ val_spec_body:
 | (* Empty spec *) { empty_vspec }
 | PURE bd=val_spec_body
   { {bd with sp_pure = true} }
+| EQUALITY bd=val_spec_body
+  { {bd with sp_equality = true} }
 | DIVERGES bd=val_spec_body
   { {bd with sp_diverge = true} }
 | MODIFIES wr=separated_list(COMMA, term) bd=val_spec_body

--- a/src/upretty_printer.ml
+++ b/src/upretty_printer.ml
@@ -63,9 +63,12 @@ let val_spec fmt vspec =
   match vspec with
   | None -> ()
   | Some vspec ->
+      let pure fmt x = if x then pp fmt "pure@\n" else () in
+      let equality fmt x = if x then pp fmt "equality@\n" else () in
       let diverge fmt x = if x then pp fmt "diverges@\n" else () in
       let print_content fmt s =
-        pp fmt "@[%a%a%a%a%a%a%a%a@]" (option spec_header) s.sp_header
+        pp fmt "@[%a%a%a%a%a%a%a%a%a%a@]" (option spec_header) s.sp_header
+          diverge s.sp_diverge pure s.sp_pure equality s.sp_equality
           (list_keyword "requires ...")
           s.sp_pre
           (list_keyword "ensures ...")
@@ -73,7 +76,7 @@ let val_spec fmt vspec =
           (list_keyword "modifies ...")
           s.sp_writes
           (list_keyword "consumes ...")
-          s.sp_consumes diverge s.sp_diverge
+          s.sp_consumes
           (list_keyword "equivalent ...")
           s.sp_equiv
       in

--- a/test/equality/negative/dune
+++ b/test/equality/negative/dune
@@ -1,0 +1,15 @@
+(include dune.inc)
+
+(rule
+ (targets dune.inc.gen)
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ../../gen/gen.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/test/equality/negative/dune.inc
+++ b/test/equality/negative/dune.inc
@@ -1,0 +1,52 @@
+(rule
+ (targets type_arg.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:type_arg.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:type_arg.mli.expected} %{dep:type_arg.mli.output})))
+
+(rule
+ (targets wrong_arg_number.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_arg_number.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_arg_number.mli.expected} %{dep:wrong_arg_number.mli.output})))
+
+(rule
+ (targets wrong_args.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_args.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_args.mli.expected} %{dep:wrong_args.mli.output})))
+
+(rule
+ (targets wrong_ret.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_ret.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_ret.mli.expected} %{dep:wrong_ret.mli.output})))
+

--- a/test/equality/negative/dune.inc
+++ b/test/equality/negative/dune.inc
@@ -1,4 +1,69 @@
 (rule
+ (targets equality_order.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:equality_order.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:equality_order.mli.expected} %{dep:equality_order.mli.output})))
+
+(rule
+ (targets extra_arg.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:extra_arg.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:extra_arg.mli.expected} %{dep:extra_arg.mli.output})))
+
+(rule
+ (targets inner_equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:inner_equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:inner_equality.mli.expected} %{dep:inner_equality.mli.output})))
+
+(rule
+ (targets polymorphic_equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:polymorphic_equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:polymorphic_equality.mli.expected} %{dep:polymorphic_equality.mli.output})))
+
+(rule
+ (targets too_few_args.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:too_few_args.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:too_few_args.mli.expected} %{dep:too_few_args.mli.output})))
+
+(rule
  (targets type_arg.mli.output)
  (deps (source_tree .))
  (action
@@ -36,6 +101,19 @@
 (rule
  (alias runtest)
  (action (diff %{dep:wrong_args.mli.expected} %{dep:wrong_args.mli.output})))
+
+(rule
+ (targets wrong_order.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_order.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_order.mli.expected} %{dep:wrong_order.mli.output})))
 
 (rule
  (targets wrong_ret.mli.output)

--- a/test/equality/negative/equality_order.mli
+++ b/test/equality/negative/equality_order.mli
@@ -1,0 +1,5 @@
+type ('a, 'b) t
+
+val f :
+  ('b -> 'b -> bool) -> ('a -> 'a -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool
+(*@ equality *)

--- a/test/equality/negative/equality_order.mli.expected
+++ b/test/equality/negative/equality_order.mli.expected
@@ -1,0 +1,25 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type ('a, 'b) t
+val f :
+  ('b -> 'b -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool[@@gospel
+                                                            {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type ('a, 'b) t
+  
+
+val f :
+  ('b -> 'b -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool
+(*@ equality
+     *)
+File "equality_order.mli", lines 3-5, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/extra_arg.mli
+++ b/test/equality/negative/extra_arg.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : (int -> int -> bool) -> 'a t -> 'a t -> bool
+(*@ equality *)

--- a/test/equality/negative/extra_arg.mli.expected
+++ b/test/equality/negative/extra_arg.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : (int -> int -> bool) -> 'a t -> 'a t -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : (int -> int -> bool) -> 'a t -> 'a t -> bool
+(*@ equality
+     *)
+File "extra_arg.mli", lines 3-4, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/inner_equality.mli
+++ b/test/equality/negative/inner_equality.mli
@@ -1,0 +1,5 @@
+type ('a, 'b) t
+
+val f :
+  ('a list -> 'a list -> bool) -> ('a list, 'b) t -> ('a list, 'b) t -> bool
+(*@ equality *)

--- a/test/equality/negative/inner_equality.mli.expected
+++ b/test/equality/negative/inner_equality.mli.expected
@@ -1,0 +1,23 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type ('a, 'b) t
+val f :
+  ('a list -> 'a list -> bool) -> ('a list, 'b) t -> ('a list, 'b) t -> bool
+[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type ('a, 'b) t
+  
+
+val f :
+  ('a list -> 'a list -> bool) -> ('a list, 'b) t -> ('a list, 'b) t -> bool
+(*@ equality
+     *)
+File "inner_equality.mli", lines 3-5, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/polymorphic_equality.mli
+++ b/test/equality/negative/polymorphic_equality.mli
@@ -1,0 +1,2 @@
+val f : 'a -> 'a -> bool
+(*@ equality *)

--- a/test/equality/negative/polymorphic_equality.mli.expected
+++ b/test/equality/negative/polymorphic_equality.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : 'a -> 'a -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : 'a -> 'a -> bool
+(*@ equality
+     *)
+File "polymorphic_equality.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/too_few_args.mli
+++ b/test/equality/negative/too_few_args.mli
@@ -1,0 +1,2 @@
+val f : int -> bool
+(*@ equality *)

--- a/test/equality/negative/too_few_args.mli.expected
+++ b/test/equality/negative/too_few_args.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> bool
+(*@ equality
+     *)
+File "too_few_args.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/type_arg.mli
+++ b/test/equality/negative/type_arg.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : 'a t -> 'b t -> bool
+(*@ equality *)

--- a/test/equality/negative/type_arg.mli.expected
+++ b/test/equality/negative/type_arg.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : 'a t -> 'b t -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : 'a t -> 'b t -> bool
+(*@ equality
+     *)
+File "type_arg.mli", lines 3-4, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_arg_number.mli
+++ b/test/equality/negative/wrong_arg_number.mli
@@ -1,0 +1,2 @@
+val f : int -> int -> int -> bool
+(*@ equality *)

--- a/test/equality/negative/wrong_arg_number.mli.expected
+++ b/test/equality/negative/wrong_arg_number.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int -> int -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int -> int -> bool
+(*@ equality
+     *)
+File "wrong_arg_number.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_args.mli
+++ b/test/equality/negative/wrong_args.mli
@@ -1,0 +1,2 @@
+val f : int -> string -> bool
+(*@ equality *)

--- a/test/equality/negative/wrong_args.mli.expected
+++ b/test/equality/negative/wrong_args.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> string -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> string -> bool
+(*@ equality
+     *)
+File "wrong_args.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_order.mli
+++ b/test/equality/negative/wrong_order.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : 'a t -> 'a t -> ('a -> 'a -> bool) -> bool
+(*@ equality *)

--- a/test/equality/negative/wrong_order.mli.expected
+++ b/test/equality/negative/wrong_order.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : 'a t -> 'a t -> ('a -> 'a -> bool) -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : 'a t -> 'a t -> ('a -> 'a -> bool) -> bool
+(*@ equality
+     *)
+File "wrong_order.mli", lines 3-4, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_ret.mli
+++ b/test/equality/negative/wrong_ret.mli
@@ -1,0 +1,2 @@
+val f : int -> int -> string
+(*@ equality *)

--- a/test/equality/negative/wrong_ret.mli.expected
+++ b/test/equality/negative/wrong_ret.mli.expected
@@ -2,19 +2,15 @@
 *******************************
 ********** Parsed file ********
 *******************************
-val f : int -> int[@@gospel {| y = f x
-    pure
-    diverges |}]
+val f : int -> int -> string[@@gospel {| equality |}]
 
 *******************************
 ****** GOSPEL translation *****
 *******************************
 (*@ open Gospelstdlib *)
 
-val f : int -> int
-(*@ y = f x
-    diverges
-    pure
+val f : int -> int -> string
+(*@ equality
      *)
-File "impure2.mli", line 2, characters 5-6:
-Error: Type checking error: a pure function cannot diverge
+File "wrong_ret.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/positive/dune
+++ b/test/equality/positive/dune
@@ -1,0 +1,15 @@
+(include dune.inc)
+
+(rule
+ (targets dune.inc.gen)
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ../../gen/gen.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/test/equality/positive/dune.inc
+++ b/test/equality/positive/dune.inc
@@ -1,0 +1,13 @@
+(rule
+ (targets equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:equality.mli.expected} %{dep:equality.mli.output})))
+

--- a/test/equality/positive/equality.mli
+++ b/test/equality/positive/equality.mli
@@ -11,7 +11,44 @@ type 'a u
 val h : 'a u -> 'a u -> bool
 (*@ equality *)
 
+val h' : 'b u -> 'b u -> bool
+(*@ equality *)
+
+val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool
+(*@ equality *)
+
 type v = t
 
 val i : v -> t -> bool
+(*@ equality *)
+
+type ('a, 'b) w
+
+val h : ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h :
+  ('a -> 'a -> bool) -> ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality *)
+
+val h :
+  ('a -> 'a -> bool) -> ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+(*@ equality *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
 (*@ equality *)

--- a/test/equality/positive/equality.mli
+++ b/test/equality/positive/equality.mli
@@ -1,0 +1,17 @@
+val f : int -> int -> bool
+(*@ equality *)
+
+type t
+
+val g : t -> t -> bool
+(*@ equality *)
+
+type 'a u
+
+val h : 'a u -> 'a u -> bool
+(*@ equality *)
+
+type v = t
+
+val i : v -> t -> bool
+(*@ equality *)

--- a/test/equality/positive/equality.mli.expected
+++ b/test/equality/positive/equality.mli.expected
@@ -1,0 +1,92 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int -> bool[@@gospel {| equality |}]
+type t
+val g : t -> t -> bool[@@gospel {| equality |}]
+type 'a u
+val h : 'a u -> 'a u -> bool[@@gospel {| equality |}]
+type v = t
+val i : v -> t -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int -> bool
+(*@ equality
+     *)
+
+type t
+  
+
+val g : t -> t -> bool
+(*@ equality
+     *)
+
+type 'a u
+  
+
+val h : 'a u -> 'a u -> bool
+(*@ equality
+     *)
+
+type v = t
+  
+
+val i : v -> t -> bool
+(*@ equality
+     *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module equality.mli
+
+  Namespace: equality.mli
+    Type symbols
+       t
+      ('a) u
+       v [=t]
+      
+    Logic Symbols
+      
+    Field Symbols
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    val f : int -> int -> bool
+    (*@ result:bool = f $x0:int $x1:int
+        equality*)
+    
+    type t
+         
+    
+    val g : t -> t -> bool
+    (*@ result_1:bool = g $x0_1:t $x1_1:t
+        equality*)
+    
+    type 'a u
+         
+    
+    val h : 'a u -> 'a u -> bool
+    (*@ result_2:bool = h $x0_2:'a u $x1_2:'a u
+        equality*)
+    
+    type v = t
+         
+    
+    val i : v -> t -> bool
+    (*@ result_3:bool = i $x0_3:t $x1_3:t
+        equality*)
+
+OK

--- a/test/equality/positive/equality.mli.expected
+++ b/test/equality/positive/equality.mli.expected
@@ -7,8 +7,32 @@ type t
 val g : t -> t -> bool[@@gospel {| equality |}]
 type 'a u
 val h : 'a u -> 'a u -> bool[@@gospel {| equality |}]
+val h' : 'b u -> 'b u -> bool[@@gospel {| equality |}]
+val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool[@@gospel {| equality |}]
 type v = t
 val i : v -> t -> bool[@@gospel {| equality |}]
+type ('a, 'b) w
+val h : ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel
+                                                                {| equality |}]
+val h : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel
+                                                                {| equality |}]
+val h :
+  ('a -> 'a -> bool) ->
+    ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel
+                                                            {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool[@@gospel
+                                                                {| equality |}]
+val h :
+  ('a -> 'a -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool[@@gospel
+                                                            {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+[@@gospel {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+[@@gospel {| equality |}]
+val h : ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+[@@gospel {| equality |}]
 
 *******************************
 ****** GOSPEL translation *****
@@ -33,10 +57,61 @@ val h : 'a u -> 'a u -> bool
 (*@ equality
      *)
 
+val h' : 'b u -> 'b u -> bool
+(*@ equality
+     *)
+
+val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool
+(*@ equality
+     *)
+
 type v = t
   
 
 val i : v -> t -> bool
+(*@ equality
+     *)
+
+type ('a, 'b) w
+  
+
+val h : ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h :
+  ('a -> 'a -> bool) ->
+    ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality
+     *)
+
+val h :
+  ('a -> 'a -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+(*@ equality
+     *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
 (*@ equality
      *)
 
@@ -50,6 +125,7 @@ module equality.mli
        t
       ('a) u
        v [=t]
+      ('a, 'b) w
       
     Logic Symbols
       
@@ -82,11 +158,75 @@ module equality.mli
     (*@ result_2:bool = h $x0_2:'a u $x1_2:'a u
         equality*)
     
+    val h' : 'b u -> 'b u -> bool
+    (*@ result_3:bool = h' $x0_3:'b u $x1_3:'b u
+        equality*)
+    
+    val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool
+    (*@ result_4:bool = h'' $x0_4:'a -> 'a -> bool $x1_4:'a u $x2:'a u
+        equality*)
+    
     type v = t
          
     
     val i : v -> t -> bool
-    (*@ result_3:bool = i $x0_3:t $x1_3:t
+    (*@ result_5:bool = i $x0_5:t $x1_5:t
+        equality*)
+    
+    type ('a, 'b) w
+         
+    
+    val h_1 : ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_6:bool = h_1 $x0_6:('a, 'b) w $x1_6:('a, 'b) w
+        equality*)
+    
+    val h_2 : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_7:bool = h_2
+        $x0_7:'a -> 'a -> bool $x1_7:('a, 'b) w $x2_1:('a, 'b) w
+        equality*)
+    
+    val h_3 : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_8:bool = h_3
+        $x0_8:'b -> 'b -> bool $x1_8:('a, 'b) w $x2_2:('a, 'b) w
+        equality*)
+    
+    val h_4 :
+    ('a -> 'a -> bool) ->
+      ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_9:bool = h_4
+        $x0_9:'a -> 'a -> bool $x1_9:'b -> 'b -> bool $x2_3:('a, 'b) w
+        $x3:('a, 'b) w
+        equality*)
+    
+    val h_5 : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+    (*@ result_10:bool = h_5
+        $x0_10:'a -> 'a -> bool $x1_10:('a, 'a) w $x2_4:('a, 'a) w
+        equality*)
+    
+    val h_6 :
+    ('a -> 'a -> bool) ->
+      ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+    (*@ result_11:bool = h_6
+        $x0_11:'a -> 'a -> bool $x1_11:'a -> 'a -> bool $x2_5:('a, 'a) w
+        $x3_1:('a, 'a) w
+        equality*)
+    
+    val h_7 :
+    ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+    (*@ result_12:bool = h_7
+        $x0_12:'a -> 'a -> bool $x1_12:('a, 'b) w list $x2_6:('a, 'b) w list
+        equality*)
+    
+    val h_8 :
+    ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+    (*@ result_13:bool = h_8
+        $x0_13:'a -> 'a -> bool $x1_13:('a, 'b list) w $x2_7:('a, 'b list) w
+        equality*)
+    
+    val h_9 :
+    ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+    (*@ result_14:bool = h_9
+        $x0_14:'b -> 'b -> bool $x1_14:('a, 'b list) w $x2_8:('a, 'b list) w
         equality*)
 
 OK

--- a/test/pure/negative/impure1.mli.expected
+++ b/test/pure/negative/impure1.mli.expected
@@ -19,6 +19,7 @@ type t
 
 val f : t -> int
 (*@ y = f x
+    pure
     modifies ...
      *)
 File "impure1.mli", line 5, characters 5-6:

--- a/test/pure/negative/impure3.mli.expected
+++ b/test/pure/negative/impure3.mli.expected
@@ -14,6 +14,7 @@ val f : int -> int[@@gospel
 
 val f : int -> int
 (*@ y = f x
+    pure
     with ...
      *)
 File "impure3.mli", line 2, characters 5-6:

--- a/test/pure/negative/impure4.mli.expected
+++ b/test/pure/negative/impure4.mli.expected
@@ -13,6 +13,7 @@ val f : int -> int[@@gospel {| y = f x
 
 val f : int -> int
 (*@ y = f x
+    pure
      *)
 File "impure4.mli", line 2, characters 5-6:
 Error: Type checking error: a pure function cannot raise exceptions

--- a/test/pure/positive/pure.mli.expected
+++ b/test/pure/positive/pure.mli.expected
@@ -18,7 +18,8 @@ f: int }
   
 
 val f : int -> int
-(*@  *)
+(*@ pure
+     *)
 
 val g : int -> int
 (*@ y = g x
@@ -56,7 +57,8 @@ module pure.mli
          
     
     val f : int -> int
-    (*@ result:int = f $x0:int*)
+    (*@ result:int = f $x0:int
+        pure*)
     
     val g : int -> int
     (*@ y:int = g x:int


### PR DESCRIPTION
This adds a new clause `equality`, which lets the user specify that a function `val equal : t -> t -> bool` is an equality function over the type `t`.