### PR TITLE
Fix constants contract typing

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -880,7 +880,11 @@ let process_val ~loc ?(ghost = Nonghost) kid crcm ns vd =
               let arity = ts_arity ts in
               List.init arity (fun i ->
                   Uast.Lnone (Preid.create ~loc:vd.vloc (Fmt.str "result%d" i)))
-          | _ -> [ Uast.Lnone (Preid.create ~loc:vd.vloc "result") ]
+          | _ ->
+              [
+                Uast.Lnone
+                  (if args = [] then id else Preid.create ~loc:vd.vloc "result");
+              ]
         in
         let args = List.mapi mk_dummy_var args in
         match vd.vspec with

--- a/test/positive/constants.mli
+++ b/test/positive/constants.mli
@@ -7,9 +7,12 @@ val incr_x : unit -> unit
 type t
 
 val y : t
+(*@ ensures y = y *)
+
 val modify_y : unit -> unit
 (*@ modify_y ()
     modifies y *)
+
 (* {gospel_expected|
    [0] OK
    |gospel_expected} *)


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/ocaml-gospel/gospel/pull/193: constants should be in the typing namespace for their contract, without needing the `e = e` header.