### PR TITLE
fix a typo in fibonacci example

### DIFF
--- a/docs/docs/walkthroughs/fibonacci.md
+++ b/docs/docs/walkthroughs/fibonacci.md
@@ -30,7 +30,7 @@ uninterpreted logical function along with an axiom defining it.
 
 ```ocaml
 (*@ function fibonacci (n: integer) : integer *)
-(*@ axiom A: 
+(*@ axiom a:
          fibonacci 0 = 0
       /\ fibonacci 1 = 1
       /\ forall n. n >= 2 -> fibonacci n = fibonacci (n-1) + fibonacci (n-2) *) 


### PR DESCRIPTION
axiom identifiers should begin by a lowercase character