### PR TITLE
typechecker: fix support for types containing functions

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -493,7 +493,7 @@ let type_type_declaration kid crcm ns tdl =
         try { ty_node = Tyvar (Mstr.find s tvl) }
         with Not_found -> error ~loc:core.ptyp_loc (UnboundVar s))
     | Ptyp_arrow (lbl, ct1, ct2) ->
-        assert (lbl != Nolabel);
+        assert (lbl = Nolabel);
         (* TODO check what to do *)
         let ty1, ty2 = (parse_core alias tvl ct1, parse_core alias tvl ct2) in
         ty_app ts_arrow [ ty1; ty2 ]

--- a/test/positive/dune.inc
+++ b/test/positive/dune.inc
@@ -298,6 +298,19 @@
  (action (diff %{dep:pattern_matching.mli.expected} %{dep:pattern_matching.mli.output})))
 
 (rule
+ (targets record_functions.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:record_functions.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:record_functions.mli.expected} %{dep:record_functions.mli.output})))
+
+(rule
  (targets stdlib_exceptions.mli.output)
  (deps (source_tree .))
  (action

--- a/test/positive/record_functions.mli
+++ b/test/positive/record_functions.mli
@@ -1,0 +1,4 @@
+type t = int -> int
+type u = (int -> int) ref
+type v = private { x : int -> int }
+(*@ invariant x 0i = 0 *)

--- a/test/positive/record_functions.mli.expected
+++ b/test/positive/record_functions.mli.expected
@@ -1,0 +1,66 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type t = int -> int
+type u = (int -> int) ref
+type v = private {
+  x: int -> int }[@@gospel {| invariant x 0i = 0 |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type t = int -> int
+  
+
+type u = (int -> int) ref
+  
+
+type v = private {
+x: int -> int }
+  (*@ invariant ...
+       *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module record_functions.mli
+
+  Namespace: record_functions.mli
+    Type symbols
+       t [=int -> int]
+       u [=int -> int ref]
+       v
+      
+    Logic Symbols
+      function constr#v (_:int -> int) : v
+      
+    Field Symbols
+      function x (_:v) : int -> int
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    type t = int -> int
+         
+    
+    type u = int -> int ref
+         
+    
+    type v = {x:int -> int}
+          function constr#v (_:int -> int) : v
+          function x (_:v) : int -> int
+         (*@ 
+             invariant ((integer_of_int 
+                       (apply  (x ):int -> int 0i:int):int):integer = 0:
+                       integer):prop *)
+
+OK


### PR DESCRIPTION
It is not clear at all to me why this assertion is here. I can imagine the opposite assertion (and this is what this PR does): we don't know what to do with labelled arguments because Gospel can't reflect them.
This should probably be fixed anyways.