### PR TITLE
Add `self` in type invariants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Added
 
+- Added a `self` variable in type invariants referring to a value of the
+  specified type. [\#187](https://github.com/ocaml-gospel/gospel/pull/187)
 - Added support for `int` literals.
   [\#175](https://github.com/ocaml-gospel/gospel/pull/175) and
   [\#177](https://github.com/ocaml-gospel/gospel/pull/177)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## Added
 
-- Added a `self` variable in type invariants referring to a value of the
-  specified type. [\#187](https://github.com/ocaml-gospel/gospel/pull/187)
+- Added a `with` construct to name a variable in type invariants referring to a
+  value of the specified type.
+  [\#187](https://github.com/ocaml-gospel/gospel/pull/187)
 - Added support for `int` literals.
   [\#175](https://github.com/ocaml-gospel/gospel/pull/175) and
   [\#177](https://github.com/ocaml-gospel/gospel/pull/177)

--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(dirs :standard \ docs)

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -250,8 +250,7 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
         if extra = [] then dt else map_apply dt extra
   in
   let fun_app ~loc ls tl =
-    if ls.ls_field && ls.ls_args <> [] then
-      W.error ~loc (W.Field_application ls.ls_name.id_str);
+    if ls.ls_field then W.error ~loc (W.Field_application ls.ls_name.id_str);
     gen_app ~loc ls tl
   in
   let qualid_app q tl =
@@ -296,6 +295,8 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   | Uast.Tpreid q ->
       (* in this case it must be a constant *)
       let ls = find_q_ls ns q in
+      if ls.ls_field then
+        W.error ~loc (W.Symbol_not_found (string_list_of_qualid q));
       if ls.ls_args <> [] then
         W.error ~loc (W.Partial_application ls.ls_name.id_str);
       let _, dty = specialize_ls ls in
@@ -463,8 +464,7 @@ let process_type_spec kid crcm ns ty spec =
   let field (ns, fields) f =
     let f_ty = ty_of_pty ns f.f_pty in
     let ls = fsymbol ~field:true (Ident.of_preid f.f_preid) [ ty ] f_ty in
-    let ls_inv = fsymbol ~field:true (Ident.of_preid f.f_preid) [] f_ty in
-    ( ns_add_ls ~allow_duplicate:true ns f.f_preid.pid_str ls_inv,
+    ( ns_add_fd ~allow_duplicate:true ns f.f_preid.pid_str ls,
       (ls, f.f_mutable) :: fields )
   in
   let ns, fields = List.fold_left field (ns, []) spec.ty_field in
@@ -489,10 +489,8 @@ let type_type_declaration kid crcm ns tdl =
     | Ptyp_any -> W.error ~loc (W.Unsupported "_ type parameters")
     | Ptyp_var s -> (
         try { ty_node = Tyvar (Mstr.find s tvl) }
-        with Not_found -> W.error ~loc (W.Unbound_variable s))
-    | Ptyp_arrow (lbl, ct1, ct2) ->
-        assert (lbl = Nolabel);
-        (* TODO check what to do *)
+        with Not_found -> W.error ~loc:core.ptyp_loc (W.Unbound_variable s))
+    | Ptyp_arrow (_lbl, ct1, ct2) ->
         let ty1, ty2 = (parse_core alias tvl ct1, parse_core alias tvl ct2) in
         ty_app ts_arrow [ ty1; ty2 ]
     | Ptyp_tuple ctl ->
@@ -549,39 +547,44 @@ let type_type_declaration kid crcm ns tdl =
         let id = Ident.create ~loc:ld.pld_loc ld.pld_name.txt in
         let ty_res = parse_core alias tvl ld.pld_type in
         let field = fsymbol ~field:true id [ ty ] ty_res in
-        let field_inv = fsymbol ~field:true id [] ty_res in
         let mut = mutable_flag ld.pld_mutable in
         let ld = label_declaration field mut ld.pld_loc ld.pld_attributes in
-        (ld :: ldl, ns_add_ls ~allow_duplicate:true ns id.id_str field_inv)
+        (ld :: ldl, ns_add_fd ~allow_duplicate:true ns id.id_str field)
       in
       let rd_ldl, ns = List.fold_right mk_ld ldl ([], ns) in
       ({ rd_cs; rd_ldl }, ns)
     in
 
-    let process_variant ty alias cd =
+    let process_variant ty_res alias cd (acc, ns) =
       let loc = cd.pcd_loc in
       if cd.pcd_res != None then
         W.error ~loc (W.Unsupported "type in constructors");
       let cs_id = Ident.create ~loc cd.pcd_name.txt in
-      let cd_cs, cd_ld =
+      let cd_cs, cd_ld, ns =
         match cd.pcd_args with
         | Pcstr_tuple ctl ->
             let tyl = List.map (parse_core alias tvl) ctl in
-            (fsymbol ~constr:true ~field:false cs_id tyl ty, [])
+            let ls = fsymbol ~constr:true ~field:false cs_id tyl ty_res in
+            (ls, [], ns_add_ls ~allow_duplicate:true ns cs_id.id_str ls)
         | Pcstr_record ldl ->
-            let add ld (ldl, tyl) =
+            let add ld (ldl, tyl, ns) =
               let id = Ident.create ~loc:ld.pld_loc ld.pld_name.txt in
               let ty = parse_core alias tvl ld.pld_type in
-              let field = (id, ty) in
               let mut = mutable_flag ld.pld_mutable in
-              let loc, attrs = (ld.pld_loc, ld.pld_attributes) in
-              let ld = label_declaration field mut loc attrs in
-              (ld :: ldl, ty :: tyl)
+              let field = fsymbol ~constr:false ~field:true id [ ty_res ] ty in
+              let ld =
+                label_declaration (id, ty) mut ld.pld_loc ld.pld_attributes
+              in
+              ( ld :: ldl,
+                ty :: tyl,
+                ns_add_fd ~allow_duplicate:true ns id.id_str field )
             in
-            let ldl, tyl = List.fold_right add ldl ([], []) in
-            (fsymbol ~constr:true ~field:false cs_id tyl ty, ldl)
+            let ldl, tyl, ns = List.fold_right add ldl ([], [], ns) in
+            let cs = fsymbol ~constr:true ~field:false cs_id tyl ty_res in
+            let ns = ns_add_ls ~allow_duplicate:true ns cs_id.id_str cs in
+            (cs, ldl, ns)
       in
-      constructor_decl cd_cs cd_ld cd.pcd_loc cd.pcd_attributes
+      (constructor_decl cd_cs cd_ld cd.pcd_loc cd.pcd_attributes :: acc, ns)
     in
 
     let ty = ty_app td_ts (List.map ty_of_var params) in
@@ -590,12 +593,19 @@ let type_type_declaration kid crcm ns tdl =
       match td.tkind with
       | Ptype_abstract -> (Pty_abstract, ns)
       | Ptype_variant cdl ->
-          (Pty_variant (List.map (process_variant ty alias) cdl), ns)
+          let v, ns = List.fold_right (process_variant ty alias) cdl ([], ns) in
+          (Pty_variant v, ns)
       | Ptype_record ldl ->
           let record, ns = process_record ty alias ldl in
           (Pty_record record, ns)
       | Ptype_open -> assert false
     in
+
+    (* Adding a `self` variable of type `t` in the namespace for invariants *)
+    let self_ident = Ident.create ~loc:Location.none "self" in
+    let self_ls = lsymbol ~constr:false ~field:false self_ident [] (Some ty) in
+    let ns = ns_add_ls ~allow_duplicate:true ns "self" self_ls in
+
     (* invariants are only allowed on abstract/private types *)
     (match ((td.tkind, td.tmanifest), td.tspec) with
     | ( ((Ptype_variant _ | Ptype_record _), _ | _, Some _),
@@ -705,23 +715,12 @@ let process_val_spec kid crcm ns id args ret vs =
   let env, args = process_args header.sp_hd_args args Mstr.empty [] in
 
   let pre = List.map (fmla kid crcm ns env) vs.sp_pre in
-
   let checks = List.map (fmla kid crcm ns env) vs.sp_checks in
-
   let wr =
-    List.map
-      (fun t ->
-        let dt = dterm kid crcm ns env t in
-        term env dt)
-      vs.sp_writes
+    List.map (fun t -> dterm kid crcm ns env t |> term env) vs.sp_writes
   in
-
   let cs =
-    List.map
-      (fun t ->
-        let dt = dterm kid crcm ns env t in
-        term env dt)
-      vs.sp_consumes
+    List.map (fun t -> dterm kid crcm ns env t |> term env) vs.sp_consumes
   in
 
   let process_xpost (loc, exn) =

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -111,7 +111,7 @@ type field = {
 type type_spec = {
   ty_ephemeral : bool;
   ty_field : field list;
-  ty_invariant : term list;
+  ty_invariant : Preid.t option * term list;
   ty_text : string;
   ty_loc : Location.t;
 }

--- a/src/upretty_printer.ml
+++ b/src/upretty_printer.ml
@@ -43,9 +43,9 @@ let type_spec f ts =
     pp f "@[<v>%a%a%a@]" ephemeral ts.ty_ephemeral (list_keyword "model ...")
       ts.ty_field
       (list_keyword "invariant ...")
-      ts.ty_invariant
+      (snd ts.ty_invariant)
   in
-  if ts.ty_ephemeral || ts.ty_field != [] || ts.ty_invariant != [] then
+  if ts.ty_ephemeral || ts.ty_field != [] || snd ts.ty_invariant != [] then
     pp f "@[%a@]" (spec print_tspec) ts
   else ()
 

--- a/test/negative/dune.inc
+++ b/test/negative/dune.inc
@@ -142,6 +142,32 @@
  (action (diff %{dep:invariant3.mli.expected} %{dep:invariant3.mli.output})))
 
 (rule
+ (targets invariant4.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:invariant4.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:invariant4.mli.expected} %{dep:invariant4.mli.output})))
+
+(rule
+ (targets invariant5.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:invariant5.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:invariant5.mli.expected} %{dep:invariant5.mli.output})))
+
+(rule
  (targets t1.mli.output)
  (deps (source_tree .))
  (action

--- a/test/negative/invariant4.mli
+++ b/test/negative/invariant4.mli
@@ -1,0 +1,3 @@
+type 'a t = private { a : 'a }
+(*@ with self
+    invariant self.a = 42 *)

--- a/test/negative/invariant4.mli.expected
+++ b/test/negative/invariant4.mli.expected
@@ -1,0 +1,19 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t = private {
+  a: 'a }[@@gospel {| with self
+    invariant self.a = 42 |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t = private {
+a: 'a }
+  (*@ invariant ...
+       *)
+File "invariant4.mli", line 3, characters 14-20:
+Error: This term has type `'a' but a term was expected of type `integer'.

--- a/test/negative/invariant5.mli
+++ b/test/negative/invariant5.mli
@@ -1,0 +1,2 @@
+type 'a t = private { a : 'a }
+(*@ invariant self.a = self.a *)

--- a/test/negative/invariant5.mli.expected
+++ b/test/negative/invariant5.mli.expected
@@ -1,0 +1,18 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type 'a t = private {
+  a: 'a }[@@gospel {| invariant self.a = self.a |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type 'a t = private {
+a: 'a }
+  (*@ invariant ...
+       *)
+File "invariant5.mli", line 2, characters 11-15:
+Error: Symbol self not found.

--- a/test/positive/FM19.mli
+++ b/test/positive/FM19.mli
@@ -72,8 +72,8 @@ type elem
 (*@ mutable model dom: elem set
     mutable model rep: elem -> elem
     mutable model internal: unit
-    invariant forall x. Set.mem x dom -> Set.mem (rep x) dom
-    invariant forall x. Set.mem x dom -> rep (rep x) = rep x *)
+    invariant forall x. Set.mem x self.dom -> Set.mem (self.rep x) self.dom
+    invariant forall x. Set.mem x self.dom -> self.rep (self.rep x) = self.rep x *)
 
 val equiv : elem -> elem -> bool
 (*@ b = equiv [uf: uf_instance] e1 e2

--- a/test/positive/FM19.mli
+++ b/test/positive/FM19.mli
@@ -72,6 +72,7 @@ type elem
 (*@ mutable model dom: elem set
     mutable model rep: elem -> elem
     mutable model internal: unit
+    with self
     invariant forall x. Set.mem x self.dom -> Set.mem (self.rep x) self.dom
     invariant forall x. Set.mem x self.dom -> self.rep (self.rep x) = self.rep x *)
 

--- a/test/positive/FM19.mli.expected
+++ b/test/positive/FM19.mli.expected
@@ -51,6 +51,7 @@ type elem
                           {| mutable model dom: elem set
     mutable model rep: elem -> elem
     mutable model internal: unit
+    with self
     invariant forall x. Set.mem x self.dom -> Set.mem (self.rep x) self.dom
     invariant forall x. Set.mem x self.dom -> self.rep (self.rep x) = self.rep x |}]]
 val equiv : elem -> elem -> bool[@@gospel
@@ -343,15 +344,25 @@ module FM19.mli
                  mutable model rep : elem -> elem
                  mutable model internal : unit
                  invariant forall x_1:elem. (mem 
-                           x_1:elem ((self ):uf_instance).dom):prop -> (mem 
-                           (apply  ((self ):uf_instance).rep x_1:elem):
-                           elem ((self ):uf_instance).dom):propinvariant
-                           forall x_2:elem. (mem 
-                           x_2:elem ((self ):uf_instance).dom):prop -> ((apply 
-                           ((self ):uf_instance).rep (apply 
-                           ((self ):uf_instance).rep x_2:elem):elem):
-                           elem = (apply 
-                           ((self ):uf_instance).rep x_2:elem):elem):prop *) *)
+                           x_1:elem (self:uf_instance).dom):prop -> (mem 
+                           (apply  (self:uf_instance).rep x_1:elem):elem
+                           (self:uf_instance).dom):propinvariantforall 
+                                                                x_2:elem. (mem 
+                                                                x_2:elem
+                                                                (self:
+                                                                 uf_instance).dom):prop -> ((apply 
+                                                                (self:
+                                                                 uf_instance).rep
+                                                                (apply 
+                                                                (self:
+                                                                 uf_instance).rep
+                                                                x_2:elem):
+                                                                elem):
+                                                                elem = (apply 
+                                                                (self:
+                                                                 uf_instance).rep
+                                                                x_2:elem):
+                                                                elem):prop *) *)
     
     val equiv : elem -> elem -> bool
     (*@ b_2:bool = equiv [uf:uf_instance: uf_instance] e1:elem e2:elem

--- a/test/positive/FM19.mli.expected
+++ b/test/positive/FM19.mli.expected
@@ -51,8 +51,8 @@ type elem
                           {| mutable model dom: elem set
     mutable model rep: elem -> elem
     mutable model internal: unit
-    invariant forall x. Set.mem x dom -> Set.mem (rep x) dom
-    invariant forall x. Set.mem x dom -> rep (rep x) = rep x |}]]
+    invariant forall x. Set.mem x self.dom -> Set.mem (self.rep x) self.dom
+    invariant forall x. Set.mem x self.dom -> self.rep (self.rep x) = self.rep x |}]]
 val equiv : elem -> elem -> bool[@@gospel
                                   {| b = equiv [uf: uf_instance] e1 e2
     requires Set.mem e1 uf.dom && Set.mem e2 uf.dom
@@ -343,23 +343,15 @@ module FM19.mli
                  mutable model rep : elem -> elem
                  mutable model internal : unit
                  invariant forall x_1:elem. (mem 
-                           x_1:elem (dom_1 ):elem set):prop -> (mem 
-                           (apply  (rep_1 ):elem -> elem x_1:elem):elem
-                           (dom_1 ):elem set):propinvariantforall x_2:elem. (mem 
-                                                           x_2:elem
-                                                           (dom_1 ):elem 
-                                                           set):prop -> ((apply 
-                                                           (rep_1 ):elem ->
-                                                                    elem
-                                                           (apply 
-                                                           (rep_1 ):elem ->
-                                                                    elem
-                                                           x_2:elem):
-                                                           elem):elem = (apply 
-                                                           (rep_1 ):elem ->
-                                                                    elem
-                                                           x_2:elem):
-                                                           elem):prop *) *)
+                           x_1:elem ((self ):uf_instance).dom):prop -> (mem 
+                           (apply  ((self ):uf_instance).rep x_1:elem):
+                           elem ((self ):uf_instance).dom):propinvariant
+                           forall x_2:elem. (mem 
+                           x_2:elem ((self ):uf_instance).dom):prop -> ((apply 
+                           ((self ):uf_instance).rep (apply 
+                           ((self ):uf_instance).rep x_2:elem):elem):
+                           elem = (apply 
+                           ((self ):uf_instance).rep x_2:elem):elem):prop *) *)
     
     val equiv : elem -> elem -> bool
     (*@ b_2:bool = equiv [uf:uf_instance: uf_instance] e1:elem e2:elem

--- a/test/positive/bitvector.mli
+++ b/test/positive/bitvector.mli
@@ -1,5 +1,6 @@
 type t = private { size : int; mutable mask : int }
-(*@ invariant 0 <= self.size <= 63
+(*@ with self
+    invariant 0 <= self.size <= 63
     invariant 0 <= self.mask < pow 2 self.size *)
 
 (*@ predicate mem (i: integer) (bv: t) = logand bv.mask (pow 2 i) <> 0 *)

--- a/test/positive/bitvector.mli
+++ b/test/positive/bitvector.mli
@@ -1,6 +1,6 @@
 type t = private { size : int; mutable mask : int }
-(*@ invariant 0 <= size <= 63
-    invariant 0 <= mask < pow 2 size *)
+(*@ invariant 0 <= self.size <= 63
+    invariant 0 <= self.mask < pow 2 self.size *)
 
 (*@ predicate mem (i: integer) (bv: t) = logand bv.mask (pow 2 i) <> 0 *)
 

--- a/test/positive/bitvector.mli.expected
+++ b/test/positive/bitvector.mli.expected
@@ -5,8 +5,8 @@
 type t = private {
   size: int ;
   mutable mask: int }[@@gospel
-                       {| invariant 0 <= size <= 63
-    invariant 0 <= mask < pow 2 size |}]
+                       {| invariant 0 <= self.size <= 63
+    invariant 0 <= self.mask < pow 2 self.size |}]
 [@@@gospel
   {| predicate mem (i: integer) (bv: t) = logand bv.mask (pow 2 i) <> 0 |}]
 val create : int -> t[@@gospel
@@ -88,12 +88,12 @@ module bitvector.mli
           function mask (_:t) : int
          (*@ 
              invariant (0:integer <= (integer_of_int 
-                       (size ):int):integer):prop /\ ((integer_of_int 
-                       (size ):int):integer <= 63:integer):propinvariant
+                       ((self ):t).size):integer):prop /\ ((integer_of_int 
+                       ((self ):t).size):integer <= 63:integer):propinvariant
                        (0:integer <= (integer_of_int 
-                       (mask ):int):integer):prop /\ ((integer_of_int 
-                       (mask ):int):integer < (pow 
-                       2:integer (integer_of_int  (size ):int):integer):
+                       ((self ):t).mask):integer):prop /\ ((integer_of_int 
+                       ((self ):t).mask):integer < (pow 
+                       2:integer (integer_of_int  ((self ):t).size):integer):
                        integer):prop *)
     
     (*@ predicate mem (i:integer) (bv:t) =

--- a/test/positive/bitvector.mli.expected
+++ b/test/positive/bitvector.mli.expected
@@ -5,7 +5,8 @@
 type t = private {
   size: int ;
   mutable mask: int }[@@gospel
-                       {| invariant 0 <= self.size <= 63
+                       {| with self
+    invariant 0 <= self.size <= 63
     invariant 0 <= self.mask < pow 2 self.size |}]
 [@@@gospel
   {| predicate mem (i: integer) (bv: t) = logand bv.mask (pow 2 i) <> 0 |}]
@@ -88,12 +89,12 @@ module bitvector.mli
           function mask (_:t) : int
          (*@ 
              invariant (0:integer <= (integer_of_int 
-                       ((self ):t).size):integer):prop /\ ((integer_of_int 
-                       ((self ):t).size):integer <= 63:integer):propinvariant
+                       (self:t).size):integer):prop /\ ((integer_of_int 
+                       (self:t).size):integer <= 63:integer):propinvariant
                        (0:integer <= (integer_of_int 
-                       ((self ):t).mask):integer):prop /\ ((integer_of_int 
-                       ((self ):t).mask):integer < (pow 
-                       2:integer (integer_of_int  ((self ):t).size):integer):
+                       (self:t).mask):integer):prop /\ ((integer_of_int 
+                       (self:t).mask):integer < (pow 
+                       2:integer (integer_of_int  (self:t).size):integer):
                        integer):prop *)
     
     (*@ predicate mem (i:integer) (bv:t) =

--- a/test/positive/dune.inc
+++ b/test/positive/dune.inc
@@ -311,6 +311,19 @@
  (action (diff %{dep:record_functions.mli.expected} %{dep:record_functions.mli.output})))
 
 (rule
+ (targets recursive_type_invariant.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:recursive_type_invariant.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:recursive_type_invariant.mli.expected} %{dep:recursive_type_invariant.mli.output})))
+
+(rule
  (targets stdlib_exceptions.mli.output)
  (deps (source_tree .))
  (action

--- a/test/positive/invariants.mli
+++ b/test/positive/invariants.mli
@@ -1,3 +1,3 @@
-type t1 = private { a : int } (*@ invariant self.a >= 0 *)
+type t1 = private { a : int } (*@ with toto invariant toto.a >= 0 *)
 type t2 = private A | B (*@ invariant 1 > 0 *)
 type t3 = private int * int (*@ invariant 1 > 0 *)

--- a/test/positive/invariants.mli
+++ b/test/positive/invariants.mli
@@ -1,3 +1,3 @@
-type t1 = private { a : int } (*@ invariant a >= 0 *)
+type t1 = private { a : int } (*@ invariant self.a >= 0 *)
 type t2 = private A | B (*@ invariant 1 > 0 *)
 type t3 = private int * int (*@ invariant 1 > 0 *)

--- a/test/positive/invariants.mli.expected
+++ b/test/positive/invariants.mli.expected
@@ -3,7 +3,7 @@
 ********** Parsed file ********
 *******************************
 type t1 = private {
-  a: int }[@@gospel {| invariant a >= 0 |}]
+  a: int }[@@gospel {| invariant self.a >= 0 |}]
 type t2 = private
   | A 
   | B [@@gospel {| invariant 1 > 0 |}]
@@ -62,7 +62,7 @@ module invariants.mli
            function a_1 (_:t1) : int
          (*@ 
              invariant ((integer_of_int 
-                       (a_1 ):int):integer >= 0:integer):prop *)
+                       ((self ):t1).a_1):integer >= 0:integer):prop *)
     
     type t2 = A of 
               function A  : t2

--- a/test/positive/invariants.mli.expected
+++ b/test/positive/invariants.mli.expected
@@ -3,7 +3,7 @@
 ********** Parsed file ********
 *******************************
 type t1 = private {
-  a: int }[@@gospel {| invariant self.a >= 0 |}]
+  a: int }[@@gospel {| with toto invariant toto.a >= 0 |}]
 type t2 = private
   | A 
   | B [@@gospel {| invariant 1 > 0 |}]
@@ -62,7 +62,7 @@ module invariants.mli
            function a_1 (_:t1) : int
          (*@ 
              invariant ((integer_of_int 
-                       ((self ):t1).a_1):integer >= 0:integer):prop *)
+                       (toto:t1).a_1):integer >= 0:integer):prop *)
     
     type t2 = A of 
               function A  : t2

--- a/test/positive/record_functions.mli
+++ b/test/positive/record_functions.mli
@@ -1,4 +1,4 @@
 type t = int -> int
 type u = (int -> int) ref
 type v = private { x : int -> int }
-(*@ invariant self.x 0i = 0 *)
+(*@ with self invariant self.x 0i = 0 *)

--- a/test/positive/record_functions.mli
+++ b/test/positive/record_functions.mli
@@ -1,4 +1,4 @@
 type t = int -> int
 type u = (int -> int) ref
 type v = private { x : int -> int }
-(*@ invariant x 0i = 0 *)
+(*@ invariant self.x 0i = 0 *)

--- a/test/positive/record_functions.mli.expected
+++ b/test/positive/record_functions.mli.expected
@@ -5,7 +5,7 @@
 type t = int -> int
 type u = (int -> int) ref
 type v = private {
-  x: int -> int }[@@gospel {| invariant self.x 0i = 0 |}]
+  x: int -> int }[@@gospel {| with self invariant self.x 0i = 0 |}]
 
 *******************************
 ****** GOSPEL translation *****
@@ -60,7 +60,6 @@ module record_functions.mli
           function x (_:v) : int -> int
          (*@ 
              invariant ((integer_of_int 
-                       (apply  ((self ):v).x 0i:int):int):integer = 0:
-                       integer):prop *)
+                       (apply  (self:v).x 0i:int):int):integer = 0:integer):prop *)
 
 OK

--- a/test/positive/record_functions.mli.expected
+++ b/test/positive/record_functions.mli.expected
@@ -5,7 +5,7 @@
 type t = int -> int
 type u = (int -> int) ref
 type v = private {
-  x: int -> int }[@@gospel {| invariant x 0i = 0 |}]
+  x: int -> int }[@@gospel {| invariant self.x 0i = 0 |}]
 
 *******************************
 ****** GOSPEL translation *****
@@ -60,7 +60,7 @@ module record_functions.mli
           function x (_:v) : int -> int
          (*@ 
              invariant ((integer_of_int 
-                       (apply  (x ):int -> int 0i:int):int):integer = 0:
+                       (apply  ((self ):v).x 0i:int):int):integer = 0:
                        integer):prop *)
 
 OK

--- a/test/positive/recursive_type_invariant.mli
+++ b/test/positive/recursive_type_invariant.mli
@@ -1,0 +1,12 @@
+type t = private A | B of t | C of { x : t }
+(*@ invariant match self with
+              | A -> true
+              | B t' -> self = t'
+              | C a -> a.x = self *)
+
+type u = private { tag : int; next : u }
+(*@ invariant self.tag = self.next.tag = self.next.next.tag *)
+
+val f : u -> u
+(*@ y = f x
+    requires x.tag = 0 *)

--- a/test/positive/recursive_type_invariant.mli
+++ b/test/positive/recursive_type_invariant.mli
@@ -1,11 +1,13 @@
 type t = private A | B of t | C of { x : t }
-(*@ invariant match self with
+(*@ with self
+    invariant match self with
               | A -> true
               | B t' -> self = t'
               | C a -> a.x = self *)
 
 type u = private { tag : int; next : u }
-(*@ invariant self.tag = self.next.tag = self.next.next.tag *)
+(*@ with self
+    invariant self.tag = self.next.tag = self.next.next.tag *)
 
 val f : u -> u
 (*@ y = f x

--- a/test/positive/recursive_type_invariant.mli.expected
+++ b/test/positive/recursive_type_invariant.mli.expected
@@ -7,14 +7,16 @@ type t = private
   | B of t 
   | C of {
   x: t } [@@gospel
-           {| invariant match self with
+           {| with self
+    invariant match self with
               | A -> true
               | B t' -> self = t'
               | C a -> a.x = self |}]
 type u = private {
   tag: int ;
   next: u }[@@gospel
-             {| invariant self.tag = self.next.tag = self.next.next.tag |}]
+             {| with self
+    invariant self.tag = self.next.tag = self.next.next.tag |}]
 val f : u -> u[@@gospel {| y = f x
     requires x.tag = 0 |}]
 
@@ -78,11 +80,11 @@ module recursive_type_invariant.mli
              | C of {x:t}
                function C (_:t) : t
          (*@ 
-             invariant (match (self ):t with
+             invariant (match self:t with
                        | A -> (True ):bool
-                       | B t':t -> if ((self ):t = t':t):prop then (True ):
+                       | B t':t -> if (self:t = t':t):prop then (True ):
                                    bool else (False ):bool
-                       | C a_1:t -> if ((a_1:t).x = (self ):t):prop then (True ):
+                       | C a_1:t -> if ((a_1:t).x = self:t):prop then (True ):
                                     bool else (False ):bool
                        end::bool = (True ):bool):prop *)
     
@@ -91,8 +93,8 @@ module recursive_type_invariant.mli
           function tag (_:u) : int
           function next (_:u) : u
          (*@ 
-             invariant (((self_1 ):u).tag = (((self_1 ):u).next).tag):prop /\ ((((self_1 ):
-                       u).next).tag = ((((self_1 ):u).next).next).tag):prop *)
+             invariant ((self_1:u).tag = ((self_1:u).next).tag):prop /\ (((
+                       self_1:u).next).tag = (((self_1:u).next).next).tag):prop *)
     
     val f : u -> u
     (*@ y:u = f x_1:u

--- a/test/positive/recursive_type_invariant.mli.expected
+++ b/test/positive/recursive_type_invariant.mli.expected
@@ -1,0 +1,101 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+type t = private
+  | A 
+  | B of t 
+  | C of {
+  x: t } [@@gospel
+           {| invariant match self with
+              | A -> true
+              | B t' -> self = t'
+              | C a -> a.x = self |}]
+type u = private {
+  tag: int ;
+  next: u }[@@gospel
+             {| invariant self.tag = self.next.tag = self.next.next.tag |}]
+val f : u -> u[@@gospel {| y = f x
+    requires x.tag = 0 |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Gospelstdlib *)
+
+type t = private
+| A 
+| B of t 
+| C of {
+x: t } 
+  (*@ invariant ...
+       *)
+
+type u = private {
+tag: int ;
+next: u }
+  (*@ invariant ...
+       *)
+
+val f : u -> u
+(*@ y = f x
+    requires ...
+     *)
+
+*******************************
+********* Typed GOSPEL ********
+*******************************
+module recursive_type_invariant.mli
+
+  Namespace: recursive_type_invariant.mli
+    Type symbols
+       t
+       u
+      
+    Logic Symbols
+      function A  : t
+      function B (_:t) : t
+      function C (_:t) : t
+      function constr#u (_:int) (_:u) : u
+      
+    Field Symbols
+      function next (_:u) : u
+      function tag (_:u) : int
+      
+    Exception Symbols
+      
+    Namespaces
+      
+    Type Namespaces
+      
+  Signatures
+    (*@ open Gospelstdlib *)
+    
+    type t = A of 
+             function A  : t
+             | B of t
+               function B (_:t) : t
+             | C of {x:t}
+               function C (_:t) : t
+         (*@ 
+             invariant (match (self ):t with
+                       | A -> (True ):bool
+                       | B t':t -> if ((self ):t = t':t):prop then (True ):
+                                   bool else (False ):bool
+                       | C a_1:t -> if ((a_1:t).x = (self ):t):prop then (True ):
+                                    bool else (False ):bool
+                       end::bool = (True ):bool):prop *)
+    
+    type u = {tag:int; next:u}
+          function constr#u (_:int) (_:u) : u
+          function tag (_:u) : int
+          function next (_:u) : u
+         (*@ 
+             invariant (((self_1 ):u).tag = (((self_1 ):u).next).tag):prop /\ ((((self_1 ):
+                       u).next).tag = ((((self_1 ):u).next).next).tag):prop *)
+    
+    val f : u -> u
+    (*@ y:u = f x_1:u
+        requires ((integer_of_int  (x_1:u).tag):integer = 0:integer):prop*)
+
+OK

--- a/test/vocal/HashTable.mli
+++ b/test/vocal/HashTable.mli
@@ -31,9 +31,9 @@ module Make (K : HashedType) : sig
   type 'a table
   (*@ ephemeral
       mutable model dom : key set
-      invariant forall x y: key. Set.mem x dom -> Set.mem y dom -> K.equiv x y -> x = y
+      invariant forall x y: key. Set.mem x self.dom -> Set.mem y self.dom -> K.equiv x y -> x = y
       mutable model view: key -> 'a list
-      invariant forall k: key. not (Set.mem k dom) -> view k = [] *)
+      invariant forall k: key. not (Set.mem k self.dom) -> self.view k = [] *)
 
   type 'a t = 'a table
 

--- a/test/vocal/HashTable.mli
+++ b/test/vocal/HashTable.mli
@@ -31,8 +31,9 @@ module Make (K : HashedType) : sig
   type 'a table
   (*@ ephemeral
       mutable model dom : key set
-      invariant forall x y: key. Set.mem x self.dom -> Set.mem y self.dom -> K.equiv x y -> x = y
       mutable model view: key -> 'a list
+      with self
+      invariant forall x y: key. Set.mem x self.dom -> Set.mem y self.dom -> K.equiv x y -> x = y
       invariant forall k: key. not (Set.mem k self.dom) -> self.view k = [] *)
 
   type 'a t = 'a table

--- a/test/vocal/HashTable.mli.expected
+++ b/test/vocal/HashTable.mli.expected
@@ -26,8 +26,9 @@ functor (K : HashedType) ->
     type 'a table[@@gospel
                    {| ephemeral
       mutable model dom : key set
-      invariant forall x y: key. Set.mem x self.dom -> Set.mem y self.dom -> K.equiv x y -> x = y
       mutable model view: key -> 'a list
+      with self
+      invariant forall x y: key. Set.mem x self.dom -> Set.mem y self.dom -> K.equiv x y -> x = y
       invariant forall k: key. not (Set.mem k self.dom) -> self.view k = [] |}]
     type 'a t = 'a table
     val create : int -> 'a t[@@gospel
@@ -294,12 +295,12 @@ module HashTable.mli
                  mutable model dom : t set
                  mutable model view : t -> 'a list
                  invariant forall x_8:t y_5:t. (mem 
-                           x_8:t ((self ):'a41 table).dom):prop -> (mem 
-                           y_5:t ((self ):'a44 table).dom):prop -> (equiv 
+                           x_8:t (self:'a table).dom):prop -> (mem 
+                           y_5:t (self:'a table).dom):prop -> (equiv 
                            x_8:t y_5:t):prop -> (x_8:t = y_5:t):propinvariant
                            forall k:t. not (mem 
-                           k:t ((self ):'a48 table).dom):prop -> ((apply 
-                           ((self ):'a51 table).view k:t):'a51 list = ([] ):'a51 
+                           k:t (self:'a table).dom):prop -> ((apply 
+                           (self:'a table).view k:t):'a list = ([] ):'a 
                            list):prop *)
         type 'a t_1 = 'a table
              

--- a/test/vocal/HashTable.mli.expected
+++ b/test/vocal/HashTable.mli.expected
@@ -26,9 +26,9 @@ functor (K : HashedType) ->
     type 'a table[@@gospel
                    {| ephemeral
       mutable model dom : key set
-      invariant forall x y: key. Set.mem x dom -> Set.mem y dom -> K.equiv x y -> x = y
+      invariant forall x y: key. Set.mem x self.dom -> Set.mem y self.dom -> K.equiv x y -> x = y
       mutable model view: key -> 'a list
-      invariant forall k: key. not (Set.mem k dom) -> view k = [] |}]
+      invariant forall k: key. not (Set.mem k self.dom) -> self.view k = [] |}]
     type 'a t = 'a table
     val create : int -> 'a t[@@gospel
                               {| h = create n
@@ -294,12 +294,12 @@ module HashTable.mli
                  mutable model dom : t set
                  mutable model view : t -> 'a list
                  invariant forall x_8:t y_5:t. (mem 
-                           x_8:t (dom_1 ):t set):prop -> (mem 
-                           y_5:t (dom_1 ):t set):prop -> (equiv 
+                           x_8:t ((self ):'a41 table).dom):prop -> (mem 
+                           y_5:t ((self ):'a44 table).dom):prop -> (equiv 
                            x_8:t y_5:t):prop -> (x_8:t = y_5:t):propinvariant
                            forall k:t. not (mem 
-                           k:t (dom_1 ):t set):prop -> ((apply 
-                           (view_1 ):t -> 'a44 list k:t):'a44 list = ([] ):'a44 
+                           k:t ((self ):'a48 table).dom):prop -> ((apply 
+                           ((self ):'a51 table).view k:t):'a51 list = ([] ):'a51 
                            list):prop *)
         type 'a t_1 = 'a table
              

--- a/test/vocal/PriorityQueue.mli
+++ b/test/vocal/PriorityQueue.mli
@@ -26,8 +26,9 @@ module Make (X : sig
 end) : sig
   type elt = X.t
   type heap
-  (*@ mutable model bag : elt bag *)
-  (*@ invariant card bag <= Sys.max_array_length *)
+  (*@ mutable model bag : elt bag
+      with self
+      invariant Bag.cardinal self.bag <= Sys.max_array_length *)
 
   (*@ predicate mem (x: elt) (h: heap) = Bag.occurrences x h.bag > 0 *)
 

--- a/test/vocal/PriorityQueue.mli.expected
+++ b/test/vocal/PriorityQueue.mli.expected
@@ -17,8 +17,10 @@ functor (X :
   end) ->
   sig
     type elt = X.t
-    type heap[@@gospel {| mutable model bag : elt bag |}][@@gospel
-                                                           {| invariant card bag <= Sys.max_array_length |}]
+    type heap[@@gospel
+               {| mutable model bag : elt bag
+      with self
+      invariant Bag.cardinal self.bag <= Sys.max_array_length |}]
     [@@@gospel
       {| predicate mem (x: elt) (h: heap) = Bag.occurrences x h.bag > 0 |}]
     val create : unit -> heap[@@gospel
@@ -85,9 +87,10 @@ sig
 end) ->
 sig
   type elt = X.t
-    type heap[@@gospel {| invariant card bag <= Sys.max_array_length |}]
+    type heap
     (*@ ephemeral
         model ...
+        invariant ...
          *)
   (*@ predicate mem ... *)
   val create : unit -> heap
@@ -197,7 +200,10 @@ module PriorityQueue.mli
              
         type heap
              (*@ ephemeral
-                 mutable model bag_1 : t bag *)
+                 mutable model bag_1 : t bag
+                 invariant ((cardinal 
+                           (self:heap).bag_1):integer <= (max_array_length ):
+                           integer):prop *)
         (*@ predicate mem (x_1:t) (h:heap) =
             ((occurrences  x_1:t (h:heap).bag_1):integer > 0:integer):prop
         *)

--- a/test/vocal/RingBuffer.mli
+++ b/test/vocal/RingBuffer.mli
@@ -13,6 +13,7 @@
 type 'a buffer
 (*@ mutable model sequence: 'a seq
             model capacity: integer
+    with self
     invariant length self.sequence <= self.capacity <= Sys.max_array_length *)
 
 val create : int -> 'a -> 'a buffer

--- a/test/vocal/RingBuffer.mli
+++ b/test/vocal/RingBuffer.mli
@@ -13,7 +13,7 @@
 type 'a buffer
 (*@ mutable model sequence: 'a seq
             model capacity: integer
-    invariant length sequence <= capacity <= Sys.max_array_length *)
+    invariant length self.sequence <= self.capacity <= Sys.max_array_length *)
 
 val create : int -> 'a -> 'a buffer
 (*@ b = create n dummy

--- a/test/vocal/RingBuffer.mli.expected
+++ b/test/vocal/RingBuffer.mli.expected
@@ -6,6 +6,7 @@
 type 'a buffer[@@gospel
                 {| mutable model sequence: 'a seq
             model capacity: integer
+    with self
     invariant length self.sequence <= self.capacity <= Sys.max_array_length |}]
 val create : int -> 'a -> 'a buffer[@@gospel
                                      {| b = create n dummy
@@ -146,8 +147,8 @@ module RingBuffer.mli
              mutable model sequence : 'a seq
              model capacity : integer
              invariant ((length 
-                       ((self ):'a40 buffer).sequence):integer <= ((self ):'a42 
-                       buffer).capacity):prop /\ (((self ):'a42 buffer).capacity <= (max_array_length ):
+                       (self:'a buffer).sequence):integer <= (self:'a buffer).capacity):prop /\ ((
+                       self:'a buffer).capacity <= (max_array_length ):
                        integer):prop *)
     
     val create : int -> 'a -> 'a buffer

--- a/test/vocal/RingBuffer.mli.expected
+++ b/test/vocal/RingBuffer.mli.expected
@@ -6,7 +6,7 @@
 type 'a buffer[@@gospel
                 {| mutable model sequence: 'a seq
             model capacity: integer
-    invariant length sequence <= capacity <= Sys.max_array_length |}]
+    invariant length self.sequence <= self.capacity <= Sys.max_array_length |}]
 val create : int -> 'a -> 'a buffer[@@gospel
                                      {| b = create n dummy
       requires 0 < n <= Sys.max_array_length
@@ -146,8 +146,8 @@ module RingBuffer.mli
              mutable model sequence : 'a seq
              model capacity : integer
              invariant ((length 
-                       (sequence_1 ):'a39 seq):integer <= (capacity_1 ):
-                       integer):prop /\ ((capacity_1 ):integer <= (max_array_length ):
+                       ((self ):'a40 buffer).sequence):integer <= ((self ):'a42 
+                       buffer).capacity):prop /\ (((self ):'a42 buffer).capacity <= (max_array_length ):
                        integer):prop *)
     
     val create : int -> 'a -> 'a buffer

--- a/test/vocal/UnionFind.mli
+++ b/test/vocal/UnionFind.mli
@@ -17,6 +17,7 @@ type 'a elem
 (*@ mutable model dom : 'a elem set
     mutable model rep : 'a elem -> 'a elem
     mutable model img : 'a elem -> 'a
+    with self
     invariant forall x: 'a elem. mem x self.dom -> self.img x = self.img (self.rep x)
     invariant forall x: 'a elem. mem x self.dom -> self.rep (self.rep x) = self.rep x
     invariant forall x: 'a elem. mem x self.dom -> mem (self.rep x) self.dom *)

--- a/test/vocal/UnionFind.mli
+++ b/test/vocal/UnionFind.mli
@@ -17,9 +17,9 @@ type 'a elem
 (*@ mutable model dom : 'a elem set
     mutable model rep : 'a elem -> 'a elem
     mutable model img : 'a elem -> 'a
-    invariant forall x: 'a elem. mem x dom -> img x = img (rep x)
-    invariant forall x: 'a elem. mem x dom -> rep (rep x) = rep x
-    invariant forall x: 'a elem. mem x dom -> mem (rep x) dom *)
+    invariant forall x: 'a elem. mem x self.dom -> self.img x = self.img (self.rep x)
+    invariant forall x: 'a elem. mem x self.dom -> self.rep (self.rep x) = self.rep x
+    invariant forall x: 'a elem. mem x self.dom -> mem (self.rep x) self.dom *)
 
 (*@ predicate equiv (uf: 'a uf) (x: 'a elem) (y: 'a elem) =
       uf.rep x = uf.rep y *)

--- a/test/vocal/UnionFind.mli.expected
+++ b/test/vocal/UnionFind.mli.expected
@@ -10,6 +10,7 @@ type 'a elem
                     {| mutable model dom : 'a elem set
     mutable model rep : 'a elem -> 'a elem
     mutable model img : 'a elem -> 'a
+    with self
     invariant forall x: 'a elem. mem x self.dom -> self.img x = self.img (self.rep x)
     invariant forall x: 'a elem. mem x self.dom -> self.rep (self.rep x) = self.rep x
     invariant forall x: 'a elem. mem x self.dom -> mem (self.rep x) self.dom |}]]
@@ -247,20 +248,20 @@ module UnionFind.mli
                  mutable model rep : 'a elem -> 'a elem
                  mutable model img : 'a elem -> 'a
                  invariant forall x:'a elem. (mem 
-                           x:'a elem ((self ):'a uf).dom):prop -> ((apply 
-                           ((self ):'a uf).img x:'a elem):'a = (apply 
-                           ((self ):'a uf).img (apply 
-                           ((self ):'a uf).rep x:'a elem):'a elem):'a):propinvariant
+                           x:'a elem (self:'a uf).dom):prop -> ((apply 
+                           (self:'a uf).img x:'a elem):'a = (apply 
+                           (self:'a uf).img (apply 
+                           (self:'a uf).rep x:'a elem):'a elem):'a):propinvariant
                            forall x_1:'a elem. (mem 
-                           x_1:'a elem ((self ):'a uf).dom):prop -> ((apply 
-                           ((self ):'a uf).rep (apply 
-                           ((self ):'a uf).rep x_1:'a elem):'a elem):'a 
+                           x_1:'a elem (self:'a uf).dom):prop -> ((apply 
+                           (self:'a uf).rep (apply 
+                           (self:'a uf).rep x_1:'a elem):'a elem):'a 
                            elem = (apply 
-                           ((self ):'a uf).rep x_1:'a elem):'a elem):propinvariant
+                           (self:'a uf).rep x_1:'a elem):'a elem):propinvariant
                            forall x_2:'a elem. (mem 
-                           x_2:'a elem ((self ):'a uf).dom):prop -> (mem 
-                           (apply  ((self ):'a uf).rep x_2:'a elem):'a 
-                           elem ((self ):'a uf).dom):prop *) *)
+                           x_2:'a elem (self:'a uf).dom):prop -> (mem 
+                           (apply  (self:'a uf).rep x_2:'a elem):'a elem
+                           (self:'a uf).dom):prop *) *)
     
     (*@ predicate equiv (uf_1:'a uf) (x_3:'a elem) (y:'a elem) =
         ((apply  (uf_1:'a uf).rep x_3:'a elem):'a elem = (apply 

--- a/test/vocal/UnionFind.mli.expected
+++ b/test/vocal/UnionFind.mli.expected
@@ -10,9 +10,9 @@ type 'a elem
                     {| mutable model dom : 'a elem set
     mutable model rep : 'a elem -> 'a elem
     mutable model img : 'a elem -> 'a
-    invariant forall x: 'a elem. mem x dom -> img x = img (rep x)
-    invariant forall x: 'a elem. mem x dom -> rep (rep x) = rep x
-    invariant forall x: 'a elem. mem x dom -> mem (rep x) dom |}]]
+    invariant forall x: 'a elem. mem x self.dom -> self.img x = self.img (self.rep x)
+    invariant forall x: 'a elem. mem x self.dom -> self.rep (self.rep x) = self.rep x
+    invariant forall x: 'a elem. mem x self.dom -> mem (self.rep x) self.dom |}]]
 [@@@gospel
   {| predicate equiv (uf: 'a uf) (x: 'a elem) (y: 'a elem) =
       uf.rep x = uf.rep y |}]
@@ -247,25 +247,20 @@ module UnionFind.mli
                  mutable model rep : 'a elem -> 'a elem
                  mutable model img : 'a elem -> 'a
                  invariant forall x:'a elem. (mem 
-                           x:'a elem (dom_1 ):'a elem set):prop -> ((apply 
-                           (img_1 ):'a elem -> 'a x:'a elem):'a = (apply 
-                           (img_1 ):'a elem -> 'a (apply 
-                           (rep_1 ):'a elem -> 'a elem x:'a elem):'a 
-                           elem):'a):propinvariantforall x_1:'a elem. (mem 
-                                                  x_1:'a elem
-                                                  (dom_1 ):'a elem set):prop -> ((apply 
-                                                  (rep_1 ):'a elem -> 'a elem
-                                                  (apply 
-                                                  (rep_1 ):'a elem -> 'a elem
-                                                  x_1:'a elem):'a elem):'a 
-                                                  elem = (apply 
-                                                  (rep_1 ):'a elem -> 'a elem
-                                                  x_1:'a elem):'a elem):propinvariant
+                           x:'a elem ((self ):'a uf).dom):prop -> ((apply 
+                           ((self ):'a uf).img x:'a elem):'a = (apply 
+                           ((self ):'a uf).img (apply 
+                           ((self ):'a uf).rep x:'a elem):'a elem):'a):propinvariant
+                           forall x_1:'a elem. (mem 
+                           x_1:'a elem ((self ):'a uf).dom):prop -> ((apply 
+                           ((self ):'a uf).rep (apply 
+                           ((self ):'a uf).rep x_1:'a elem):'a elem):'a 
+                           elem = (apply 
+                           ((self ):'a uf).rep x_1:'a elem):'a elem):propinvariant
                            forall x_2:'a elem. (mem 
-                           x_2:'a elem (dom_1 ):'a elem set):prop -> (mem 
-                           (apply 
-                           (rep_1 ):'a elem -> 'a elem x_2:'a elem):'a 
-                           elem (dom_1 ):'a elem set):prop *) *)
+                           x_2:'a elem ((self ):'a uf).dom):prop -> (mem 
+                           (apply  ((self ):'a uf).rep x_2:'a elem):'a 
+                           elem ((self ):'a uf).dom):prop *) *)
     
     (*@ predicate equiv (uf_1:'a uf) (x_3:'a elem) (y:'a elem) =
         ((apply  (uf_1:'a uf).rep x_3:'a elem):'a elem = (apply 

--- a/test/vocal/Vector.mli
+++ b/test/vocal/Vector.mli
@@ -31,8 +31,9 @@
 
 type 'a t
 (** The polymorphic type of vectors. This is a mutable data type. *)
-(*@ mutable model view: 'a seq *)
-(*@ invariant Seq.length view <= Sys.max_array_length *)
+(*@ mutable model view: 'a seq
+    with self
+    invariant Seq.length self.view <= Sys.max_array_length *)
 
 (** {2 Operations proper to vectors, or with a different type and/or semantics
     than those of module [Array]} *)

--- a/test/vocal/Vector.mli.expected
+++ b/test/vocal/Vector.mli.expected
@@ -4,8 +4,10 @@
 *******************************
 [@@@ocaml.text
   " Vectors (aka resizable arrays, growing arrays, dynamic arrays, etc.)\n\n    This module implements arrays that automatically expand as necessary. Its\n    implementation uses a traditional array and replaces it with a larger array\n    when needed (and elements are copied from the old array to the new one). The\n    current implementation doubles the capacity when growing the array (and\n    shrinks it whenever the number of elements comes to one fourth of the\n    capacity).\n\n    The unused part of the internal array is filled with a dummy value, which is\n    user-provided at creation time (and referred to below as ``the dummy\n    value''). Consequently, vectors do not retain pointers to values that are\n    not used anymore after a shrinking.\n\n    Vectors provide an efficient implementation of stacks, with a better\n    locality of reference than list-based implementations (such as standard\n    library {!Stack}). A stack interface is provided, similar to that of\n    {!Stack} (though {!Vector.push} have arguments in the other way round).\n    Inserting [n] elements with {!Vector.push} has overall complexity O(n) i.e.\n    each insertion has amortized constant time complexity. "]
-type 'a t[@@gospel {| mutable model view: 'a seq |}][@@gospel
-                                                      {| invariant Seq.length view <= Sys.max_array_length |}]
+type 'a t[@@gospel
+           {| mutable model view: 'a seq
+    with self
+    invariant Seq.length self.view <= Sys.max_array_length |}]
 [@@@ocaml.text
   " {2 Operations proper to vectors, or with a different type and/or semantics\n    than those of module [Array]} "]
 val create : ?capacity:int -> dummy:'a -> 'a t[@@gospel
@@ -160,9 +162,10 @@ val top_opt : 'a t -> 'a option[@@gospel
 [@@@ocaml.text
   " Vectors (aka resizable arrays, growing arrays, dynamic arrays, etc.)\n\n    This module implements arrays that automatically expand as necessary. Its\n    implementation uses a traditional array and replaces it with a larger array\n    when needed (and elements are copied from the old array to the new one). The\n    current implementation doubles the capacity when growing the array (and\n    shrinks it whenever the number of elements comes to one fourth of the\n    capacity).\n\n    The unused part of the internal array is filled with a dummy value, which is\n    user-provided at creation time (and referred to below as ``the dummy\n    value''). Consequently, vectors do not retain pointers to values that are\n    not used anymore after a shrinking.\n\n    Vectors provide an efficient implementation of stacks, with a better\n    locality of reference than list-based implementations (such as standard\n    library {!Stack}). A stack interface is provided, similar to that of\n    {!Stack} (though {!Vector.push} have arguments in the other way round).\n    Inserting [n] elements with {!Vector.push} has overall complexity O(n) i.e.\n    each insertion has amortized constant time complexity. "]
 
-type 'a t[@@gospel {| invariant Seq.length view <= Sys.max_array_length |}]
+type 'a t
   (*@ ephemeral
       model ...
+      invariant ...
        *)
 
 [@@@ocaml.text
@@ -373,7 +376,10 @@ module Vector.mli
     
     type 'a t
          (*@ ephemeral
-             mutable model view : 'a seq *)
+             mutable model view : 'a seq
+             invariant ((length 
+                       (self:'a t).view):integer <= (max_array_length ):
+                       integer):prop *)
     
     [@@@ocaml.text
       " {2 Operations proper to vectors, or with a different type and/or semantics\n    than those of module [Array]} "]

--- a/test/vocal/ZipperList.mli
+++ b/test/vocal/ZipperList.mli
@@ -13,7 +13,7 @@
 type 'a t
 (*@ model seq: 'a seq
     model idx: integer
-    invariant 0 <= idx <= Seq.length seq *)
+    invariant 0 <= self.idx <= Seq.length self.seq *)
 
 val empty : unit -> 'a t
 (*@ z = empty ()

--- a/test/vocal/ZipperList.mli
+++ b/test/vocal/ZipperList.mli
@@ -13,6 +13,7 @@
 type 'a t
 (*@ model seq: 'a seq
     model idx: integer
+    with self
     invariant 0 <= self.idx <= Seq.length self.seq *)
 
 val empty : unit -> 'a t

--- a/test/vocal/ZipperList.mli.expected
+++ b/test/vocal/ZipperList.mli.expected
@@ -6,7 +6,7 @@
 type 'a t[@@gospel
            {| model seq: 'a seq
     model idx: integer
-    invariant 0 <= idx <= Seq.length seq |}]
+    invariant 0 <= self.idx <= Seq.length self.seq |}]
 val empty : unit -> 'a t[@@gospel
                           {| z = empty ()
     ensures z.seq = Seq.empty
@@ -201,8 +201,9 @@ module ZipperList.mli
          (*@ 
              model seq_1 : 'a seq
              model idx : integer
-             invariant (0:integer <= (idx_1 ):integer):prop /\ ((idx_1 ):
-                       integer <= (length  (seq_2 ):'a39 seq):integer):prop *)
+             invariant (0:integer <= ((self ):'a39 t).idx):prop /\ (((self ):'a39 
+                       t).idx <= (length 
+                       ((self ):'a42 t).seq_1):integer):prop *)
     
     val empty : unit -> 'a t
     (*@ z:'a t = empty ()

--- a/test/vocal/ZipperList.mli.expected
+++ b/test/vocal/ZipperList.mli.expected
@@ -6,6 +6,7 @@
 type 'a t[@@gospel
            {| model seq: 'a seq
     model idx: integer
+    with self
     invariant 0 <= self.idx <= Seq.length self.seq |}]
 val empty : unit -> 'a t[@@gospel
                           {| z = empty ()
@@ -201,9 +202,8 @@ module ZipperList.mli
          (*@ 
              model seq_1 : 'a seq
              model idx : integer
-             invariant (0:integer <= ((self ):'a39 t).idx):prop /\ (((self ):'a39 
-                       t).idx <= (length 
-                       ((self ):'a42 t).seq_1):integer):prop *)
+             invariant (0:integer <= (self:'a t).idx):prop /\ ((self:'a t).idx <= (length 
+                       (self:'a t).seq_1):integer):prop *)
     
     val empty : unit -> 'a t
     (*@ z:'a t = empty ()


### PR DESCRIPTION
Users can now refer to `self` in invariants, which refers to the value of the type the invariant applies to. This lets us specify invariants on recursive types, and pattern matching on variant types in invariants.

Maybe a more debatable point: this PR also removes the ability to refer to a type model or field by just referring to the field, now we have to use `self` all the time. This is not necessary, but I figured that would push for uniform specs, and gets closer to OCaml, although I agree it makes the invariants a little bit more verbose.
To make thinks clearer, 
```ocaml
type t = {x : int; y : int}
(*@ invariant x > 0 *)
```
now has to be written
```ocaml
type t = {x : int; y : int}
(*@ invariant self.x > 0 *)
```

 Happy to hear thoughts about that!