### PR TITLE
Add `comparison` clause

### DIFF
--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -52,6 +52,7 @@ clause = "requires" formula
        | "equivalent" string_literal
        | "diverges"
        | "equality"
+       | "comparison"
        | "pure"
        | "consumes" expr ("," expr)*
 exception_case = qualid "->" formula
@@ -384,22 +385,28 @@ Pure functions can be used in further Gospel specifications.
 On the contrary, OCaml functions not declared as `pure` cannot be used
 in specifications.
 
-## Equality functions
+## Equality and comparison functions
 
-As OCaml developers are used to providing equality functions for their abstract
-types, Gospel provides a convenient `equality` clause to specify them.
+As OCaml developers are used to providing equality or comparison functions for
+their abstract types, Gospel provides convenient `equality` and `comparison`
+clauses to specify them.
 
-```ocaml {4}
+```ocaml {4,7}
 type t
+
+val compare : t -> t -> int
+(*@ comparison *)
 
 val equal : t -> t -> bool
 (*@ equality *)
 ```
 
+### Equality
+
 The equality clause states that:
 - The function is pure. See the [section on `pure` functions](#pure-functions)
   for more details.
-- The function implements the logical equality over the type of its arguments
+- The function implements the logical equality over the type of its arguments.
 
 The previous contract is equivalent to the following one:
 
@@ -412,9 +419,31 @@ val equal : t -> t -> bool
     ensures b <-> t1 = t2 *)
 ```
 
-Functions that are parametrized by equality functions over their type arguments
-are also allowed. In that case, the equality functions should be passed in an
-order compatible with the appearance of type variables, from left to right.
+### Comparison
+
+The comparison clause states that:
+- The function is pure. See the [section on `pure` functions](#pure-functions)
+  for more details.
+- The function implements a [pre-order](https://en.wikipedia.org/wiki/Pre-order)
+  over the type of its arguments
+
+The previous contract is equivalent to the following one:
+
+```ocaml {4,6}
+type t
+
+val compare : t -> t -> int
+(*@ pure *)
+
+(*@ axiom compare_is_order : Order.is_pre_order compare *)
+```
+
+### Parametrized functions
+
+Functions that are parametrized by equality or comparison functions over their
+type arguments are also allowed. In that case, these functions should be passed
+in an order compatible with the appearance of type variables, from left to
+right.
 
 ```ocaml {4-5}
 type ('a, 'b) t
@@ -441,7 +470,7 @@ val equal :
 :::
 
 Gospel also supports functions that do not require the caller to provide
-equality functions for all type parameters.
+equality or comparison functions for all type parameters.
 
 ```ocaml {2}
 val equal :

--- a/src/stdlib/gospelstdlib.mli
+++ b/src/stdlib/gospelstdlib.mli
@@ -19,6 +19,7 @@
    type float
    type bool
    type integer
+   type int
 
    type 'a option
    function None: 'a option
@@ -99,8 +100,6 @@
     specifications can be written using type [integer] only, and yet use OCaml's
     variables of type [int]. The Gospel typechecker will automatically apply
     [integer_of_int] whenever necessary. *)
-
-type int
 
 (*@ function integer_of_int (x: int) : integer *)
 (*@ coercion *)

--- a/src/tast.ml
+++ b/src/tast.ml
@@ -36,6 +36,7 @@ type val_spec = {
   sp_diverge : bool;  (** Diverges *)
   sp_pure : bool;  (** Pure *)
   sp_equality : bool;  (** Equality *)
+  sp_comparison : bool;  (** Comparison *)
   sp_equiv : string list;  (** Equivalent *)
   sp_text : string;
       (** String containing the original specificaion as written by the user *)

--- a/src/tast.ml
+++ b/src/tast.ml
@@ -35,6 +35,7 @@ type val_spec = {
   sp_cs : term list;  (** Consumes *)
   sp_diverge : bool;  (** Diverges *)
   sp_pure : bool;  (** Pure *)
+  sp_equality : bool;  (** Equality *)
   sp_equiv : string list;  (** Equivalent *)
   sp_text : string;
       (** String containing the original specificaion as written by the user *)

--- a/src/tast_helper.ml
+++ b/src/tast_helper.ml
@@ -16,7 +16,7 @@ let ty_of_lb_arg = function
   | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> vs.vs_ty
 
 let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
-    sp_diverge sp_pure sp_equiv sp_text sp_loc =
+    sp_diverge sp_pure sp_equality sp_equiv sp_text sp_loc =
   {
     sp_args;
     sp_ret;
@@ -28,6 +28,7 @@ let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
     sp_cs;
     sp_diverge;
     sp_pure;
+    sp_equality;
     sp_equiv;
     sp_text;
     sp_loc;
@@ -35,12 +36,9 @@ let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
 
 (* Checks the following:
    1 - no duplicated args
-   2 - pre and post of type prop
-
-   TODO:
-   1 - check what to do with writes
-   2 - sp_xpost sp_reads sp_alias *)
-let mk_val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc =
+   2 - pre and post of type prop *)
+let mk_val_spec args ret pre checks post xpost wr cs dv pure equality equiv txt
+    loc =
   let add args = function
     | Lunit -> args
     | a ->
@@ -53,7 +51,7 @@ let mk_val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc =
   List.iter (ty_check None) pre;
   List.iter (ty_check None) checks;
   List.iter (ty_check None) post;
-  val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc
+  val_spec args ret pre checks post xpost wr cs dv pure equality equiv txt loc
 
 let mk_val_description vd_name vd_type vd_prim vd_attrs vd_args vd_ret vd_spec
     vd_loc =

--- a/src/tast_helper.ml
+++ b/src/tast_helper.ml
@@ -16,7 +16,7 @@ let ty_of_lb_arg = function
   | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> vs.vs_ty
 
 let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
-    sp_diverge sp_pure sp_equality sp_equiv sp_text sp_loc =
+    sp_diverge sp_pure sp_equality sp_comparison sp_equiv sp_text sp_loc =
   {
     sp_args;
     sp_ret;
@@ -29,6 +29,7 @@ let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
     sp_diverge;
     sp_pure;
     sp_equality;
+    sp_comparison;
     sp_equiv;
     sp_text;
     sp_loc;
@@ -37,8 +38,8 @@ let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
 (* Checks the following:
    1 - no duplicated args
    2 - pre and post of type prop *)
-let mk_val_spec args ret pre checks post xpost wr cs dv pure equality equiv txt
-    loc =
+let mk_val_spec args ret pre checks post xpost wr cs dv pure equality comparison
+    equiv txt loc =
   let add args = function
     | Lunit -> args
     | a ->
@@ -51,7 +52,8 @@ let mk_val_spec args ret pre checks post xpost wr cs dv pure equality equiv txt
   List.iter (ty_check None) pre;
   List.iter (ty_check None) checks;
   List.iter (ty_check None) post;
-  val_spec args ret pre checks post xpost wr cs dv pure equality equiv txt loc
+  val_spec args ret pre checks post xpost wr cs dv pure equality comparison
+    equiv txt loc
 
 let mk_val_description vd_name vd_type vd_prim vd_attrs vd_args vd_ret vd_spec
     vd_loc =

--- a/src/tast_helper.mli
+++ b/src/tast_helper.mli
@@ -29,6 +29,7 @@ val mk_val_spec :
   term list ->
   bool ->
   bool ->
+  bool ->
   string list ->
   string ->
   Location.t ->

--- a/src/tast_helper.mli
+++ b/src/tast_helper.mli
@@ -30,6 +30,7 @@ val mk_val_spec :
   bool ->
   bool ->
   bool ->
+  bool ->
   string list ->
   string ->
   Location.t ->

--- a/src/tast_printer.ml
+++ b/src/tast_printer.ml
@@ -111,20 +111,21 @@ let print_xposts f xposts =
 let print_diverges f d = if not d then () else pp f "@\n@[diverges@]"
 let print_pure f d = if not d then () else pp f "@\n@[pure@]"
 let print_equality f d = if not d then () else pp f "@\n@[equality@]"
+let print_comparison f d = if not d then () else pp f "@\n@[comparison@]"
 
 let print_vd_spec val_id fmt spec =
   let print_term f t = pp f "@[%a@]" print_term t in
   match spec with
   | None -> ()
   | Some vs ->
-      pp fmt "(*@@ @[%a%s@ %a@ %a@]%a%a%a%a%a%a%a%a%a%a*)"
+      pp fmt "(*@@ @[%a%s@ %a@ %a@]%a%a%a%a%a%a%a%a%a%a%a*)"
         (list ~sep:comma print_lb_arg)
         vs.sp_ret
         (if vs.sp_ret = [] then "" else " =")
         Ident.pp val_id
         (list ~sep:sp print_lb_arg)
         vs.sp_args print_diverges vs.sp_diverge print_pure vs.sp_pure
-        print_equality vs.sp_equality
+        print_equality vs.sp_equality print_comparison vs.sp_comparison
         (list
            ~first:(newline ++ const string "requires ")
            ~sep:(newline ++ const string "requires ")

--- a/src/tast_printer.ml
+++ b/src/tast_printer.ml
@@ -108,19 +108,23 @@ let print_xposts f xposts =
     in
     List.iter print_xpost xposts
 
+let print_diverges f d = if not d then () else pp f "@\n@[diverges@]"
+let print_pure f d = if not d then () else pp f "@\n@[pure@]"
+let print_equality f d = if not d then () else pp f "@\n@[equality@]"
+
 let print_vd_spec val_id fmt spec =
   let print_term f t = pp f "@[%a@]" print_term t in
-  let print_diverges f d = if not d then () else pp f "@\n@[diverges@]" in
   match spec with
   | None -> ()
   | Some vs ->
-      pp fmt "(*@@ @[%a%s@ %a@ %a@]%a%a%a%a%a%a%a%a*)"
+      pp fmt "(*@@ @[%a%s@ %a@ %a@]%a%a%a%a%a%a%a%a%a%a*)"
         (list ~sep:comma print_lb_arg)
         vs.sp_ret
         (if vs.sp_ret = [] then "" else " =")
         Ident.pp val_id
         (list ~sep:sp print_lb_arg)
-        vs.sp_args print_diverges vs.sp_diverge
+        vs.sp_args print_diverges vs.sp_diverge print_pure vs.sp_pure
+        print_equality vs.sp_equality
         (list
            ~first:(newline ++ const string "requires ")
            ~sep:(newline ++ const string "requires ")

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -167,6 +167,7 @@ let ns_with_primitives =
   let primitive_tys =
     [
       ("integer", ts_integer);
+      ("int", ts_int);
       ("string", ts_string);
       ("char", ts_char);
       ("float", ts_float);

--- a/src/ttypes.ml
+++ b/src/ttypes.ml
@@ -66,6 +66,11 @@ let rec ty_equal x y =
       ts_equal tsx tsy && List.for_all2 ty_equal tylx tyly
   | _ -> false
 
+let rec ty_vars ty =
+  match ty.ty_node with
+  | Tyvar _ -> [ ty ]
+  | Tyapp (_, l) -> List.fold_left (fun acc ty -> ty_vars ty @ acc) l []
+
 module Ts = struct
   type t = tysymbol
 

--- a/src/ttypes.ml
+++ b/src/ttypes.ml
@@ -177,6 +177,7 @@ let ty_equal_check ty1 ty2 =
 
 let ts_unit = ts (Ident.create ~loc:Location.none "unit") []
 let ts_integer = ts (Ident.create ~loc:Location.none "integer") []
+let ts_int = ts (Ident.create ~loc:Location.none "int") []
 let ts_bool = ts (Ident.create ~loc:Location.none "bool") []
 let ts_float = ts (Ident.create ~loc:Location.none "float") []
 let ts_char = ts (Ident.create ~loc:Location.none "char") []
@@ -220,6 +221,7 @@ let is_ts_tuple ts =
 let is_ts_arrow ts = Ident.equal ts_arrow.ts_ident ts.ts_ident
 let ty_unit = ty_app ts_unit []
 let ty_integer = ty_app ts_integer []
+let ty_int = ty_app ts_int []
 let ty_bool = ty_app ts_bool []
 let ty_float = ty_app ts_float []
 let ty_char = ty_app ts_char []

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -763,8 +763,15 @@ let process_val_spec kid crcm ns id args ret vs =
     if wr <> [] then error_report ~loc "a pure function cannot have writes";
     if xpost <> [] || checks <> [] then
       error_report ~loc "a pure function cannot raise exceptions");
+  (if vs.sp_equality then
+   match (args, ret) with
+   | [ t1; t2 ], [ b ]
+     when ty_equal (ty_of_lb_arg t1) (ty_of_lb_arg t2)
+          && ty_equal (ty_of_lb_arg b) ty_bool ->
+       ()
+   | _, _ -> error_report ~loc "type is incompatible with equality clause");
   mk_val_spec args ret pre checks post xpost wr cs vs.sp_diverge vs.sp_pure
-    vs.sp_equiv vs.sp_text vs.sp_loc
+    vs.sp_equality vs.sp_equiv vs.sp_text vs.sp_loc
 
 let empty_spec preid ret args =
   {
@@ -777,6 +784,7 @@ let empty_spec preid ret args =
     sp_consumes = [];
     sp_diverge = false;
     sp_pure = false;
+    sp_equality = false;
     sp_equiv = [];
     sp_text = "";
     sp_loc = Location.none;

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -631,8 +631,8 @@ let check_equality_type ~loc args ret expected_ret_ty =
     | _, [] -> (* If there are no more arguments, we're done *) ()
     | a :: vl, (eq :: eql as l) ->
         let expected =
-          (* ['a -> 'a -> bool] *)
-          ty_app ts_arrow [ a; ty_app ts_arrow [ a; ty_bool ] ]
+          (* ['a -> 'a -> expected_ret_ty] *)
+          ty_app ts_arrow [ a; ty_app ts_arrow [ a; expected_ret_ty ] ]
         in
         if ty_equal (ty_of_lb_arg eq) expected then
           (* If [eq] is an equality over 'a, we check the next arguments *)
@@ -799,8 +799,9 @@ let process_val_spec kid crcm ns id args ret vs =
     if xpost <> [] || checks <> [] then
       error_report ~loc "a pure function cannot raise exceptions");
   if vs.sp_equality then check_equality_type ~loc args ret ty_bool;
+  if vs.sp_comparison then check_equality_type ~loc args ret ty_int;
   mk_val_spec args ret pre checks post xpost wr cs vs.sp_diverge vs.sp_pure
-    vs.sp_equality vs.sp_equiv vs.sp_text vs.sp_loc
+    vs.sp_equality vs.sp_comparison vs.sp_equiv vs.sp_text vs.sp_loc
 
 let empty_spec preid ret args =
   {
@@ -814,6 +815,7 @@ let empty_spec preid ret args =
     sp_diverge = false;
     sp_pure = false;
     sp_equality = false;
+    sp_comparison = false;
     sp_equiv = [];
     sp_text = "";
     sp_loc = Location.none;

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -98,6 +98,7 @@ type val_spec = {
   sp_consumes : term list;
   sp_diverge : bool;
   sp_pure : bool;
+  sp_equality : bool;
   sp_equiv : string list;
   sp_text : string;
   sp_loc : Location.t;

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -99,6 +99,7 @@ type val_spec = {
   sp_diverge : bool;
   sp_pure : bool;
   sp_equality : bool;
+  sp_comparison : bool;
   sp_equiv : string list;
   sp_text : string;
   sp_loc : Location.t;

--- a/src/ulexer.mll
+++ b/src/ulexer.mll
@@ -75,6 +75,7 @@
         "checks", CHECKS;
         "diverges", DIVERGES;
         "pure", PURE;
+        "equality", EQUALITY;
         "ephemeral", EPHEMERAL;
         "model", MODEL;
       ]

--- a/src/ulexer.mll
+++ b/src/ulexer.mll
@@ -76,6 +76,7 @@
         "diverges", DIVERGES;
         "pure", PURE;
         "equality", EQUALITY;
+        "comparison", COMPARISON;
         "ephemeral", EPHEMERAL;
         "model", MODEL;
       ]

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -51,6 +51,7 @@
     sp_diverge = false;
     sp_pure = false;
     sp_equality = false;
+    sp_comparison = false;
     sp_equiv = [];
     sp_text = "";
     sp_loc = Location.none;
@@ -104,7 +105,7 @@
 %token COERCION
 %token IF IN
 %token OLD NOT RAISES
-%token THEN TRUE MODIFIES EQUIVALENT CHECKS DIVERGES PURE EQUALITY
+%token THEN TRUE MODIFIES EQUIVALENT CHECKS DIVERGES PURE EQUALITY COMPARISON
 
 %token AS
 %token LET MATCH PREDICATE
@@ -228,6 +229,8 @@ val_spec_body:
 | (* Empty spec *) { empty_vspec }
 | PURE bd=val_spec_body
   { {bd with sp_pure = true} }
+| COMPARISON bd=val_spec_body
+  { {bd with sp_comparison = true} }
 | EQUALITY bd=val_spec_body
   { {bd with sp_equality = true} }
 | DIVERGES bd=val_spec_body

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -50,6 +50,7 @@
     sp_consumes= [];
     sp_diverge = false;
     sp_pure = false;
+    sp_equality = false;
     sp_equiv = [];
     sp_text = "";
     sp_loc = Location.none;
@@ -103,7 +104,7 @@
 %token COERCION
 %token IF IN
 %token OLD NOT RAISES
-%token THEN TRUE MODIFIES EQUIVALENT CHECKS DIVERGES PURE
+%token THEN TRUE MODIFIES EQUIVALENT CHECKS DIVERGES PURE EQUALITY
 
 %token AS
 %token LET MATCH PREDICATE
@@ -227,6 +228,8 @@ val_spec_body:
 | (* Empty spec *) { empty_vspec }
 | PURE bd=val_spec_body
   { {bd with sp_pure = true} }
+| EQUALITY bd=val_spec_body
+  { {bd with sp_equality = true} }
 | DIVERGES bd=val_spec_body
   { {bd with sp_diverge = true} }
 | MODIFIES wr=separated_list(COMMA, term) bd=val_spec_body

--- a/src/upretty_printer.ml
+++ b/src/upretty_printer.ml
@@ -64,11 +64,13 @@ let val_spec fmt vspec =
   | None -> ()
   | Some vspec ->
       let pure fmt x = if x then pp fmt "pure@\n" else () in
-      let equality fmt x = if x then pp fmt "equality@\n" else () in
       let diverge fmt x = if x then pp fmt "diverges@\n" else () in
+      let comparison fmt x = if x then pp fmt "comparison@\n" else () in
+      let equality fmt x = if x then pp fmt "equality@\n" else () in
       let print_content fmt s =
-        pp fmt "@[%a%a%a%a%a%a%a%a%a%a@]" (option spec_header) s.sp_header
-          diverge s.sp_diverge pure s.sp_pure equality s.sp_equality
+        pp fmt "@[%a%a%a%a%a%a%a%a%a%a%a@]" (option spec_header) s.sp_header
+          diverge s.sp_diverge pure s.sp_pure equality s.sp_equality comparison
+          s.sp_comparison
           (list_keyword "requires ...")
           s.sp_pre
           (list_keyword "ensures ...")

--- a/src/upretty_printer.ml
+++ b/src/upretty_printer.ml
@@ -63,9 +63,12 @@ let val_spec fmt vspec =
   match vspec with
   | None -> ()
   | Some vspec ->
+      let pure fmt x = if x then pp fmt "pure@\n" else () in
+      let equality fmt x = if x then pp fmt "equality@\n" else () in
       let diverge fmt x = if x then pp fmt "diverges@\n" else () in
       let print_content fmt s =
-        pp fmt "@[%a%a%a%a%a%a%a%a@]" (option spec_header) s.sp_header
+        pp fmt "@[%a%a%a%a%a%a%a%a%a%a@]" (option spec_header) s.sp_header
+          diverge s.sp_diverge pure s.sp_pure equality s.sp_equality
           (list_keyword "requires ...")
           s.sp_pre
           (list_keyword "ensures ...")
@@ -73,7 +76,7 @@ let val_spec fmt vspec =
           (list_keyword "modifies ...")
           s.sp_writes
           (list_keyword "consumes ...")
-          s.sp_consumes diverge s.sp_diverge
+          s.sp_consumes
           (list_keyword "equivalent ...")
           s.sp_equiv
       in

--- a/test/equality/negative/comp_equality_order.mli
+++ b/test/equality/negative/comp_equality_order.mli
@@ -1,0 +1,5 @@
+type ('a, 'b) t
+
+val f :
+  ('b -> 'b -> int) -> ('a -> 'a -> int) -> ('a, 'b) t -> ('a, 'b) t -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_equality_order.mli.expected
+++ b/test/equality/negative/comp_equality_order.mli.expected
@@ -1,0 +1,23 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type ('a, 'b) t
+val f :
+  ('b -> 'b -> int) -> ('a -> 'a -> int) -> ('a, 'b) t -> ('a, 'b) t -> int
+[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type ('a, 'b) t
+  
+
+val f :
+  ('b -> 'b -> int) -> ('a -> 'a -> int) -> ('a, 'b) t -> ('a, 'b) t -> int
+(*@ comparison
+     *)
+File "comp_equality_order.mli", lines 3-5, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_extra_arg.mli
+++ b/test/equality/negative/comp_extra_arg.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : (int -> int -> int) -> 'a t -> 'a t -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_extra_arg.mli.expected
+++ b/test/equality/negative/comp_extra_arg.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : (int -> int -> int) -> 'a t -> 'a t -> int[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : (int -> int -> int) -> 'a t -> 'a t -> int
+(*@ comparison
+     *)
+File "comp_extra_arg.mli", lines 3-4, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_inner_equality.mli
+++ b/test/equality/negative/comp_inner_equality.mli
@@ -1,0 +1,4 @@
+type ('a, 'b) t
+
+val f : ('a list -> 'a list -> int) -> ('a list, 'b) t -> ('a list, 'b) t -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_inner_equality.mli.expected
+++ b/test/equality/negative/comp_inner_equality.mli.expected
@@ -1,0 +1,23 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type ('a, 'b) t
+val f :
+  ('a list -> 'a list -> int) -> ('a list, 'b) t -> ('a list, 'b) t -> int
+[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type ('a, 'b) t
+  
+
+val f :
+  ('a list -> 'a list -> int) -> ('a list, 'b) t -> ('a list, 'b) t -> int
+(*@ comparison
+     *)
+File "comp_inner_equality.mli", lines 3-5, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_polymorphic_equality.mli
+++ b/test/equality/negative/comp_polymorphic_equality.mli
@@ -1,0 +1,2 @@
+val f : 'a -> 'a -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_polymorphic_equality.mli.expected
+++ b/test/equality/negative/comp_polymorphic_equality.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : 'a -> 'a -> int[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : 'a -> 'a -> int
+(*@ comparison
+     *)
+File "comp_polymorphic_equality.mli", lines 1-2, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_too_few_args.mli
+++ b/test/equality/negative/comp_too_few_args.mli
@@ -1,0 +1,2 @@
+val f : int -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_too_few_args.mli.expected
+++ b/test/equality/negative/comp_too_few_args.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int
+(*@ comparison
+     *)
+File "comp_too_few_args.mli", lines 1-2, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_type_arg.mli
+++ b/test/equality/negative/comp_type_arg.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : 'a t -> 'b t -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_type_arg.mli.expected
+++ b/test/equality/negative/comp_type_arg.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : 'a t -> 'b t -> int[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : 'a t -> 'b t -> int
+(*@ comparison
+     *)
+File "comp_type_arg.mli", lines 3-4, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_wrong_arg_number.mli
+++ b/test/equality/negative/comp_wrong_arg_number.mli
@@ -1,0 +1,2 @@
+val f : int -> int -> int -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_wrong_arg_number.mli.expected
+++ b/test/equality/negative/comp_wrong_arg_number.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int -> int -> int[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int -> int -> int
+(*@ comparison
+     *)
+File "comp_wrong_arg_number.mli", lines 1-2, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_wrong_args.mli
+++ b/test/equality/negative/comp_wrong_args.mli
@@ -1,0 +1,2 @@
+val f : int -> string -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_wrong_args.mli.expected
+++ b/test/equality/negative/comp_wrong_args.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> string -> int[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> string -> int
+(*@ comparison
+     *)
+File "comp_wrong_args.mli", lines 1-2, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_wrong_order.mli
+++ b/test/equality/negative/comp_wrong_order.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : 'a t -> 'a t -> ('a -> 'a -> int) -> int
+(*@ comparison *)

--- a/test/equality/negative/comp_wrong_order.mli.expected
+++ b/test/equality/negative/comp_wrong_order.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : 'a t -> 'a t -> ('a -> 'a -> int) -> int[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : 'a t -> 'a t -> ('a -> 'a -> int) -> int
+(*@ comparison
+     *)
+File "comp_wrong_order.mli", lines 3-4, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/comp_wrong_ret.mli
+++ b/test/equality/negative/comp_wrong_ret.mli
@@ -1,0 +1,2 @@
+val f : int -> int -> string
+(*@ comparison *)

--- a/test/equality/negative/comp_wrong_ret.mli.expected
+++ b/test/equality/negative/comp_wrong_ret.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int -> string[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int -> string
+(*@ comparison
+     *)
+File "comp_wrong_ret.mli", lines 1-2, characters 0-27:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/dune
+++ b/test/equality/negative/dune
@@ -1,0 +1,15 @@
+(include dune.inc)
+
+(rule
+ (targets dune.inc.gen)
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ../../gen/gen.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/test/equality/negative/dune.inc
+++ b/test/equality/negative/dune.inc
@@ -1,0 +1,52 @@
+(rule
+ (targets type_arg.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:type_arg.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:type_arg.mli.expected} %{dep:type_arg.mli.output})))
+
+(rule
+ (targets wrong_arg_number.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_arg_number.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_arg_number.mli.expected} %{dep:wrong_arg_number.mli.output})))
+
+(rule
+ (targets wrong_args.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_args.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_args.mli.expected} %{dep:wrong_args.mli.output})))
+
+(rule
+ (targets wrong_ret.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_ret.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_ret.mli.expected} %{dep:wrong_ret.mli.output})))
+

--- a/test/equality/negative/dune.inc
+++ b/test/equality/negative/dune.inc
@@ -1,4 +1,134 @@
 (rule
+ (targets comp_equality_order.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_equality_order.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_equality_order.mli.expected} %{dep:comp_equality_order.mli.output})))
+
+(rule
+ (targets comp_extra_arg.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_extra_arg.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_extra_arg.mli.expected} %{dep:comp_extra_arg.mli.output})))
+
+(rule
+ (targets comp_inner_equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_inner_equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_inner_equality.mli.expected} %{dep:comp_inner_equality.mli.output})))
+
+(rule
+ (targets comp_polymorphic_equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_polymorphic_equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_polymorphic_equality.mli.expected} %{dep:comp_polymorphic_equality.mli.output})))
+
+(rule
+ (targets comp_too_few_args.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_too_few_args.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_too_few_args.mli.expected} %{dep:comp_too_few_args.mli.output})))
+
+(rule
+ (targets comp_type_arg.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_type_arg.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_type_arg.mli.expected} %{dep:comp_type_arg.mli.output})))
+
+(rule
+ (targets comp_wrong_arg_number.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_wrong_arg_number.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_wrong_arg_number.mli.expected} %{dep:comp_wrong_arg_number.mli.output})))
+
+(rule
+ (targets comp_wrong_args.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_wrong_args.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_wrong_args.mli.expected} %{dep:comp_wrong_args.mli.output})))
+
+(rule
+ (targets comp_wrong_order.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_wrong_order.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_wrong_order.mli.expected} %{dep:comp_wrong_order.mli.output})))
+
+(rule
+ (targets comp_wrong_ret.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comp_wrong_ret.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comp_wrong_ret.mli.expected} %{dep:comp_wrong_ret.mli.output})))
+
+(rule
  (targets equality_order.mli.output)
  (deps (source_tree .))
  (action

--- a/test/equality/negative/dune.inc
+++ b/test/equality/negative/dune.inc
@@ -1,4 +1,69 @@
 (rule
+ (targets equality_order.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:equality_order.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:equality_order.mli.expected} %{dep:equality_order.mli.output})))
+
+(rule
+ (targets extra_arg.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:extra_arg.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:extra_arg.mli.expected} %{dep:extra_arg.mli.output})))
+
+(rule
+ (targets inner_equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:inner_equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:inner_equality.mli.expected} %{dep:inner_equality.mli.output})))
+
+(rule
+ (targets polymorphic_equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:polymorphic_equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:polymorphic_equality.mli.expected} %{dep:polymorphic_equality.mli.output})))
+
+(rule
+ (targets too_few_args.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:too_few_args.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:too_few_args.mli.expected} %{dep:too_few_args.mli.output})))
+
+(rule
  (targets type_arg.mli.output)
  (deps (source_tree .))
  (action
@@ -36,6 +101,19 @@
 (rule
  (alias runtest)
  (action (diff %{dep:wrong_args.mli.expected} %{dep:wrong_args.mli.output})))
+
+(rule
+ (targets wrong_order.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:wrong_order.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:wrong_order.mli.expected} %{dep:wrong_order.mli.output})))
 
 (rule
  (targets wrong_ret.mli.output)

--- a/test/equality/negative/equality_order.mli
+++ b/test/equality/negative/equality_order.mli
@@ -1,0 +1,5 @@
+type ('a, 'b) t
+
+val f :
+  ('b -> 'b -> bool) -> ('a -> 'a -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool
+(*@ equality *)

--- a/test/equality/negative/equality_order.mli.expected
+++ b/test/equality/negative/equality_order.mli.expected
@@ -1,0 +1,25 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type ('a, 'b) t
+val f :
+  ('b -> 'b -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool[@@gospel
+                                                            {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type ('a, 'b) t
+  
+
+val f :
+  ('b -> 'b -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool
+(*@ equality
+     *)
+File "equality_order.mli", lines 3-5, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/extra_arg.mli
+++ b/test/equality/negative/extra_arg.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : (int -> int -> bool) -> 'a t -> 'a t -> bool
+(*@ equality *)

--- a/test/equality/negative/extra_arg.mli.expected
+++ b/test/equality/negative/extra_arg.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : (int -> int -> bool) -> 'a t -> 'a t -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : (int -> int -> bool) -> 'a t -> 'a t -> bool
+(*@ equality
+     *)
+File "extra_arg.mli", lines 3-4, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/inner_equality.mli
+++ b/test/equality/negative/inner_equality.mli
@@ -1,0 +1,5 @@
+type ('a, 'b) t
+
+val f :
+  ('a list -> 'a list -> bool) -> ('a list, 'b) t -> ('a list, 'b) t -> bool
+(*@ equality *)

--- a/test/equality/negative/inner_equality.mli.expected
+++ b/test/equality/negative/inner_equality.mli.expected
@@ -1,0 +1,23 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type ('a, 'b) t
+val f :
+  ('a list -> 'a list -> bool) -> ('a list, 'b) t -> ('a list, 'b) t -> bool
+[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type ('a, 'b) t
+  
+
+val f :
+  ('a list -> 'a list -> bool) -> ('a list, 'b) t -> ('a list, 'b) t -> bool
+(*@ equality
+     *)
+File "inner_equality.mli", lines 3-5, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/polymorphic_equality.mli
+++ b/test/equality/negative/polymorphic_equality.mli
@@ -1,0 +1,2 @@
+val f : 'a -> 'a -> bool
+(*@ equality *)

--- a/test/equality/negative/polymorphic_equality.mli.expected
+++ b/test/equality/negative/polymorphic_equality.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : 'a -> 'a -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : 'a -> 'a -> bool
+(*@ equality
+     *)
+File "polymorphic_equality.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/too_few_args.mli
+++ b/test/equality/negative/too_few_args.mli
@@ -1,0 +1,2 @@
+val f : int -> bool
+(*@ equality *)

--- a/test/equality/negative/too_few_args.mli.expected
+++ b/test/equality/negative/too_few_args.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> bool
+(*@ equality
+     *)
+File "too_few_args.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/type_arg.mli
+++ b/test/equality/negative/type_arg.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : 'a t -> 'b t -> bool
+(*@ equality *)

--- a/test/equality/negative/type_arg.mli.expected
+++ b/test/equality/negative/type_arg.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : 'a t -> 'b t -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : 'a t -> 'b t -> bool
+(*@ equality
+     *)
+File "type_arg.mli", lines 3-4, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_arg_number.mli
+++ b/test/equality/negative/wrong_arg_number.mli
@@ -1,0 +1,2 @@
+val f : int -> int -> int -> bool
+(*@ equality *)

--- a/test/equality/negative/wrong_arg_number.mli.expected
+++ b/test/equality/negative/wrong_arg_number.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int -> int -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int -> int -> bool
+(*@ equality
+     *)
+File "wrong_arg_number.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_args.mli
+++ b/test/equality/negative/wrong_args.mli
@@ -1,0 +1,2 @@
+val f : int -> string -> bool
+(*@ equality *)

--- a/test/equality/negative/wrong_args.mli.expected
+++ b/test/equality/negative/wrong_args.mli.expected
@@ -1,0 +1,16 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> string -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> string -> bool
+(*@ equality
+     *)
+File "wrong_args.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_order.mli
+++ b/test/equality/negative/wrong_order.mli
@@ -1,0 +1,4 @@
+type 'a t
+
+val f : 'a t -> 'a t -> ('a -> 'a -> bool) -> bool
+(*@ equality *)

--- a/test/equality/negative/wrong_order.mli.expected
+++ b/test/equality/negative/wrong_order.mli.expected
@@ -1,0 +1,20 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t
+val f : 'a t -> 'a t -> ('a -> 'a -> bool) -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t
+  
+
+val f : 'a t -> 'a t -> ('a -> 'a -> bool) -> bool
+(*@ equality
+     *)
+File "wrong_order.mli", lines 3-4, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/negative/wrong_ret.mli
+++ b/test/equality/negative/wrong_ret.mli
@@ -1,0 +1,2 @@
+val f : int -> int -> string
+(*@ equality *)

--- a/test/equality/negative/wrong_ret.mli.expected
+++ b/test/equality/negative/wrong_ret.mli.expected
@@ -2,19 +2,15 @@
 *******************************
 ********** Parsed file ********
 *******************************
-val f : int -> int[@@gospel {| y = f x
-    pure
-    diverges |}]
+val f : int -> int -> string[@@gospel {| equality |}]
 
 *******************************
 ****** GOSPEL translation *****
 *******************************
 (*@ open Gospelstdlib *)
 
-val f : int -> int
-(*@ y = f x
-    diverges
-    pure
+val f : int -> int -> string
+(*@ equality
      *)
-File "impure2.mli", line 2, characters 5-6:
-Error: Type checking error: a pure function cannot diverge
+File "wrong_ret.mli", lines 1-2, characters 0-25:
+Error: Type checking error: type is incompatible with equality clause

--- a/test/equality/positive/comparison.mli
+++ b/test/equality/positive/comparison.mli
@@ -1,0 +1,54 @@
+val f : int -> int -> int
+(*@ comparison *)
+
+type t
+
+val g : t -> t -> int
+(*@ comparison *)
+
+type 'a u
+
+val h : 'a u -> 'a u -> int
+(*@ comparison *)
+
+val h' : 'b u -> 'b u -> int
+(*@ comparison *)
+
+val h'' : ('a -> 'a -> int) -> 'a u -> 'a u -> int
+(*@ comparison *)
+
+type v = t
+
+val i : v -> t -> int
+(*@ comparison *)
+
+type ('a, 'b) w
+
+val h : ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison *)
+
+val h : ('a -> 'a -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison *)
+
+val h : ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison *)
+
+val h :
+  ('a -> 'a -> int) -> ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison *)
+
+val h : ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int
+(*@ comparison *)
+
+val h :
+  ('a -> 'a -> int) -> ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int
+(*@ comparison *)
+
+val h : ('a -> 'a -> int) -> ('a, 'b) w list -> ('a, 'b) w list -> int
+(*@ comparison *)
+
+val h : ('a -> 'a -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+(*@ comparison *)
+
+val h : ('b -> 'b -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+(*@ comparison *)

--- a/test/equality/positive/comparison.mli.expected
+++ b/test/equality/positive/comparison.mli.expected
@@ -1,0 +1,223 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int -> int[@@gospel {| comparison |}]
+type t
+val g : t -> t -> int[@@gospel {| comparison |}]
+type 'a u
+val h : 'a u -> 'a u -> int[@@gospel {| comparison |}]
+val h' : 'b u -> 'b u -> int[@@gospel {| comparison |}]
+val h'' : ('a -> 'a -> int) -> 'a u -> 'a u -> int[@@gospel {| comparison |}]
+type v = t
+val i : v -> t -> int[@@gospel {| comparison |}]
+type ('a, 'b) w
+val h : ('a, 'b) w -> ('a, 'b) w -> int[@@gospel {| comparison |}]
+val h : ('a -> 'a -> int) -> ('a, 'b) w -> ('a, 'b) w -> int[@@gospel
+                                                              {| comparison |}]
+val h : ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int[@@gospel
+                                                              {| comparison |}]
+val h :
+  ('a -> 'a -> int) -> ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+[@@gospel {| comparison |}]
+val h : ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int[@@gospel
+                                                              {| comparison |}]
+val h :
+  ('a -> 'a -> int) -> ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int
+[@@gospel {| comparison |}]
+val h : ('a -> 'a -> int) -> ('a, 'b) w list -> ('a, 'b) w list -> int
+[@@gospel {| comparison |}]
+val h : ('a -> 'a -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+[@@gospel {| comparison |}]
+val h : ('b -> 'b -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+[@@gospel {| comparison |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int -> int
+(*@ comparison
+     *)
+
+type t
+  
+
+val g : t -> t -> int
+(*@ comparison
+     *)
+
+type 'a u
+  
+
+val h : 'a u -> 'a u -> int
+(*@ comparison
+     *)
+
+val h' : 'b u -> 'b u -> int
+(*@ comparison
+     *)
+
+val h'' : ('a -> 'a -> int) -> 'a u -> 'a u -> int
+(*@ comparison
+     *)
+
+type v = t
+  
+
+val i : v -> t -> int
+(*@ comparison
+     *)
+
+type ('a, 'b) w
+  
+
+val h : ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison
+     *)
+
+val h : ('a -> 'a -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison
+     *)
+
+val h : ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison
+     *)
+
+val h :
+  ('a -> 'a -> int) -> ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+(*@ comparison
+     *)
+
+val h : ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int
+(*@ comparison
+     *)
+
+val h :
+  ('a -> 'a -> int) -> ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int
+(*@ comparison
+     *)
+
+val h : ('a -> 'a -> int) -> ('a, 'b) w list -> ('a, 'b) w list -> int
+(*@ comparison
+     *)
+
+val h : ('a -> 'a -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+(*@ comparison
+     *)
+
+val h : ('b -> 'b -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+(*@ comparison
+     *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module comparison.mli
+
+  Namespace: comparison.mli
+    Type symbols
+       t
+      ('a) u
+       v [=t]
+      ('a, 'b) w
+      
+    Logic Symbols
+      
+    Field Symbols
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    val f : int -> int -> int
+    (*@ result:int = f $x0:int $x1:int
+        comparison*)
+    
+    type t
+         
+    
+    val g : t -> t -> int
+    (*@ result_1:int = g $x0_1:t $x1_1:t
+        comparison*)
+    
+    type 'a u
+         
+    
+    val h : 'a u -> 'a u -> int
+    (*@ result_2:int = h $x0_2:'a u $x1_2:'a u
+        comparison*)
+    
+    val h' : 'b u -> 'b u -> int
+    (*@ result_3:int = h' $x0_3:'b u $x1_3:'b u
+        comparison*)
+    
+    val h'' : ('a -> 'a -> int) -> 'a u -> 'a u -> int
+    (*@ result_4:int = h'' $x0_4:'a -> 'a -> int $x1_4:'a u $x2:'a u
+        comparison*)
+    
+    type v = t
+         
+    
+    val i : v -> t -> int
+    (*@ result_5:int = i $x0_5:t $x1_5:t
+        comparison*)
+    
+    type ('a, 'b) w
+         
+    
+    val h_1 : ('a, 'b) w -> ('a, 'b) w -> int
+    (*@ result_6:int = h_1 $x0_6:('a, 'b) w $x1_6:('a, 'b) w
+        comparison*)
+    
+    val h_2 : ('a -> 'a -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+    (*@ result_7:int = h_2
+        $x0_7:'a -> 'a -> int $x1_7:('a, 'b) w $x2_1:('a, 'b) w
+        comparison*)
+    
+    val h_3 : ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+    (*@ result_8:int = h_3
+        $x0_8:'b -> 'b -> int $x1_8:('a, 'b) w $x2_2:('a, 'b) w
+        comparison*)
+    
+    val h_4 :
+    ('a -> 'a -> int) -> ('b -> 'b -> int) -> ('a, 'b) w -> ('a, 'b) w -> int
+    (*@ result_9:int = h_4
+        $x0_9:'a -> 'a -> int $x1_9:'b -> 'b -> int $x2_3:('a, 'b) w
+        $x3:('a, 'b) w
+        comparison*)
+    
+    val h_5 : ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int
+    (*@ result_10:int = h_5
+        $x0_10:'a -> 'a -> int $x1_10:('a, 'a) w $x2_4:('a, 'a) w
+        comparison*)
+    
+    val h_6 :
+    ('a -> 'a -> int) -> ('a -> 'a -> int) -> ('a, 'a) w -> ('a, 'a) w -> int
+    (*@ result_11:int = h_6
+        $x0_11:'a -> 'a -> int $x1_11:'a -> 'a -> int $x2_5:('a, 'a) w
+        $x3_1:('a, 'a) w
+        comparison*)
+    
+    val h_7 : ('a -> 'a -> int) -> ('a, 'b) w list -> ('a, 'b) w list -> int
+    (*@ result_12:int = h_7
+        $x0_12:'a -> 'a -> int $x1_12:('a, 'b) w list $x2_6:('a, 'b) w list
+        comparison*)
+    
+    val h_8 : ('a -> 'a -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+    (*@ result_13:int = h_8
+        $x0_13:'a -> 'a -> int $x1_13:('a, 'b list) w $x2_7:('a, 'b list) w
+        comparison*)
+    
+    val h_9 : ('b -> 'b -> int) -> ('a, 'b list) w -> ('a, 'b list) w -> int
+    (*@ result_14:int = h_9
+        $x0_14:'b -> 'b -> int $x1_14:('a, 'b list) w $x2_8:('a, 'b list) w
+        comparison*)
+
+OK

--- a/test/equality/positive/dune
+++ b/test/equality/positive/dune
@@ -1,0 +1,15 @@
+(include dune.inc)
+
+(rule
+ (targets dune.inc.gen)
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ../../gen/gen.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/test/equality/positive/dune.inc
+++ b/test/equality/positive/dune.inc
@@ -1,0 +1,13 @@
+(rule
+ (targets equality.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:equality.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:equality.mli.expected} %{dep:equality.mli.output})))
+

--- a/test/equality/positive/dune.inc
+++ b/test/equality/positive/dune.inc
@@ -1,4 +1,17 @@
 (rule
+ (targets comparison.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:comparison.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:comparison.mli.expected} %{dep:comparison.mli.output})))
+
+(rule
  (targets equality.mli.output)
  (deps (source_tree .))
  (action

--- a/test/equality/positive/equality.mli
+++ b/test/equality/positive/equality.mli
@@ -11,7 +11,44 @@ type 'a u
 val h : 'a u -> 'a u -> bool
 (*@ equality *)
 
+val h' : 'b u -> 'b u -> bool
+(*@ equality *)
+
+val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool
+(*@ equality *)
+
 type v = t
 
 val i : v -> t -> bool
+(*@ equality *)
+
+type ('a, 'b) w
+
+val h : ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h :
+  ('a -> 'a -> bool) -> ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality *)
+
+val h :
+  ('a -> 'a -> bool) -> ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+(*@ equality *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+(*@ equality *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
 (*@ equality *)

--- a/test/equality/positive/equality.mli
+++ b/test/equality/positive/equality.mli
@@ -1,0 +1,17 @@
+val f : int -> int -> bool
+(*@ equality *)
+
+type t
+
+val g : t -> t -> bool
+(*@ equality *)
+
+type 'a u
+
+val h : 'a u -> 'a u -> bool
+(*@ equality *)
+
+type v = t
+
+val i : v -> t -> bool
+(*@ equality *)

--- a/test/equality/positive/equality.mli.expected
+++ b/test/equality/positive/equality.mli.expected
@@ -1,0 +1,92 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+val f : int -> int -> bool[@@gospel {| equality |}]
+type t
+val g : t -> t -> bool[@@gospel {| equality |}]
+type 'a u
+val h : 'a u -> 'a u -> bool[@@gospel {| equality |}]
+type v = t
+val i : v -> t -> bool[@@gospel {| equality |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+val f : int -> int -> bool
+(*@ equality
+     *)
+
+type t
+  
+
+val g : t -> t -> bool
+(*@ equality
+     *)
+
+type 'a u
+  
+
+val h : 'a u -> 'a u -> bool
+(*@ equality
+     *)
+
+type v = t
+  
+
+val i : v -> t -> bool
+(*@ equality
+     *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module equality.mli
+
+  Namespace: equality.mli
+    Type symbols
+       t
+      ('a) u
+       v [=t]
+      
+    Logic Symbols
+      
+    Field Symbols
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    val f : int -> int -> bool
+    (*@ result:bool = f $x0:int $x1:int
+        equality*)
+    
+    type t
+         
+    
+    val g : t -> t -> bool
+    (*@ result_1:bool = g $x0_1:t $x1_1:t
+        equality*)
+    
+    type 'a u
+         
+    
+    val h : 'a u -> 'a u -> bool
+    (*@ result_2:bool = h $x0_2:'a u $x1_2:'a u
+        equality*)
+    
+    type v = t
+         
+    
+    val i : v -> t -> bool
+    (*@ result_3:bool = i $x0_3:t $x1_3:t
+        equality*)
+
+OK

--- a/test/equality/positive/equality.mli.expected
+++ b/test/equality/positive/equality.mli.expected
@@ -7,8 +7,32 @@ type t
 val g : t -> t -> bool[@@gospel {| equality |}]
 type 'a u
 val h : 'a u -> 'a u -> bool[@@gospel {| equality |}]
+val h' : 'b u -> 'b u -> bool[@@gospel {| equality |}]
+val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool[@@gospel {| equality |}]
 type v = t
 val i : v -> t -> bool[@@gospel {| equality |}]
+type ('a, 'b) w
+val h : ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel
+                                                                {| equality |}]
+val h : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel
+                                                                {| equality |}]
+val h :
+  ('a -> 'a -> bool) ->
+    ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool[@@gospel
+                                                            {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool[@@gospel
+                                                                {| equality |}]
+val h :
+  ('a -> 'a -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool[@@gospel
+                                                            {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+[@@gospel {| equality |}]
+val h : ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+[@@gospel {| equality |}]
+val h : ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+[@@gospel {| equality |}]
 
 *******************************
 ****** GOSPEL translation *****
@@ -33,10 +57,61 @@ val h : 'a u -> 'a u -> bool
 (*@ equality
      *)
 
+val h' : 'b u -> 'b u -> bool
+(*@ equality
+     *)
+
+val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool
+(*@ equality
+     *)
+
 type v = t
   
 
 val i : v -> t -> bool
+(*@ equality
+     *)
+
+type ('a, 'b) w
+  
+
+val h : ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h :
+  ('a -> 'a -> bool) ->
+    ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality
+     *)
+
+val h :
+  ('a -> 'a -> bool) ->
+    ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+(*@ equality
+     *)
+
+val h : ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+(*@ equality
+     *)
+
+val h : ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
 (*@ equality
      *)
 
@@ -50,6 +125,7 @@ module equality.mli
        t
       ('a) u
        v [=t]
+      ('a, 'b) w
       
     Logic Symbols
       
@@ -82,11 +158,75 @@ module equality.mli
     (*@ result_2:bool = h $x0_2:'a u $x1_2:'a u
         equality*)
     
+    val h' : 'b u -> 'b u -> bool
+    (*@ result_3:bool = h' $x0_3:'b u $x1_3:'b u
+        equality*)
+    
+    val h'' : ('a -> 'a -> bool) -> 'a u -> 'a u -> bool
+    (*@ result_4:bool = h'' $x0_4:'a -> 'a -> bool $x1_4:'a u $x2:'a u
+        equality*)
+    
     type v = t
          
     
     val i : v -> t -> bool
-    (*@ result_3:bool = i $x0_3:t $x1_3:t
+    (*@ result_5:bool = i $x0_5:t $x1_5:t
+        equality*)
+    
+    type ('a, 'b) w
+         
+    
+    val h_1 : ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_6:bool = h_1 $x0_6:('a, 'b) w $x1_6:('a, 'b) w
+        equality*)
+    
+    val h_2 : ('a -> 'a -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_7:bool = h_2
+        $x0_7:'a -> 'a -> bool $x1_7:('a, 'b) w $x2_1:('a, 'b) w
+        equality*)
+    
+    val h_3 : ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_8:bool = h_3
+        $x0_8:'b -> 'b -> bool $x1_8:('a, 'b) w $x2_2:('a, 'b) w
+        equality*)
+    
+    val h_4 :
+    ('a -> 'a -> bool) ->
+      ('b -> 'b -> bool) -> ('a, 'b) w -> ('a, 'b) w -> bool
+    (*@ result_9:bool = h_4
+        $x0_9:'a -> 'a -> bool $x1_9:'b -> 'b -> bool $x2_3:('a, 'b) w
+        $x3:('a, 'b) w
+        equality*)
+    
+    val h_5 : ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+    (*@ result_10:bool = h_5
+        $x0_10:'a -> 'a -> bool $x1_10:('a, 'a) w $x2_4:('a, 'a) w
+        equality*)
+    
+    val h_6 :
+    ('a -> 'a -> bool) ->
+      ('a -> 'a -> bool) -> ('a, 'a) w -> ('a, 'a) w -> bool
+    (*@ result_11:bool = h_6
+        $x0_11:'a -> 'a -> bool $x1_11:'a -> 'a -> bool $x2_5:('a, 'a) w
+        $x3_1:('a, 'a) w
+        equality*)
+    
+    val h_7 :
+    ('a -> 'a -> bool) -> ('a, 'b) w list -> ('a, 'b) w list -> bool
+    (*@ result_12:bool = h_7
+        $x0_12:'a -> 'a -> bool $x1_12:('a, 'b) w list $x2_6:('a, 'b) w list
+        equality*)
+    
+    val h_8 :
+    ('a -> 'a -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+    (*@ result_13:bool = h_8
+        $x0_13:'a -> 'a -> bool $x1_13:('a, 'b list) w $x2_7:('a, 'b list) w
+        equality*)
+    
+    val h_9 :
+    ('b -> 'b -> bool) -> ('a, 'b list) w -> ('a, 'b list) w -> bool
+    (*@ result_14:bool = h_9
+        $x0_14:'b -> 'b -> bool $x1_14:('a, 'b list) w $x2_8:('a, 'b list) w
         equality*)
 
 OK

--- a/test/positive/a3.mli.expected
+++ b/test/positive/a3.mli.expected
@@ -48,7 +48,6 @@ module a3.mli
             Type symbols
               ('a) array
               ('a) bag
-               int
               ('a) ref
               ('a) seq
               ('a) set

--- a/test/pure/negative/impure1.mli.expected
+++ b/test/pure/negative/impure1.mli.expected
@@ -19,6 +19,7 @@ type t
 
 val f : t -> int
 (*@ y = f x
+    pure
     modifies ...
      *)
 File "impure1.mli", line 5, characters 5-6:

--- a/test/pure/negative/impure3.mli.expected
+++ b/test/pure/negative/impure3.mli.expected
@@ -14,6 +14,7 @@ val f : int -> int[@@gospel
 
 val f : int -> int
 (*@ y = f x
+    pure
     with ...
      *)
 File "impure3.mli", line 2, characters 5-6:

--- a/test/pure/negative/impure4.mli.expected
+++ b/test/pure/negative/impure4.mli.expected
@@ -13,6 +13,7 @@ val f : int -> int[@@gospel {| y = f x
 
 val f : int -> int
 (*@ y = f x
+    pure
      *)
 File "impure4.mli", line 2, characters 5-6:
 Error: Type checking error: a pure function cannot raise exceptions

--- a/test/pure/positive/pure.mli.expected
+++ b/test/pure/positive/pure.mli.expected
@@ -18,7 +18,8 @@ f: int }
   
 
 val f : int -> int
-(*@  *)
+(*@ pure
+     *)
 
 val g : int -> int
 (*@ y = g x
@@ -56,7 +57,8 @@ module pure.mli
          
     
     val f : int -> int
-    (*@ result:int = f $x0:int*)
+    (*@ result:int = f $x0:int
+        pure*)
     
     val g : int -> int
     (*@ y:int = g x:int


### PR DESCRIPTION
Built on top of #165.
Adds a `comparison` clause, similar to `equality` for comparison functions.
`int` has to be added as a built-in symbol for the type checks to be possible. 