### PR TITLE
Changed modifies clause warning to exclude values of type unit

### DIFF
--- a/src/typing.ml
+++ b/src/typing.ml
@@ -900,8 +900,8 @@ let process_val ~loc ?(ghost = Nonghost) kid crcm ns vd =
   let spec = process_val_spec kid crcm ns id args ret spec in
   let so = Option.map (fun _ -> spec) vd.vspec in
   let () =
-    (* check there is a modifies clause if the return type is unit, through a warning if not *)
-    if Ttypes.(ty_equal ret ty_unit) then
+    (* check there is a modifies clause if the return type is unit, throw a warning if not *)
+    if Ttypes.(ty_equal ret ty_unit) && args <> [] then
       match so with
       | None -> ()
       | Some sp ->

--- a/test/warnings/dune.inc
+++ b/test/warnings/dune.inc
@@ -1,4 +1,15 @@
 (rule
+ (target no_modifies_value_of_unit.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{target}
+      (run %{project_root}/test/gospel_check.exe %{dep:no_modifies_value_of_unit.mli}))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:no_modifies_value_of_unit.mli} %{dep:no_modifies_value_of_unit.mli.output})))
+
+(rule
  (target no_modifies_while_returning_unit.mli.output)
  (deps (source_tree .))
  (action

--- a/test/warnings/no_modifies_value_of_unit.mli
+++ b/test/warnings/no_modifies_value_of_unit.mli
@@ -1,0 +1,6 @@
+val x : unit
+(*@*)
+
+(* {gospel_expected|
+   [0] OK
+   |gospel_expected} *)


### PR DESCRIPTION
An error is thrown when values of type unit are not specified with a 'modifies' clause.  

### Example
With file
```
(*example.mli*)
val x : unit
(*@*)
```
running `ortac example.mli` produces
```
~ ᐅ ortac example.mli
File "example.mli", line 1, characters 0-18:
1 | val x : unit
2 | (*@*)
Error: The function `x' returns `unit'
       but its specifications does not contain any `modifies' clause.
```
### Cause 
The error is caused by lines 903-909 in `gospel/src/typing.ml`.  I think the intent of this code (from #37 ) is to ensure that all functions which return unit are specified as modifying something. However, as it stands, values of type unit are also required to modify something. I am not sure if this is a design decision. 

### Solution
To allow values of type unit to be pure, I added a check on line 904. I also added a test in 
`gospel/test/warnings`, next to the test for functions with return type unit.