### PR TITLE
Fix specifications in markdown documentation

### DIFF
--- a/docs/docs/dune
+++ b/docs/docs/dune
@@ -1,0 +1,3 @@
+(include ../../test/utils/dune.docs)
+
+(include dune.inc)

--- a/docs/docs/dune.inc
+++ b/docs/docs/dune.inc
@@ -1,0 +1,42 @@
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   good-practices.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:good-practices.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to good-practices.output
+    (chdir %{project_root}
+     (run gospel check %{dep:good-practices.mli})))
+   (diff? %{project_root}/test/utils/check_success good-practices.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   welcome.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:welcome.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to welcome.output
+    (chdir %{project_root}
+     (run gospel check %{dep:welcome.mli})))
+   (diff? %{project_root}/test/utils/check_success welcome.output))))
+

--- a/docs/docs/getting-started/dune
+++ b/docs/docs/getting-started/dune
@@ -1,0 +1,3 @@
+(include ../../../test/utils/dune.docs)
+
+(include dune.inc)

--- a/docs/docs/getting-started/dune.inc
+++ b/docs/docs/getting-started/dune.inc
@@ -1,0 +1,84 @@
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   first-spec.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:first-spec.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to first-spec.output
+    (chdir %{project_root}
+     (run gospel check %{dep:first-spec.mli})))
+   (diff? %{project_root}/test/utils/check_success first-spec.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   going-further.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:going-further.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to going-further.output
+    (chdir %{project_root}
+     (run gospel check %{dep:going-further.mli})))
+   (diff? %{project_root}/test/utils/check_success going-further.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   installation.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:installation.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to installation.output
+    (chdir %{project_root}
+     (run gospel check %{dep:installation.mli})))
+   (diff? %{project_root}/test/utils/check_success installation.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   tools.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:tools.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to tools.output
+    (chdir %{project_root}
+     (run gospel check %{dep:tools.mli})))
+   (diff? %{project_root}/test/utils/check_success tools.output))))
+

--- a/docs/docs/getting-started/first-spec.md
+++ b/docs/docs/getting-started/first-spec.md
@@ -61,8 +61,9 @@ in the `contents` set may not exceed `capacity`. Those are type invariants:
 type 'a t
 (*@ model capacity: int
     mutable model contents: 'a set
-    invariant capacity > 0
-    invariant Set.cardinal contents <= capacity *)
+    with t
+    invariant t.capacity > 0
+    invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
 The `Set` module is part of the [Gospel standard library](../stdlib). Although it
@@ -90,7 +91,7 @@ keyword `requires`), while the second and third ones are post-conditions (the
 keyword is `ensures`):
 
 ```ocaml
-val create: int -> t
+val create: int -> 'a t
 (*@ t = create c
     requires c > 0
     ensures t.capacity = c
@@ -107,7 +108,7 @@ depend on any internal state, and does not raise exceptions. In Gospel's
 language, this function is *pure*.
 
 ```ocaml
-val is_empty: t -> bool
+val is_empty: 'a t -> bool
 (*@ b = is_empty t
     pure
     ensures b <-> t.contents = Set.empty *)
@@ -158,6 +159,7 @@ this bit of information. If `add` raises `Full`, we can deduce that `t.contents`
 already contains `t.capacity` elements.
 
 ```ocaml
+exception Full
 val add: 'a t -> 'a -> unit
 (*@ add t x
     modifies t.contents

--- a/docs/docs/language/dune
+++ b/docs/docs/language/dune
@@ -1,0 +1,3 @@
+(include ../../../test/utils/dune.docs)
+
+(include dune.inc)

--- a/docs/docs/language/dune.inc
+++ b/docs/docs/language/dune.inc
@@ -1,0 +1,147 @@
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   constants-specifications.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:constants-specifications.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to constants-specifications.output
+    (chdir %{project_root}
+     (run gospel check %{dep:constants-specifications.mli})))
+   (diff? %{project_root}/test/utils/check_success constants-specifications.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   formulae.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:formulae.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to formulae.output
+    (chdir %{project_root}
+     (run gospel check %{dep:formulae.mli})))
+   (diff? %{project_root}/test/utils/check_success formulae.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   function-contracts.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:function-contracts.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to function-contracts.output
+    (chdir %{project_root}
+     (run gospel check %{dep:function-contracts.mli})))
+   (diff? %{project_root}/test/utils/check_success function-contracts.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   lexical-conventions.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:lexical-conventions.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to lexical-conventions.output
+    (chdir %{project_root}
+     (run gospel check %{dep:lexical-conventions.mli})))
+   (diff? %{project_root}/test/utils/check_success lexical-conventions.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   locations.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:locations.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to locations.output
+    (chdir %{project_root}
+     (run gospel check %{dep:locations.mli})))
+   (diff? %{project_root}/test/utils/check_success locations.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   logical.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:logical.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to logical.output
+    (chdir %{project_root}
+     (run gospel check %{dep:logical.mli})))
+   (diff? %{project_root}/test/utils/check_success logical.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   type-specifications.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:type-specifications.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to type-specifications.output
+    (chdir %{project_root}
+     (run gospel check %{dep:type-specifications.mli})))
+   (diff? %{project_root}/test/utils/check_success type-specifications.output))))
+

--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -122,14 +122,14 @@ function raises `Invalid_argument` whenever `y <= 0`.
 Whenever multiple pre-conditions of the same kind coexist, they hold as a
 conjunction, which means
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     requires P
     requires Q *)
 ```
 is equivalent to:
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     requires P /\ Q *)
 ```
@@ -139,14 +139,14 @@ does not matter. The `requires` clauses take precedence and must always be
 respected; otherwise the `checks` behaviour cannot be assumed. This means that
 ultimately,
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     requires P
     checks Q *)
 ```
 is equivalent to:
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     requires P
     checks P -> Q *)
@@ -186,7 +186,7 @@ verified after the function call only if the pre-conditions were satisfied.
 The handling of multiple post-conditions is identical to pre-conditions of the
 same kind: multiple post-conditions are merged as a conjunction:
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     ensures P
     ensures Q *)
@@ -194,7 +194,7 @@ same kind: multiple post-conditions are merged as a conjunction:
 
 is equivalent to:
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     ensures P /\ Q *)
 ```
@@ -224,7 +224,7 @@ clause to every function contract. Of course, you can still override that
 behaviour by stating a property whenever these exceptions are raised, like any
 other exception:
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     raises Stack_overflow -> false *)
 ```
@@ -240,7 +240,7 @@ for each exception constructor listed in this clause. Similarly to OCaml's
 pattern-matching, when an exception is raised, the post-condition that is
 satisfied is the first match in the list of the cases.
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     raises Unix_error (ENAMETOOLONG, _, _) -> P
          | Unix_error _                    -> Q *)
@@ -259,7 +259,7 @@ each other, meaning that the raised exception is matched against each `raises`'s
 case list, and each matching post-condition must hold in conjunction. For
 instance, the contract:
 
-```ocaml
+```ocaml invalidSyntax
 (*@ ...
     raises Error "foo" -> P | Error _ -> Q
     raises Error x -> R *)
@@ -282,9 +282,13 @@ the OCaml code the function behaves like, preceded by the `equivalent` keyword.
 This is useful when specifying functions whose behaviour can hardly be expressed
 in pure logic:
 
-```ocaml
+<!-- This code extract is invalid because functions returning unit must modify
+     something, equivalent is not enough -->
+```ocaml invalidSyntax
+type 'a t
 val iter : ('a -> unit) -> 'a t -> unit
 (*@ iter f t
+    ...
     equivalent "List.iter f (to_list t)" *)
 ```
 
@@ -314,7 +318,8 @@ The following example states that the execution of the function `run` may not
 terminate. It does not specify whether this function is always non-terminating
 or not.
 
-```ocaml
+<!-- invalidSyntax: see #317 -->
+```ocaml invalidSyntax
 val run : unit -> unit
 (*@ run ()
     diverges *)
@@ -328,6 +333,9 @@ the keyword `modifies`, followed by an identifier. In the following, the
 `contents` model of `a` can be modified by `inplace_map`.
 
 ```ocaml {3}
+type 'a t
+(*@ mutable model contents: int *)
+
 val inplace_map : ('a -> 'a) -> 'a t -> unit
 (*@ inplace_map f a
     modifies a.contents *)
@@ -359,6 +367,7 @@ function raised an exception **instead** of mutating the data, you have to
 manually specify it:
 
 ```ocaml {4}
+exception E
 val inplace_map : ('a -> 'a) -> 'a t -> unit
 (*@ inplace_map f a
     modifies a.contents
@@ -390,7 +399,7 @@ the function, and should be considered dirty â€” that is, not be used anymore â€
 the rest of the program. This is expressed with the `consumes`
 keyword:
 
-```ocaml
+```ocaml invalidSyntax
 val destructive_transfer: 'a t -> 'a t -> unit
 (*@ destructive_transfer src dst
     consumes src

--- a/docs/docs/language/locations.md
+++ b/docs/docs/language/locations.md
@@ -57,7 +57,8 @@ starting with the `@` character[^1]:
     Java and [ACSL](https://frama-c.com/html/acsl.html) for C. Hence Gospel
     also uses this convention.
 
-```ocaml
+<!-- invalidSyntax: see #320 -->
+```ocaml invalidSyntax
 val f: int -> int           (* An OCaml value declaration *)
 (*@ y = f x
     ensures x > 0 *)        (* Its Gospel specification   *)
@@ -86,7 +87,7 @@ documentation, and the attribute notation will not appear anymore.
 Note that Gospel annotations can be combined with traditional documentation
 comments, *e.g.* as follows:
 
-```ocaml
+```ocaml invalidSyntax
 val eucl_division: int -> int -> int * int
 (** this is an implementation of Euclidean division *)
 (*@ q, r = eucl_division x y

--- a/docs/docs/language/type-specifications.md
+++ b/docs/docs/language/type-specifications.md
@@ -12,7 +12,7 @@ data-structure.
 type 'a t
 (*@ model capacity: int
     mutable model contents: 'a Set.t
-    invariant Set.cardinal contents <= capacity *)
+    with t invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
 The specification of this type contains three elements:
@@ -50,7 +50,7 @@ name for that model, in a fashion similar to OCaml's record fields.
 type 'a t
 (*@ model capacity: int
     mutable model contents: 'a Set.t
-    invariant Set.cardinal contents <= capacity *)
+    with t invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
 ## Mutable types
@@ -58,10 +58,10 @@ type 'a t
 Gospel lets you specify when a type may contain some mutable state by using the
 keyword `ephemeral` in its annotation:
 
-```ocaml {3}
+```ocaml {2}
 type t
-(*@ model capacity: int
-    ephemeral *)
+(*@ ephemeral
+    model capacity: int *)
 ```
 
 Of course, a type that has a mutable model is considered mutable, so the
@@ -77,7 +77,7 @@ properties may be added after the `invariant` keyword:
 type 'a t
 (*@ model capacity: int
     mutable model contents: 'a Set.t
-    invariant Set.cardinal contents <= capacity *)
+    with t invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
 Note that functions may break these invariants internally, but must restore them

--- a/docs/docs/walkthroughs/dune
+++ b/docs/docs/walkthroughs/dune
@@ -1,0 +1,3 @@
+(include ../../../test/utils/dune.docs)
+
+(include dune.inc)

--- a/docs/docs/walkthroughs/dune.inc
+++ b/docs/docs/walkthroughs/dune.inc
@@ -1,0 +1,84 @@
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   fibonacci.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:fibonacci.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to fibonacci.output
+    (chdir %{project_root}
+     (run gospel check %{dep:fibonacci.mli})))
+   (diff? %{project_root}/test/utils/check_success fibonacci.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   introduction.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:introduction.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to introduction.output
+    (chdir %{project_root}
+     (run gospel check %{dep:introduction.mli})))
+   (diff? %{project_root}/test/utils/check_success introduction.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   mutable-queue.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:mutable-queue.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to mutable-queue.output
+    (chdir %{project_root}
+     (run gospel check %{dep:mutable-queue.mli})))
+   (diff? %{project_root}/test/utils/check_success mutable-queue.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   union-find.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:union-find.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to union-find.output
+    (chdir %{project_root}
+     (run gospel check %{dep:union-find.mli})))
+   (diff? %{project_root}/test/utils/check_success union-find.output))))
+

--- a/docs/docs/walkthroughs/fibonacci.md
+++ b/docs/docs/walkthroughs/fibonacci.md
@@ -40,7 +40,7 @@ Here is an implementation of such a function. When `a` and `b` are two
 consecutive Fibonacci numbers, the following function computes the `n`th number
 ahead of `a`. Hence, `fib n 0 1` is the `n`th Fibonacci number.
 
-```ocaml
+```ocaml implementationSyntax
 let rec fib n a b =
   if n < 0 then invalid_arg "n must be non-negative";
   if n = 0 then a

--- a/docs/docs/walkthroughs/mutable-queue.md
+++ b/docs/docs/walkthroughs/mutable-queue.md
@@ -82,8 +82,8 @@ exception Empty
 val pop: 'a t -> 'a
 (*@ v = pop q
     modifies q
-    ensures  old q.view = q.view ++ Seq.cons v empty
-    raises   Empty -> q.view = old q.view = empty *)
+    ensures  old q.view = q.view ++ Seq.cons v Seq.empty
+    raises   Empty -> q.view = old q.view = Seq.empty *)
 ```
 
 We have two post-conditions:
@@ -107,10 +107,10 @@ keyword `requires`:
 
 ```ocaml {3}
 val unsafe_pop: 'a t -> 'a
-(*@ v = pop q
-    requires q.view <> empty
+(*@ v = unsafe_pop q
+    requires q.view <> Seq.empty
     modifies q
-    ensures  old q.view = q.view ++ (Seq.cons v empty) *)
+    ensures  old q.view = q.view ++ (Seq.cons v Seq.empty) *)
 ```
 
 ### Defensive version
@@ -123,9 +123,9 @@ behavior, using `checks` instead of `requires`:
 ```ocaml {3}
 val pop: 'a t -> 'a
 (*@ v = pop q
-      checks   q.view <> empty
+      checks   q.view <> Seq.empty
       modifies q
-      ensures  old q.view = q.view ++ (Seq.cons v empty) *)
+      ensures  old q.view = q.view ++ (Seq.cons v Seq.empty) *)
 ```
 
 The `checks` keyword means that function itself checks the pre-condition
@@ -142,7 +142,7 @@ declaration for an emptiness test, together with its contract:
 ```ocaml
 val is_empty: 'a t -> bool
 (*@ b = is_empty q
-      ensures b <-> q.view = empty *)
+      ensures b <-> q.view = Seq.empty *)
 ```
 
 The post-conditions captures that the function returns `true` if and only if the
@@ -160,7 +160,7 @@ specification are as follows:
 ```ocaml
 val create: unit -> 'a t
 (*@ q = create ()
-      ensures q.view = empty *)
+      ensures q.view = Seq.empty *)
 ```
 
 The newly created queue has no elements: its `view` model equals the `empty`
@@ -185,7 +185,7 @@ another, with the following specification:
 val transfer: 'a t -> 'a t -> unit
 (*@ transfer src dst
     modifies src, dst
-    ensures  src.view = empty
+    ensures  src.view = Seq.empty
     ensures  dst.view = old dst.view ++ old src.view *)
 ```
 

--- a/docs/docs/walkthroughs/mutable-queue.md
+++ b/docs/docs/walkthroughs/mutable-queue.md
@@ -25,11 +25,11 @@ elements of a queue, we attach one model to its type declaration:
 
 ```ocaml
 type 'a t
-(*@ mutable model view: 'a seq *)
+(*@ mutable model view: 'a sequence *)
 ```
 
 The model `view` represents the mathematical sequence of elements stored in
-the queue. The type `'a seq` is the type of logical sequences defined in the
+the queue. The type `'a sequence` is the type of logical sequences defined in the
 Gospel standard library and is for specifications only. The `mutable`
 keyword states that the `view` field can change over time.
 
@@ -49,7 +49,7 @@ Let us now declare and specify a `push` operation for these queues:
 val push: 'a -> 'a t -> unit
 (*@ push v q
     modifies q
-    ensures  q.view = Seq.cons v (old q.view) *)
+    ensures  q.view = Sequence.cons v (old q.view) *)
 ```
 
 - The first line of the specification is the header; it names the two arguments
@@ -62,7 +62,7 @@ val push: 'a -> 'a t -> unit
   refer to the value of an expression (here, `q.view`) in the pre-state, *i.e.*,
   before the function call.
 
-Note that the module `Seq` is part of the Gospel standard library and should not
+Note that the module `Sequence` is part of the Gospel standard library and should not
 be confused with module `Seq` from the OCaml standard library.
 
 ## Various flavors of `pop`
@@ -82,8 +82,8 @@ exception Empty
 val pop: 'a t -> 'a
 (*@ v = pop q
     modifies q
-    ensures  old q.view = q.view ++ Seq.cons v Seq.empty
-    raises   Empty -> q.view = old q.view = Seq.empty *)
+    ensures  old q.view = q.view ++ Sequence.cons v Sequence.empty
+    raises   Empty -> q.view = old q.view = Sequence.empty *)
 ```
 
 We have two post-conditions:
@@ -108,9 +108,9 @@ keyword `requires`:
 ```ocaml {3}
 val unsafe_pop: 'a t -> 'a
 (*@ v = unsafe_pop q
-    requires q.view <> Seq.empty
+    requires q.view <> Sequence.empty
     modifies q
-    ensures  old q.view = q.view ++ (Seq.cons v Seq.empty) *)
+    ensures  old q.view = q.view ++ (Sequence.cons v Sequence.empty) *)
 ```
 
 ### Defensive version
@@ -123,9 +123,9 @@ behavior, using `checks` instead of `requires`:
 ```ocaml {3}
 val pop: 'a t -> 'a
 (*@ v = pop q
-      checks   q.view <> Seq.empty
+      checks   q.view <> Sequence.empty
       modifies q
-      ensures  old q.view = q.view ++ (Seq.cons v Seq.empty) *)
+      ensures  old q.view = q.view ++ (Sequence.cons v Sequence.empty) *)
 ```
 
 The `checks` keyword means that function itself checks the pre-condition
@@ -142,7 +142,7 @@ declaration for an emptiness test, together with its contract:
 ```ocaml
 val is_empty: 'a t -> bool
 (*@ b = is_empty q
-      ensures b <-> q.view = Seq.empty *)
+      ensures b <-> q.view = Sequence.empty *)
 ```
 
 The post-conditions captures that the function returns `true` if and only if the
@@ -160,7 +160,7 @@ specification are as follows:
 ```ocaml
 val create: unit -> 'a t
 (*@ q = create ()
-      ensures q.view = Seq.empty *)
+      ensures q.view = Sequence.empty *)
 ```
 
 The newly created queue has no elements: its `view` model equals the `empty`
@@ -185,7 +185,7 @@ another, with the following specification:
 val transfer: 'a t -> 'a t -> unit
 (*@ transfer src dst
     modifies src, dst
-    ensures  src.view = Seq.empty
+    ensures  src.view = Sequence.empty
     ensures  dst.view = old dst.view ++ old src.view *)
 ```
 

--- a/docs/docs/walkthroughs/union-find.md
+++ b/docs/docs/walkthroughs/union-find.md
@@ -173,8 +173,9 @@ element` function. We can also add two invariants:
 (*@ type 'a universe *)
 (*@ mutable model dom : 'a element set
     mutable model rep : 'a element -> 'a element
-    invariant forall e. Set.mem e dom -> Set.mem (rep e) dom
-    invariant forall e. Set.mem e dom -> rep (rep e) = rep e *)
+    with u
+    invariant forall e. Set.mem e u.dom -> Set.mem (u.rep e) u.dom
+    invariant forall e. Set.mem e u.dom -> u.rep (u.rep e) = u.rep e *)
 ```
 
 :::caution
@@ -228,7 +229,7 @@ are in the same subset (or equivalence class). This is the case iff they have
 the same subset representative:
 
 ```ocaml
-(*@ predicate equivalent (u: 'a universe) (x y: 'a element) =
+(*@ predicate equiv (u: 'a universe) (x y: 'a element) =
       u.rep x = u.rep y *)
 ```
 
@@ -236,14 +237,14 @@ We can now use that to state that elements that are not equivalent to `x` or `y`
 have the same representative:
 
 ```ocaml {7-9}
-val union : 'a elements -> 'a elements -> unit
+val union : 'a element -> 'a element -> unit
 (*@ union [u: 'a universe] x y
     requires Set.mem x u.dom
     requires Set.mem y u.dom
     modifies u
     ensures u.dom = old u.dom
     ensures forall e.
-      not (old (equivalent u x e \/ equivalent u y e))
+      not (old (equiv u x e \/ equiv u y e))
       -> u.rep e = old (u.rep e) *)
 ```
 
@@ -258,10 +259,10 @@ val union : 'a element -> 'a element -> unit
     requires Set.mem y u.dom
     modifies u
     ensures u.dom = old u.dom
-    ensures forall e. not (old (equivalent u x e \/ equivalent u y e))
+    ensures forall e. not (old (equiv u x e \/ equiv u y e))
                       -> u.rep e = old (u.rep e)
     ensures exists r. (r = old (u.rep x) \/ r = old (u.rep y))
-      /\ forall e. old (equivalent u x e \/ equivalent u y e)
+      /\ forall e. old (equiv u x e \/ equiv u y e)
                    -> u.rep e = r *)
 ```
 

--- a/docs/src/pages/dune
+++ b/docs/src/pages/dune
@@ -1,0 +1,3 @@
+(include ../../../test/utils/dune.docs)
+
+(include dune.inc)

--- a/docs/src/pages/dune.inc
+++ b/docs/src/pages/dune.inc
@@ -1,0 +1,42 @@
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   faq.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:faq.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to faq.output
+    (chdir %{project_root}
+     (run gospel check %{dep:faq.mli})))
+   (diff? %{project_root}/test/utils/check_success faq.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   stdlib.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:stdlib.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to stdlib.output
+    (chdir %{project_root}
+     (run gospel check %{dep:stdlib.mli})))
+   (diff? %{project_root}/test/utils/check_success stdlib.output))))
+

--- a/docs/src/pages/faq.md
+++ b/docs/src/pages/faq.md
@@ -36,7 +36,7 @@ every possible array:
 val total_weight : weight:('a array -> int) -> ('a array) list -> int
 (*@ y = total_weight ~weight l
     requires forall a. weight a >= 0
-    ensures y = List.fold_left (fun acc a -> acc + weight a) l *)
+    ensures y = List.fold_left (fun acc a -> acc + weight a) 0 l *)
 ```
 
 <hr />
@@ -120,7 +120,9 @@ argument by some of your OCaml functions:
 
 ```ocaml
 (*@ type t *)
+```
 
+```ocaml invalidSyntax
 val f : int -> int
 (*@ y = f [t : t] x
     pure
@@ -131,16 +133,17 @@ Now, every specification that refers to `f` needs to pass the `t` argument to
 that function. You can propagate that requirement again, but you may also need
 to actually instantiate such a value and pass it directly:
 
-```ocaml
+<!-- set as invalidSyntax because make is defined later -->
+```ocaml invalidSyntax
 val g : int -> int
 (*@ y = g x
-    requires let t = make () in
-             f t x = y *)
+    ensures let t = make () in
+            f t x = y *)
 ```
 
 Of course, that `make` function does not exist either, so you also need to
 declare it as a ghost value:
 
 ```ocaml
-(*@ val make : unit -> t *)
+(*@ function make : unit -> t *)
 ```

--- a/dune
+++ b/dune
@@ -1,1 +1,3 @@
-(dirs :standard \ docs)
+(include test/utils/dune.docs)
+
+(include dune.inc)

--- a/dune.inc
+++ b/dune.inc
@@ -1,0 +1,42 @@
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   CHANGES.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:CHANGES.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to CHANGES.output
+    (chdir %{project_root}
+     (run gospel check %{dep:CHANGES.mli})))
+   (diff? %{project_root}/test/utils/check_success CHANGES.output))))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:md2mli %{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   README.mli
+   (chdir %{project_root}
+    (run awk -f %{md2mli} %{dep:README.md})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %{bin-available:awk})
+ (deps %{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to README.output
+    (chdir %{project_root}
+     (run gospel check %{dep:README.mli})))
+   (diff? %{project_root}/test/utils/check_success README.output))))
+

--- a/test/utils/dune
+++ b/test/utils/dune
@@ -3,6 +3,13 @@
  (modules dune_gen))
 
 (executable
+ (name dune_docs_gen)
+ (modules dune_docs_gen))
+
+(executable
  (name testchecker)
  (modules testchecker)
  (libraries fmt))
+
+(rule
+ (write-file check_success "OK\n"))

--- a/test/utils/dune.docs
+++ b/test/utils/dune.docs
@@ -1,0 +1,22 @@
+; Rules to generate `dune.inc` files for testing markdown documentations
+
+(rule
+ (target dune.inc.gen)
+ (deps
+  (:generator %{project_root}/test/utils/dune_docs_gen.exe)
+  (:mds
+   (glob_files *.md)))
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{generator} %{mds}))))
+
+(rule
+ (alias duneincs)
+ (action
+  (diff dune.inc dune.inc.gen)))
+
+(alias
+ (name runtest)
+ (deps
+  (alias duneincs)))

--- a/test/utils/dune_docs_gen.ml
+++ b/test/utils/dune_docs_gen.ml
@@ -1,0 +1,39 @@
+(* Given a list of files on the commandline, generates a dune configuration to
+   process all those files with [md2mli.awk] and call [gospel check] on the
+   resulting .mli *)
+
+(* The [chdir]s ensure that the full paths are fed to the awk script and the
+   Gospel checker, so that errors are properly located *)
+
+let print_rule md =
+  let base = Filename.remove_extension md in
+  let mli = base ^ ".mli" and out = base ^ ".output" in
+  Printf.printf
+    {|(rule
+ (enabled_if %%{bin-available:awk})
+ (deps
+  (:md2mli %%{project_root}/test/utils/md2mli.awk))
+ (action
+  (with-stdout-to
+   %s
+   (chdir %%{project_root}
+    (run awk -f %%{md2mli} %%{dep:%s})))))
+
+(rule
+ (alias runtest)
+ (enabled_if %%{bin-available:awk})
+ (deps %%{bin:gospel})
+ (action
+  (progn
+   (with-stdout-to %s
+    (chdir %%{project_root}
+     (run gospel check %%{dep:%s})))
+   (diff? %%{project_root}/test/utils/check_success %s))))
+
+|}
+    mli md out mli out
+
+let _ =
+  for i = 1 to Array.length Sys.argv - 1 do
+    print_rule Sys.argv.(i)
+  done

--- a/test/utils/md2mli.awk
+++ b/test/utils/md2mli.awk
@@ -1,0 +1,36 @@
+# Extract OCaml code blocks in a markdown documentation into a .mli
+# file
+
+# If a code block is started with
+#   ```ocaml invalidSyntax
+# or
+#   ```ocaml implementationSyntax
+# it will be skipped, so that the documentation can contain invalid
+# syntax (with `...` for instance) or contain .ml (implementation)
+# code
+
+# Each code block is output as a separate sub-module, so that:
+# - gospel specifications in one code block are not attached to a
+#   previous value by mistake
+# - repeatedly declaring type `t` is not an issue
+
+BEGIN {
+  block = 0
+  open = 0
+}
+
+/^ *```ocaml/,/^ *```$/ {
+  if($0 ~ "^ *```ocaml.*invalidSyntax" || $0 ~ "^ *```ocaml.*implementationSyntax" ) {
+    skip = 1
+  } else if($0 ~ "^ *```ocaml") {
+    skip = 0
+    block += 1
+    open = 1
+    printf "module Block%d : sig\n# %d \"%s\"\n", block, FNR+1, FILENAME
+  } else if($0 ~ "^ *```$" && open) {
+    open = 0
+    printf "end\nopen Block%d\n\n", block
+  } else if(!skip) {
+    print
+  }
+}


### PR DESCRIPTION
Add a few `Makefile` rules to check the Gospel specifications inserted as OCaml code blocks by extracting the code blocks to a corresponding *.mli file and calling `gospel check` on it
Skip the documentation files intentionally using invalid syntax or citing code blocks that cannot all be exported to one file
Add the generated *.mli files to .gitignore

This reveals issues in quite a few documentation files