### PR TITLE
Fix exceptional postcontion patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@
 
 ## Fixed
 
+- Fix inconsistencies in typing/parsing of exceptional postconditions patterns.
+  [\#203](https://github.com/ocaml-gospel/gospel/pull/203)
 - Fixed the type-checking of interfaces involving the OCaml Stdlib, which was
   not opened by default. GADTs are considered abstract types.
   [\#195](https://github.com/ocaml-gospel/gospel/pull/195)

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -772,7 +772,12 @@ let process_val_spec kid crcm ns id args ret vs =
     let process mxs (q, pt) =
       let xs = find_q_xs ns q in
       match pt with
-      | None -> Mxs.update xs (merge_xpost None) mxs
+      | None -> (
+          match xs.xs_type with
+          | Exn_tuple [] -> Mxs.update xs (merge_xpost None) mxs
+          | _ ->
+              W.type_checking_error ~loc
+                "Exception pattern does not match its type")
       | Some (p, t) ->
           let dp = dpattern kid ns p in
           let ty =

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -277,6 +277,8 @@ raises:
   { q, Some (mk_pat (Ptuple []) $loc(q), t) }
 | q=uqualid p=pat_arg ARROW t=term
   { q, Some (p, t) }
+| q=uqualid p=pat_arg
+  { q, Some (p, mk_term Ttrue $loc(p)) }
 | q=uqualid
   { q, None}
 ;

--- a/test/negative/dune.inc
+++ b/test/negative/dune.inc
@@ -77,6 +77,19 @@
  (action (diff %{dep:empty_match.mli.expected} %{dep:empty_match.mli.output})))
 
 (rule
+ (targets exception_no_pattern.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{targets}
+      (with-accepted-exit-codes
+       (or :standard 125)
+       (system "%{bin:gospel} check --verbose %{dep:exception_no_pattern.mli}")))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:exception_no_pattern.mli.expected} %{dep:exception_no_pattern.mli.output})))
+
+(rule
  (targets exn_arity.mli.output)
  (deps (source_tree .))
  (action

--- a/test/negative/exception_no_pattern.mli
+++ b/test/negative/exception_no_pattern.mli
@@ -1,0 +1,5 @@
+exception E of int
+
+val f : int -> int
+(*@ y = f x
+    raises E *)

--- a/test/negative/exception_no_pattern.mli.expected
+++ b/test/negative/exception_no_pattern.mli.expected
@@ -1,0 +1,23 @@
+
+*******************************
+********** Parsed file ********
+*******************************
+exception E of int 
+val f : int -> int[@@gospel {| y = f x
+    raises E |}]
+
+*******************************
+****** GOSPEL translation *****
+*******************************
+(*@ open Stdlib *)
+
+(*@ open Gospelstdlib *)
+
+exception E of int 
+
+val f : int -> int
+(*@ y = f x
+    with ...
+     *)
+File "exception_no_pattern.mli", line 5, characters 11-12:
+Error: Type checking error: Exception pattern does not match its type.

--- a/test/positive/exceptions.mli
+++ b/test/positive/exceptions.mli
@@ -29,7 +29,8 @@ exception E10 of { x : (int -> int -> float); y : float; z : bool }
 val f : 'a -> 'a
 (*@ x = f y
     raises E1 x -> integer_of_int x = 1 | E1 _ -> false
-    raises E2 (x, y) -> true
+    raises E2 (_, _)
+    raises E2 (_, _) -> true
     raises E2 (_, _) -> true
     raises E2pair _ -> true
     raises E2pair (x, y) -> true

--- a/test/positive/exceptions.mli.expected
+++ b/test/positive/exceptions.mli.expected
@@ -27,7 +27,8 @@ exception E10 of {
 val f : 'a -> 'a[@@gospel
                   {| x = f y
     raises E1 x -> integer_of_int x = 1 | E1 _ -> false
-    raises E2 (x, y) -> true
+    raises E2 (_, _)
+    raises E2 (_, _) -> true
     raises E2 (_, _) -> true
     raises E2pair _ -> true
     raises E2pair (x, y) -> true
@@ -88,6 +89,7 @@ exception E10 of {
 
 val f : 'a -> 'a
 (*@ x = f y
+    with ...
     with ...
     with ...
     with ...
@@ -172,16 +174,17 @@ module exceptions.mli
         raisesE1 _ -> false:prop
               | E1 x_3:int -> ((integer_of_int 
                               x_3:int):integer = 1:integer):prop
-        raisesE2 x_4:int, y_1:int -> true:prop
+        raisesE2 _, _ -> true:prop
+        raisesE2 _, _ -> true:prop
         raisesE2 _, _ -> true:prop
         raisesE2pair _ -> true:prop
-        raisesE2pair x_5:int, y_2:int -> true:prop
+        raisesE2pair x_4:int, y_1:int -> true:prop
         raisesE2pair _, _ -> true:prop
         raisesE2pair z:int * int -> true:prop
         raisesE3 l:int list -> (match l:int list with
                                | [] -> (False ):bool
-                               | infix :: (y_3:int, ys:int list) -> if ((integer_of_int 
-                                                                    y_3:int):
+                               | infix :: (y_2:int, ys:int list) -> if ((integer_of_int 
+                                                                    y_2:int):
                                                                     integer = 2:
                                                                     integer):prop then (True ):
                                                                     bool else (False ):
@@ -189,8 +192,8 @@ module exceptions.mli
                                end::bool = (True ):bool):prop
         raisesE4 i:int, l_1:int list -> (match l_1:int list with
                                         | [] -> (True ):bool
-                                        | infix :: (y_4:int, ys_1:int list) -> 
-                                        if (y_4:int = i:int):prop then (True ):
+                                        | infix :: (y_3:int, ys_1:int list) -> 
+                                        if (y_3:int = i:int):prop then (True ):
                                         bool else (False ):bool
                                         end::bool = (True ):bool):prop
         raisesE5 f_1:int -> int -> ((integer_of_int 


### PR DESCRIPTION
Fixes #52:
- Correctly parse xpost with pattern but no term
- Forbit xpost pattern with no args if the exception requires one
