### PR TITLE
Add support for int literals

### DIFF
--- a/docs/docs/language/lexical-conventions.md
+++ b/docs/docs/language/lexical-conventions.md
@@ -25,3 +25,6 @@ etc. There are however a number of exceptions:
 In the rest of this documentation, `lident` (resp. `uident`) stands for an
 identifier with a lowercase (resp. uppercase) first character.
 
+- There is an extra literal modifier for literals of type `int`. Unmodified 
+  literals (e.g. `42`) are of type `integer`, but Gospel adds a `i` modifier to
+  write literals of type `int` (e.g. `42i`).

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -52,6 +52,7 @@ let ty_of_dty =
 (* predefined types *)
 
 let dty_integer = dty_of_ty ty_integer
+let dty_int = dty_of_ty ty_int
 let dty_bool = dty_of_ty ty_bool
 let dty_float = dty_of_ty ty_float
 let dty_char = dty_of_ty ty_char

--- a/src/dterm.mli
+++ b/src/dterm.mli
@@ -50,6 +50,7 @@ val dty_char : dty
 val dty_float : dty
 val dty_string : dty
 val dty_integer : dty
+val dty_int : dty
 val dty_of_dterm : dterm -> dty
 val dty_of_ty : Ttypes.ty -> dty
 val dty_fresh : unit -> dty

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -273,7 +273,9 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   | Uast.Tconst c ->
       let dty =
         match c with
-        | Pconst_integer _ -> dty_integer
+        | Pconst_integer (_, None) -> dty_integer
+        | Pconst_integer (_, Some 'i') -> dty_int
+        | Pconst_integer (_, _) -> assert false
         | Pconst_char _ -> dty_char
         | Pconst_string _ -> dty_string
         | Pconst_float _ -> dty_float

--- a/src/ulexer.mll
+++ b/src/ulexer.mll
@@ -165,6 +165,7 @@ let hex_float_literal =
   ['0'-'9' 'A'-'F' 'a'-'f'] ['0'-'9' 'A'-'F' 'a'-'f' '_']*
   ('.' ['0'-'9' 'A'-'F' 'a'-'f' '_']* )?
   (['p' 'P'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']* )?
+let int_literal_modifier = 'i'
 
 let op_char_1 = ['=' '<' '>' '~']
 let op_char_2 = ['+' '-']
@@ -183,8 +184,10 @@ rule token = parse
       { newline lexbuf; token lexbuf }
   | space+
       { token lexbuf }
-  | int_literal as s
-      { INTEGER s }
+  | int_literal as lit
+      { INTEGER (lit, None) }
+  | (int_literal as lit) (int_literal_modifier as modif)
+      { INTEGER (lit, Some modif) }
   | (float_literal | hex_float_literal) as s
       { FLOAT s }
   | "\'" ([^ '\\' '\'' '\010' '\013'] as c) "\'"

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -85,7 +85,7 @@
 %token <string> BACKQUOTE_LIDENT
 %token <string> ATTRIBUTE
 
-%token <string> INTEGER
+%token <string * char option> INTEGER
 %token <string> FLOAT
 %token <char> CHAR
 %token <string> STRING
@@ -445,7 +445,7 @@ quant:
 ;
 
 constant:
-| INTEGER { Parsetree.Pconst_integer ($1, None) }
+| INTEGER { let i, m = $1 in Parsetree.Pconst_integer (i, m) }
 | FLOAT { Parsetree.Pconst_float ($1, None) }
 | STRING { Pconst_string ($1, mk_loc $loc, None) }
 | CHAR { Pconst_char $1 }

--- a/test/int_literals/negative/bad_constr_arg.mli
+++ b/test/int_literals/negative/bad_constr_arg.mli
@@ -1,0 +1,5 @@
+(*@ type t = A of integer *)
+
+val f : int -> int
+(*@ y = f x
+    requires A 42i = A 42i *)

--- a/test/int_literals/negative/bad_constr_arg.mli.expected
+++ b/test/int_literals/negative/bad_constr_arg.mli.expected
@@ -1,0 +1,55 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+[@@@gospel {| type t = A of integer |}]
+val f : int -> int[@@gospel {| y = f x
+    requires A 42i = A 42i |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+(*@ type t =
+    | A of integer 
+   *)
+
+val f : int -> int
+(*@ y = f x
+    requires ...
+     *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module bad_constr_arg.mli
+
+  Namespace: bad_constr_arg.mli
+    Type symbols
+       t
+      
+    Logic Symbols
+      function A (_:integer) : t
+      
+    Field Symbols
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    (*@ type t = A of integer
+                 function A (_:integer) : t
+              *)
+    
+    val f : int -> int
+    (*@ y:int = f x:int
+        requires ((A  (integer_of_int  42i:int):integer):t = (A 
+                 (integer_of_int  42i:int):integer):t):prop*)
+
+OK

--- a/test/int_literals/negative/dune
+++ b/test/int_literals/negative/dune
@@ -1,0 +1,15 @@
+(include dune.inc)
+
+(rule
+ (targets dune.inc.gen)
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ../../gen/gen.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/test/int_literals/negative/dune.inc
+++ b/test/int_literals/negative/dune.inc
@@ -1,0 +1,13 @@
+(rule
+ (targets bad_constr_arg.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:bad_constr_arg.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:bad_constr_arg.mli.expected} %{dep:bad_constr_arg.mli.output})))
+

--- a/test/int_literals/positive/dune
+++ b/test/int_literals/positive/dune
@@ -1,0 +1,15 @@
+(include dune.inc)
+
+(rule
+ (targets dune.inc.gen)
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ../../gen/gen.exe))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/test/int_literals/positive/dune.inc
+++ b/test/int_literals/positive/dune.inc
@@ -1,0 +1,13 @@
+(rule
+ (targets ints.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:ints.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:ints.mli.expected} %{dep:ints.mli.output})))
+

--- a/test/int_literals/positive/ints.mli
+++ b/test/int_literals/positive/ints.mli
@@ -1,0 +1,8 @@
+type t = A of int
+
+val f : int -> int
+(*@ y = f x
+    requires x = 42i
+    requires 42 = 42i
+    requires 42i = 42i
+    requires A 42i = A 43i *)

--- a/test/int_literals/positive/ints.mli.expected
+++ b/test/int_literals/positive/ints.mli.expected
@@ -1,0 +1,66 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type t =
+  | A of int 
+val f : int -> int[@@gospel
+                    {| y = f x
+    requires x = 42i
+    requires 42 = 42i
+    requires 42i = 42i
+    requires A 42i = A 43i |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type t =
+| A of int 
+  
+
+val f : int -> int
+(*@ y = f x
+    requires ...
+    requires ...
+    requires ...
+    requires ...
+     *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module ints.mli
+
+  Namespace: ints.mli
+    Type symbols
+       t
+      
+    Logic Symbols
+      function A (_:int) : t
+      
+    Field Symbols
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    type t = A of int
+             function A (_:int) : t
+         
+    
+    val f : int -> int
+    (*@ y:int = f x:int
+        requires (x:int = 42i:int):prop
+                 requires (42:integer = (integer_of_int 
+                          42i:int):integer):prop
+                 requires (42i:int = 42i:int):prop
+                 requires ((A  42i:int):t = (A  43i:int):t):prop*)
+
+OK


### PR DESCRIPTION
In this PR, literals of type `int` can be written using the `i` modifier (e.g. `42i`).
/cc @paulpatault 