### PR TITLE
Add `int` as a primitive type

### DIFF
--- a/src/stdlib/gospelstdlib.mli
+++ b/src/stdlib/gospelstdlib.mli
@@ -19,6 +19,7 @@
    type float
    type bool
    type integer
+   type int
 
    type 'a option
    function None: 'a option
@@ -99,8 +100,6 @@
     specifications can be written using type [integer] only, and yet use OCaml's
     variables of type [int]. The Gospel typechecker will automatically apply
     [integer_of_int] whenever necessary. *)
-
-type int
 
 (*@ function integer_of_int (x: int) : integer *)
 (*@ coercion *)

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -167,6 +167,7 @@ let ns_with_primitives =
   let primitive_tys =
     [
       ("integer", ts_integer);
+      ("int", ts_int);
       ("string", ts_string);
       ("char", ts_char);
       ("float", ts_float);

--- a/src/ttypes.ml
+++ b/src/ttypes.ml
@@ -172,6 +172,7 @@ let ty_equal_check ty1 ty2 =
 
 let ts_unit = ts (Ident.create ~loc:Location.none "unit") []
 let ts_integer = ts (Ident.create ~loc:Location.none "integer") []
+let ts_int = ts (Ident.create ~loc:Location.none "int") []
 let ts_bool = ts (Ident.create ~loc:Location.none "bool") []
 let ts_float = ts (Ident.create ~loc:Location.none "float") []
 let ts_char = ts (Ident.create ~loc:Location.none "char") []
@@ -215,6 +216,7 @@ let is_ts_tuple ts =
 let is_ts_arrow ts = Ident.equal ts_arrow.ts_ident ts.ts_ident
 let ty_unit = ty_app ts_unit []
 let ty_integer = ty_app ts_integer []
+let ty_int = ty_app ts_int []
 let ty_bool = ty_app ts_bool []
 let ty_float = ty_app ts_float []
 let ty_char = ty_app ts_char []

--- a/test/positive/a3.mli.expected
+++ b/test/positive/a3.mli.expected
@@ -48,7 +48,6 @@ module a3.mli
             Type symbols
               ('a) array
               ('a) bag
-               int
               ('a) ref
               ('a) seq
               ('a) set


### PR DESCRIPTION
This is useful both to #166 and #170.﻿
