### PR TITLE
Rename `Seq` to `Sequence`

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.21.0
+version = 0.24.1
 parse-docstrings = true
 break-infix = fit-or-vertical
 module-item-spacing = compact

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
 
 ## Improved
 
+- Rename standard library `Seq` and `'a seq` to `Sequence` and `'a sequence`.
+  [\#253](https://github.com/ocaml-gospel/gospel/pull/253)
 - Allow unit result in function header
   [\#215](https://github.com/ocaml-gospel/gospel/pull/215)
 - Highlight source locations when reporting errors.

--- a/src/stdlib/gospelstdlib.mli
+++ b/src/stdlib/gospelstdlib.mli
@@ -32,7 +32,7 @@
    predicate (=) (x y: 'a)
 *)
 
-(*@ type 'a seq *)
+(*@ type 'a sequence *)
 (** The type for finite sequences. *)
 
 (*@ type 'a bag *)
@@ -119,19 +119,19 @@
 
 (** {1 Sequences} *)
 
-(*@ function (++) (s s': 'a seq) : 'a seq *)
+(*@ function (++) (s s': 'a sequence) : 'a sequence *)
 (** [s ++ s'] is the sequence [s] followed by the sequence [s']. *)
 
-(*@ function ([_]) (s: 'a seq) (i: integer): 'a *)
+(*@ function ([_]) (s: 'a sequence) (i: integer): 'a *)
 (** [s\[i\]] is the [i]th element of the sequence [s]. *)
 
-(*@ function ([_.._]) (s: 'a seq) (i1: integer) (i2: integer): 'a seq *)
-(*@ function ([_..]) (s: 'a seq) (i: integer): 'a seq *)
-(*@ function ([.._]) (s: 'a seq) (i: integer): 'a seq *)
+(*@ function ([_.._]) (s: 'a sequence) (i1: integer) (i2: integer): 'a sequence *)
+(*@ function ([_..]) (s: 'a sequence) (i: integer): 'a sequence *)
+(*@ function ([.._]) (s: 'a sequence) (i: integer): 'a sequence *)
 
 module Sequence : sig
-  (*@ type 'a t = 'a seq *)
-  (** An alias for {!'a seq} *)
+  (*@ type 'a t = 'a sequence *)
+  (** An alias for {!'a sequence} *)
 
   (*@ function length (s: 'a t): integer *)
   (** [length s] is the length of the sequence [s]. *)
@@ -142,13 +142,13 @@ module Sequence : sig
   (*@ function singleton (x: 'a) : 'a t *)
   (** [singleton] is an alias for {!return}. *)
 
-  (*@ function init (n: integer) (f: integer -> 'a) : 'a seq *)
+  (*@ function init (n: integer) (f: integer -> 'a) : 'a t *)
   (** [init n f] is the sequence containing [f 0], [f 1], [...] , [f n]. *)
 
   (*@ function cons (x: 'a) (s: 'a t): 'a t *)
   (** [cons x s] is the sequence containing [x] followed by the elements of [s]. *)
 
-  (*@ function snoc (s: 'a seq) (x: 'a): 'a seq *)
+  (*@ function snoc (s: 'a t) (x: 'a): 'a t *)
   (** [snoc s x] is the sequence containing the elements of [s] followed by [x]. *)
 
   (*@ function hd (s: 'a t) : 'a *)
@@ -162,7 +162,7 @@ module Sequence : sig
   (*@ function append (s s': 'a t) : 'a t *)
   (** [append s s'] is [s ++ s']. *)
 
-  (*@ predicate mem (s: 'a seq) (x: 'a) *)
+  (*@ predicate mem (s: 'a t) (x: 'a) *)
   (** [mem s x] holds iff [x] is in [s]. *)
 
   (*@ function map (f: 'a -> 'b) (s: 'a t) : 'b t *)
@@ -183,15 +183,15 @@ module Sequence : sig
   (*@ function set (s: 'a t) (i: integer) (x: 'a): 'a t *)
   (** [set s i x] is the sequence [s] where the [i]th element is [x]. *)
 
-  (*@ function rev (s: 'a seq) : 'a seq *)
+  (*@ function rev (s: 'a t) : 'a t *)
   (** [rev s] is the sequence containing the same elements as [s], in reverse
       order. *)
 
-  (*@ function rec fold_left (f: 'a -> 'b -> 'a) (acc: 'a) (s: 'b seq) : 'a *)
+  (*@ function rec fold_left (f: 'a -> 'b -> 'a) (acc: 'a) (s: 'b sequence) : 'a *)
   (** [fold_left f acc s] is [f (... (f (f acc s\[0\]) s\[1\]) ...) s\[n-1\]],
       where [n] is the length of [s]. *)
 
-  (*@ function rec fold_right (f: 'a -> 'b -> 'b) (s: 'a seq) (acc: 'b) : 'b *)
+  (*@ function rec fold_right (f: 'a -> 'b -> 'b) (s: 'a t) (acc: 'b) : 'b *)
   (** [fold_right f s acc] is [f s\[1\] (f s\[2\] (... (f s\[n\] acc) ...))]
       where [n] is the length of [s]. *)
 end
@@ -509,8 +509,7 @@ module Set : sig
 
   (*@ function map (f: 'a -> 'b) (s: 'a t) : 'b t *)
   (** [map f s] is a fresh set which elements are [f x1 ... f xN], where
-      [x1 ...
-      xN] are the elements of [s]. *)
+      [x1 ... xN] are the elements of [s]. *)
 
   (*@ function fold (f: 'a -> 'b -> 'b) (s: 'a t) (a: 'b) : 'b *)
   (** [fold f s a] is [(f xN ... (f x2 (f x1 a))...)], where [x1 ... xN] are the

--- a/src/stdlib/gospelstdlib.mli
+++ b/src/stdlib/gospelstdlib.mli
@@ -129,7 +129,7 @@
 (*@ function ([_..]) (s: 'a seq) (i: integer): 'a seq *)
 (*@ function ([.._]) (s: 'a seq) (i: integer): 'a seq *)
 
-module Seq : sig
+module Sequence : sig
   (*@ type 'a t = 'a seq *)
   (** An alias for {!'a seq} *)
 
@@ -265,10 +265,10 @@ module List : sig
   (*@ predicate mem (x: 'a) (l: 'a t) *)
   (** [mem x l] holds iff [x] is equal to an element of [l] *)
 
-  (*@ function to_seq (s: 'a t) : 'a Seq.t *)
+  (*@ function to_seq (s: 'a t) : 'a Sequence.t *)
   (*@ coercion *)
 
-  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
+  (*@ function of_seq (s: 'a Sequence.t) : 'a t *)
 end
 
 (** {1 Arrays} *)
@@ -340,9 +340,9 @@ module Array : sig
   (*@ function to_list (a: 'a t) : 'a list *)
   (*@ function of_list (l: 'a list) : 'a t *)
 
-  (*@ function to_seq (a: 'a t) : 'a Seq.t *)
+  (*@ function to_seq (a: 'a t) : 'a Sequence.t *)
   (*@ coercion *)
-  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
+  (*@ function of_seq (s: 'a Sequence.t) : 'a t *)
 
   (*@ function to_bag (a: 'a t) : 'a bag *)
 
@@ -449,8 +449,8 @@ module Bag : sig
   (*@ function to_list (b: 'a t) : 'a list *)
   (*@ function of_list (l: 'a list) : 'a t *)
 
-  (*@ function to_seq (b: 'a t) : 'a Seq.t *)
-  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
+  (*@ function to_seq (b: 'a t) : 'a Sequence.t *)
+  (*@ function of_seq (s: 'a Sequence.t) : 'a t *)
 end
 
 (** {1 Sets} *)
@@ -537,8 +537,8 @@ module Set : sig
   (*@ function to_list (s: 'a t) : 'a list *)
   (*@ function of_list (l: 'a list) : 'a t *)
 
-  (*@ function to_seq (s: 'a t) : 'a Seq.t *)
-  (*@ function of_seq (s: 'a Seq.t) : 'a t *)
+  (*@ function to_seq (s: 'a t) : 'a Sequence.t *)
+  (*@ function of_seq (s: 'a Sequence.t) : 'a t *)
 end
 
 (*@ function ( [->] ) (f: 'a -> 'b) (x:'a) (y: 'b) : 'a -> 'b *)

--- a/test/positive/FM19.mli
+++ b/test/positive/FM19.mli
@@ -9,7 +9,7 @@
 (**************************************************************************)
 
 type 'a t
-(*@ mutable model view: 'a seq *)
+(*@ mutable model view: 'a sequence *)
 
 val push : 'a -> 'a t -> unit
 (*@ push v q

--- a/test/positive/FM19.mli
+++ b/test/positive/FM19.mli
@@ -14,26 +14,26 @@ type 'a t
 val push : 'a -> 'a t -> unit
 (*@ push v q
     modifies q
-    ensures  q.view = Seq.cons v (old q.view) *)
+    ensures  q.view = Sequence.cons v (old q.view) *)
 
 val pop : 'a t -> 'a
 (*@ v = pop q
-    requires q.view <> Seq.empty
+    requires q.view <> Sequence.empty
     modifies q
-    ensures  old q.view = q.view ++ (Seq.cons v Seq.empty) *)
+    ensures  old q.view = q.view ++ (Sequence.cons v Sequence.empty) *)
 
 val is_empty : 'a t -> bool
 (*@ b = is_empty q
-    ensures b <-> q.view = Seq.empty *)
+    ensures b <-> q.view = Sequence.empty *)
 
 val create : unit -> 'a t
 (*@ q = create ()
-    ensures q.view = Seq.empty *)
+    ensures q.view = Sequence.empty *)
 
 val in_place_concat : 'a t -> 'a t -> unit
 (*@ in_place_concat q1 q2
     modifies q1, q2
-    ensures  q1.view = Seq.empty
+    ensures  q1.view = Sequence.empty
     ensures  q2.view = old q1.view ++ old q2.view *)
 
 val in_place_destructive_concat : 'a t -> 'a t -> unit
@@ -47,8 +47,8 @@ val nondestructive_concat : 'a t -> 'a t -> 'a t
 
 val map : ('a -> 'b) -> 'a t -> 'b t
 (*@ r = map f q
-    ensures Seq.length r.view = Seq.length q.view
-    ensures forall i. 0 <= i < Seq.length q.view ->
+    ensures Sequence.length r.view = Sequence.length q.view
+    ensures forall i. 0 <= i < Sequence.length q.view ->
                       r.view[i] = f q.view[i] *)
 
 (*@ function power (x y: integer): integer *)

--- a/test/vocal/Mjrty.mli
+++ b/test/vocal/Mjrty.mli
@@ -15,7 +15,7 @@
 (*@ axiom num_base:
       forall a v lo hi. hi <= lo -> num a v lo hi = 0 *)
 (*@ axiom num_ind:
-      forall a v lo hi. 0 <= lo < hi <= Seq.length a ->
+      forall a v lo hi. 0 <= lo < hi <= Sequence.length a ->
       num a v lo hi = (if a[lo] = v then 1 else 0) + num a v (lo+1) hi *)
 
 val mjrty : string array -> string

--- a/test/vocal/Mjrty.mli
+++ b/test/vocal/Mjrty.mli
@@ -8,7 +8,7 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ function num (a: string seq) (v: string) (lo hi: integer) : integer *)
+(*@ function num (a: string sequence) (v: string) (lo hi: integer) : integer *)
 (** the number of occurrences of [v] in [a] between index [lo] included and
     index [hi] excluded *)
 

--- a/test/vocal/Queue.mli
+++ b/test/vocal/Queue.mli
@@ -9,7 +9,7 @@
 (**************************************************************************)
 
 type 'a t
-(*@ mutable model view: 'a seq *)
+(*@ mutable model view: 'a sequence *)
 
 val create : unit -> 'a t
 (** Return a new queue, initially empty. *)

--- a/test/vocal/Queue.mli
+++ b/test/vocal/Queue.mli
@@ -14,32 +14,32 @@ type 'a t
 val create : unit -> 'a t
 (** Return a new queue, initially empty. *)
 (*@ q = create ()
-      ensures q.view = Seq.empty *)
+      ensures q.view = Sequence.empty *)
 
 val push : 'a -> 'a t -> unit
 (** [add x q] adds the element [x] at the end of the queue [q]. *)
 (*@ push x q
       modifies q
-      ensures  q.view = Seq.snoc (old q.view) x *)
+      ensures  q.view = Sequence.snoc (old q.view) x *)
 
 val pop : 'a t -> 'a
 (** [pop q] removes and returns the first element in queue [q]. *)
 (*@ r = pop q
-      requires q.view <> Seq.empty
+      requires q.view <> Sequence.empty
       modifies q
-      ensures  old q.view = Seq.cons r q.view *)
+      ensures  old q.view = Sequence.cons r q.view *)
 
 val is_empty : 'a t -> bool
 (** Return [true] if the given queue is empty, [false] otherwise. *)
 (*@ b = is_empty q
-      ensures b <-> q.view = Seq.empty *)
+      ensures b <-> q.view = Sequence.empty *)
 
 val transfer : 'a t -> 'a t -> unit
 (** [transfer q1 q2] adds all of [q1]'s elements at the end of the queue [q2],
     then clears [q1]. *)
 (*@ transfer q1 q2
       modifies q1.view, q2.view
-      ensures  q1.view = Seq.empty
+      ensures  q1.view = Sequence.empty
       ensures  q2.view = old q2.view ++ old q1.view *)
 
 (* {gospel_expected|

--- a/test/vocal/RingBuffer.mli
+++ b/test/vocal/RingBuffer.mli
@@ -8,7 +8,7 @@
 (*  (as described in file LICENSE enclosed).                              *)
 (**************************************************************************)
 
-(*@ open Seq *)
+(*@ open Sequence *)
 
 type 'a buffer
 (*@ mutable model sequence: 'a seq

--- a/test/vocal/RingBuffer.mli
+++ b/test/vocal/RingBuffer.mli
@@ -11,7 +11,7 @@
 (*@ open Sequence *)
 
 type 'a buffer
-(*@ mutable model sequence: 'a seq
+(*@ mutable model sequence: 'a sequence
             model capacity: integer
     with self
     invariant length self.sequence <= self.capacity <= Sys.max_array_length *)

--- a/test/vocal/Vector.mli
+++ b/test/vocal/Vector.mli
@@ -33,7 +33,7 @@ type 'a t
 (** The polymorphic type of vectors. This is a mutable data type. *)
 (*@ mutable model view: 'a seq
     with self
-    invariant Seq.length self.view <= Sys.max_array_length *)
+    invariant Sequence.length self.view <= Sys.max_array_length *)
 
 (** {2 Operations proper to vectors, or with a different type and/or semantics
     than those of module [Array]} *)
@@ -46,7 +46,7 @@ val create : ?capacity:int -> dummy:'a -> 'a t
       requires let capacity = match capacity with
                  | None -> 0 | Some c -> c in
                0 <= capacity <= Sys.max_array_length
-      ensures  Seq.length a.view = 0 *)
+      ensures  Sequence.length a.view = 0 *)
 
 val make : ?dummy:'a -> int -> 'a -> 'a t
 (** [make dummy n x] returns a fresh vector of length [n] with all elements
@@ -54,7 +54,7 @@ val make : ?dummy:'a -> int -> 'a -> 'a t
     value for this vector. *)
 (*@ a = make ?dummy n x
       requires 0 <= n <= Sys.max_array_length
-      ensures  Seq.length a.view = n
+      ensures  Sequence.length a.view = n
       ensures  forall i: integer. 0 <= i < n -> a.view[i] = x *)
 
 val init : dummy:'a -> int -> (int -> 'a) -> 'a t
@@ -65,7 +65,7 @@ val init : dummy:'a -> int -> (int -> 'a) -> 'a t
     Raise [Invalid_argument] if [n < 0] or [n > Sys.max_array_length]. *)
 (*@ a = init ~dummy n f
       requires 0 <= n <= Sys.max_array_length
-      ensures  Seq.length a.view = n
+      ensures  Sequence.length a.view = n
       ensures  forall i: int. 0 <= i < n -> a.view[i] = f i *)
 
 val resize : 'a t -> int -> unit
@@ -79,8 +79,8 @@ val resize : 'a t -> int -> unit
 (*@ resize a n
       checks   0 <= n <= Sys.max_array_length
       modifies a
-      ensures  Seq.length a.view = n
-      ensures  forall i. 0 <= i < min (Seq.length (old a.view)) n ->
+      ensures  Sequence.length a.view = n
+      ensures  forall i. 0 <= i < min (Sequence.length (old a.view)) n ->
                  a.view[i] = (old a.view)[i] *)
 
 (** {2 Array interface} *)
@@ -90,18 +90,18 @@ val clear : 'a t -> unit
     to 0 with [resize]. *)
 (*@ clear a
       modifies a
-      ensures Seq.length a.view = 0 *)
+      ensures Sequence.length a.view = 0 *)
 
 val is_empty : 'a t -> bool
 (** Return [true] if the given vector is empty, [false] otherwise. *)
 (*@ r = is_empty a
-      ensures r <-> Seq.length a.view = 0 *)
+      ensures r <-> Sequence.length a.view = 0 *)
 
 val length : 'a t -> int
 (** Return the length (number of elements) of the given vector. Note: the number
     of memory words occupied by the vector can be larger. *)
 (*@ n = length a
-      ensures n = Seq.length a.view *)
+      ensures n = Sequence.length a.view *)
 
 val get : 'a t -> int -> 'a
 (** [get a n] returns the element number [n] of vector [a]. The first element
@@ -110,7 +110,7 @@ val get : 'a t -> int -> 'a
     Raise [Invalid_argument "Vector.get"] if [n] is outside the range [0] to
     [length a - 1]. *)
 (*@ x = get a i
-      requires 0 <= i < Seq.length a.view
+      requires 0 <= i < Sequence.length a.view
       ensures  x = a.view[i] *)
 
 val set : 'a t -> int -> 'a -> unit
@@ -120,19 +120,19 @@ val set : 'a t -> int -> 'a -> unit
     Raise [Invalid_argument "Vector.set"] if [n] is outside the range 0 to
     [length a - 1]. *)
 (*@ set a i x
-      requires 0 <= i < Seq.length a.view
+      requires 0 <= i < Sequence.length a.view
       modifies a
-      ensures Seq.length a.view = Seq.length (old a).view
+      ensures Sequence.length a.view = Sequence.length (old a).view
       ensures  a.view[i] = x
-      ensures  forall j. 0 <= j < Seq.length a.view -> j <> i ->
+      ensures  forall j. 0 <= j < Sequence.length a.view -> j <> i ->
                  a.view[j] = (old a).view[j] *)
 
 val sub : 'a t -> int -> int -> 'a t
 (** [sub a start len] returns a fresh vector of length [len], containing the
     elements number [start] to [start + len - 1] of vector [a]. *)
 (*@ r = sub a ofs n
-      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Seq.length a.view
-      ensures  Seq.length r.view = n
+      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Sequence.length a.view
+      ensures  Sequence.length r.view = n
       ensures  forall i. 0 <= i < n -> r.view[i] = a.view[ofs + i] *)
 
 val fill : 'a t -> int -> int -> 'a -> unit
@@ -142,9 +142,9 @@ val fill : 'a t -> int -> int -> 'a -> unit
     Raise [Invalid_argument "Vector.fill"] if [ofs] and [len] do not designate a
     valid subvector of [a]. *)
 (*@ fill a ofs n x
-      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Seq.length a.view
+      requires 0 <= ofs /\ 0 <= n /\ ofs + n <= Sequence.length a.view
       modifies a
-      ensures  forall i. (0 <= i < ofs \/ ofs + n <= i < Seq.length a.view) ->
+      ensures  forall i. (0 <= i < ofs \/ ofs + n <= i < Sequence.length a.view) ->
                  a.view[i] = (old a).view[i]
       ensures  forall i. ofs <= i < ofs + n -> a.view[i] = x *)
 
@@ -159,10 +159,10 @@ val blit : 'a t -> int -> 'a t -> int -> int -> unit
     subvector of [a2]. *)
 (*@ blit a1 ofs1 a2 ofs2 n
       requires 0 <= n
-      requires 0 <= ofs1 /\ ofs1 + n <= Seq.length a1.view
-      requires 0 <= ofs2 /\ ofs2 + n <= Seq.length a2.view
+      requires 0 <= ofs1 /\ ofs1 + n <= Sequence.length a1.view
+      requires 0 <= ofs2 /\ ofs2 + n <= Sequence.length a2.view
       modifies a2
-      ensures  forall i. (0 <= i < ofs2 \/ ofs2 + n <= i < Seq.length a2.view) ->
+      ensures  forall i. (0 <= i < ofs2 \/ ofs2 + n <= i < Sequence.length a2.view) ->
                          a2.view[i] = (old a2).view[i]
       ensures  forall i. ofs2 <= i < ofs2 + n ->
                          a2.view[i] = (old a1).view[ofs1 + i - ofs2] *)
@@ -173,24 +173,24 @@ val append : 'a t -> 'a t -> 'a t
 
     It works correctly even if [a1] and [a2] are the same vector. *)
 (*@ a3 = append a1 a2
-      requires Seq.length a1.view + Seq.length a2.view <= Sys.max_array_length
-      ensures  Seq.length a3.view = Seq.length a1.view + Seq.length a2.view
-      ensures  forall i. 0 <= i < Seq.length a1.view -> a3.view[i] = a1.view[i]
-      ensures  forall i. 0 <= i < Seq.length a2.view ->
-                 a3.view[Seq.length a1.view + i] = a2.view[i] *)
+      requires Sequence.length a1.view + Sequence.length a2.view <= Sys.max_array_length
+      ensures  Sequence.length a3.view = Sequence.length a1.view + Sequence.length a2.view
+      ensures  forall i. 0 <= i < Sequence.length a1.view -> a3.view[i] = a1.view[i]
+      ensures  forall i. 0 <= i < Sequence.length a2.view ->
+                 a3.view[Sequence.length a1.view + i] = a2.view[i] *)
 
 val merge_right : 'a t -> 'a t -> unit
 (** [merge_right a1 a2] moves all elements of [a2] to the end of [a1]. Empties
     [a2]. Assumes [a1] and [a2] to be disjoint. *)
 (*@ merge_right a1 a2
-      requires Seq.length a1.view + Seq.length a2.view <= Sys.max_array_length
+      requires Sequence.length a1.view + Sequence.length a2.view <= Sys.max_array_length
       modifies a1, a2
-      ensures  Seq.length a2.view = 0
-      ensures  Seq.length a1.view = Seq.length (old a1).view + Seq.length (old a2).view
-      ensures  forall i. 0 <= i < Seq.length (old a1).view ->
+      ensures  Sequence.length a2.view = 0
+      ensures  Sequence.length a1.view = Sequence.length (old a1).view + Sequence.length (old a2).view
+      ensures  forall i. 0 <= i < Sequence.length (old a1).view ->
                  a1.view[i] = (old a1).view[i]
-      ensures  forall i. 0 <= i < Seq.length (old a2).view ->
-                 a1.view[Seq.length (old a1).view + i] = (old a2).view[i] *)
+      ensures  forall i. 0 <= i < Sequence.length (old a2).view ->
+                 a1.view[Sequence.length (old a1).view + i] = (old a2).view[i] *)
 
 (* requires disjoint a1 a2 FIXME: disjoint is undefined *)
 
@@ -202,8 +202,8 @@ val map : dummy:'b -> 'a t -> ('a -> 'b) -> 'b t
     the dummy value of [a]. If this is not what you want, first create a new
     vector and then fill it with the value [f (get a 0)], [f (get a 1)], etc. *)
 (*@ a2 = map ~dummy a1 f
-      ensures  Seq.length a2.view = Seq.length a1.view
-      ensures  forall i. 0 <= i < Seq.length a1.view -> a2.view[i] = f a1.view[i] *)
+      ensures  Sequence.length a2.view = Sequence.length a1.view
+      ensures  forall i. 0 <= i < Sequence.length a1.view -> a2.view[i] = f a1.view[i] *)
 
 val mapi : dummy:'b -> 'a t -> (int -> 'a -> 'b) -> 'b t
 (** Same as {!Vector.map}, but the function is applied to the index of the
@@ -212,35 +212,35 @@ val mapi : dummy:'b -> 'a t -> (int -> 'a -> 'b) -> 'b t
     Note: the dummy value of the returned vector is obtained by applying [f 0]
     to the dummy value of [a]. *)
 (*@ a2 = mapi ~dummy a1 f
-      ensures  Seq.length a2.view = Seq.length a1.view
-      ensures  forall i: int. 0 <= i < Seq.length a1.view ->
+      ensures  Sequence.length a2.view = Sequence.length a1.view
+      ensures  forall i: int. 0 <= i < Sequence.length a1.view ->
                a2.view[i] = f i a1.view[i] *)
 
 val copy : 'a t -> 'a t
 (** [copy a] returns a copy of [a], that is, a fresh vector containing the same
     elements as [a]. *)
 (*@ a2 = copy a1
-      ensures  Seq.length a2.view = Seq.length a1.view
-      ensures  forall i. 0 <= i < Seq.length a1.view -> a2.view[i] = a1.view[i] *)
+      ensures  Sequence.length a2.view = Sequence.length a1.view
+      ensures  forall i. 0 <= i < Sequence.length a1.view -> a2.view[i] = a1.view[i] *)
 
 val fold_left : 'b t -> ('a -> 'b -> 'a) -> 'a -> 'a
 (** [fold_left f x a] computes
     [f (... (f (f x (get a 0)) (get a 1)) ...) (get a (n-1))], where [n] is the
     length of the vector [a]. *)
 (*@ r = fold_left a f acc
-      ensures  r = Seq.fold_left f acc a.view *)
+      ensures  r = Sequence.fold_left f acc a.view *)
 
 val fold_right : 'b t -> ('b -> 'a -> 'a) -> 'a -> 'a
 (** [fold_right f a x] computes
     [f (get a 0) (f (get a 1) ( ... (f (get a (n-1)) x) ...))], where [n] is the
     length of the vector [a]. *)
 (*@ r = fold_right a f acc
-      ensures  r = Seq.fold_right f a.view acc *)
+      ensures  r = Sequence.fold_right f a.view acc *)
 
 (* val iter : ('a -> unit) -> 'a t -> unit
  * (\** [iter f a] applies function [f] in turn to all
  *    the elements of [a].  It is equivalent to
- *    [f (get a 0); f (get a 1); ...; f (get a (Seq.length a - 1))]. *\)
+ *    [f (get a 0); f (get a 1); ...; f (get a (Sequence.length a - 1))]. *\)
  * (\*@ iter f a
  *       equivalent "for i = 0 to length a - 1 do f (get a i) done" *\)
  *
@@ -262,11 +262,11 @@ val push : 'a t -> 'a -> unit
 
     Note: the order of the arguments is not that of {!Stack.push}. *)
 (*@ push a x
-      requires Seq.length a.view < Sys.max_array_length
+      requires Sequence.length a.view < Sys.max_array_length
       modifies a
-      ensures  Seq.length a.view = Seq.length (old a.view) + 1
-      ensures  a.view[Seq.length a.view - 1] = x
-      ensures  forall i. 0 <= i < Seq.length (old a.view) ->
+      ensures  Sequence.length a.view = Sequence.length (old a.view) + 1
+      ensures  a.view[Sequence.length a.view - 1] = x
+      ensures  forall i. 0 <= i < Sequence.length (old a.view) ->
                  a.view[i] = (old a).view[i] *)
 
 exception Empty
@@ -276,10 +276,10 @@ val pop : 'a t -> 'a
     [Empty] if the stack is empty. *)
 (*@ x = pop a
       modifies a
-      raises   Empty -> Seq.length a.view = Seq.length (old a).view = 0
-      ensures  Seq.length a.view = Seq.length (old a).view - 1
-      ensures  x = (old a).view[Seq.length a.view]
-      ensures  forall i. 0 <= i < Seq.length a.view ->
+      raises   Empty -> Sequence.length a.view = Sequence.length (old a).view = 0
+      ensures  Sequence.length a.view = Sequence.length (old a).view - 1
+      ensures  x = (old a).view[Sequence.length a.view]
+      ensures  forall i. 0 <= i < Sequence.length a.view ->
                  a.view[i] = (old a).view[i] *)
 
 val pop_opt : 'a t -> 'a option
@@ -287,25 +287,25 @@ val pop_opt : 'a t -> 'a option
 (*@ r = pop_opt a
       modifies a
       ensures  match r with
-               | None   -> Seq.length a.view = Seq.length (old a).view = 0
-               | Some x -> Seq.length a.view = Seq.length (old a).view - 1 /\
-                           x = (old a).view[Seq.length a.view] /\
-                           forall i. 0 <= i < Seq.length a.view ->
+               | None   -> Sequence.length a.view = Sequence.length (old a).view = 0
+               | Some x -> Sequence.length a.view = Sequence.length (old a).view - 1 /\
+                           x = (old a).view[Sequence.length a.view] /\
+                           forall i. 0 <= i < Sequence.length a.view ->
                                      a.view[i] = (old a).view[i] *)
 
 val top : 'a t -> 'a
 (** [top a] returns the rightmost element in vector [a], or raises [Empty] if
     the vector is empty. *)
 (*@ x = top a
-      requires 0 < Seq.length a.view
-      ensures  x = a.view[Seq.length a.view - 1] *)
+      requires 0 < Sequence.length a.view
+      ensures  x = a.view[Sequence.length a.view - 1] *)
 
 val top_opt : 'a t -> 'a option
 (** similar to [top], but with an option instead of an exception *)
 (*@ r = top_opt a
       ensures  match r with
-               | None   -> Seq.length a.view = 0
-               | Some x -> x = a.view[Seq.length a.view - 1] *)
+               | None   -> Sequence.length a.view = 0
+               | Some x -> x = a.view[Sequence.length a.view - 1] *)
 
 (** {2 Conversions to/from arrays and lists} *)
 

--- a/test/vocal/Vector.mli
+++ b/test/vocal/Vector.mli
@@ -31,7 +31,7 @@
 
 type 'a t
 (** The polymorphic type of vectors. This is a mutable data type. *)
-(*@ mutable model view: 'a seq
+(*@ mutable model view: 'a sequence
     with self
     invariant Sequence.length self.view <= Sys.max_array_length *)
 

--- a/test/vocal/ZipperList.mli
+++ b/test/vocal/ZipperList.mli
@@ -14,21 +14,21 @@ type 'a t
 (*@ model seq: 'a seq
     model idx: integer
     with self
-    invariant 0 <= self.idx <= Seq.length self.seq *)
+    invariant 0 <= self.idx <= Sequence.length self.seq *)
 
 val empty : unit -> 'a t
 (*@ z = empty ()
-    ensures z.seq = Seq.empty
+    ensures z.seq = Sequence.empty
     ensures z.idx = 0 *)
 (* could be deduced from invariant *)
 
 val is_empty : 'a t -> bool
 (*@ b = is_empty z
-    ensures b <-> z.seq = Seq.empty *)
+    ensures b <-> z.seq = Sequence.empty *)
 
 val length : 'a t -> int
 (*@ r = length z
-    ensures r = Seq.length z.seq *)
+    ensures r = Sequence.length z.seq *)
 
 val to_list : 'a t -> 'a list
 (*@ l = to_list z
@@ -47,7 +47,7 @@ val move_left : 'a t -> 'a t
 
 val insert_left : 'a -> 'a t -> 'a t
 (*@ r = insert_left x z
-    ensures  r.seq = Seq.snoc z.seq[.. z.idx] x ++ z.seq[z.idx ..]
+    ensures  r.seq = Sequence.snoc z.seq[.. z.idx] x ++ z.seq[z.idx ..]
     ensures  r.idx = z.idx + 1 *)
 
 val remove_left : 'a t -> 'a t
@@ -63,35 +63,35 @@ val move_all_left : 'a t -> 'a t
 
 val move_right : 'a t -> 'a t
 (*@ r = move_right z
-    requires z.idx < Seq.length z.seq
+    requires z.idx < Sequence.length z.seq
     ensures  r.seq = z.seq
     ensures  r.idx = z.idx + 1 *)
 
 val insert_right : 'a -> 'a t -> 'a t
 (*@ r = insert_right x z
-    ensures  r.seq = z.seq[.. z.idx] ++ Seq.cons x z.seq[z.idx ..]
+    ensures  r.seq = z.seq[.. z.idx] ++ Sequence.cons x z.seq[z.idx ..]
     ensures  r.idx = z.idx *)
 
 val remove_right : 'a t -> 'a t
 (*@ r = remove_right z
-    requires z.idx < Seq.length z.seq
+    requires z.idx < Sequence.length z.seq
     ensures  r.seq = z.seq[.. z.idx] ++ z.seq[z.idx + 1 ..]
     ensures  r.idx = z.idx *)
 
 val move_all_right : 'a t -> 'a t
 (*@ r = move_all_right z
     ensures r.seq = z.seq
-    ensures r.idx = Seq.length z.seq *)
+    ensures r.idx = Sequence.length z.seq *)
 
 val is_focused : 'a t -> bool
 (*@ b = is_focused z
-    ensures b <-> z.idx < Seq.length z.seq *)
+    ensures b <-> z.idx < Sequence.length z.seq *)
 
 val focused : 'a t -> 'a option
 (*@ r = focused z
     ensures match r with
-            | None   -> z.idx = Seq.length z.seq
-            | Some x -> z.idx < Seq.length z.seq /\ x = z.seq[z.idx] *)
+            | None   -> z.idx = Sequence.length z.seq
+            | Some x -> z.idx < Sequence.length z.seq /\ x = z.seq[z.idx] *)
 
 (* {gospel_expected|
    [0] OK

--- a/test/vocal/ZipperList.mli
+++ b/test/vocal/ZipperList.mli
@@ -11,7 +11,7 @@
 (** Zippers for lists *)
 
 type 'a t
-(*@ model seq: 'a seq
+(*@ model seq: 'a sequence
     model idx: integer
     with self
     invariant 0 <= self.idx <= Sequence.length self.seq *)


### PR DESCRIPTION
Implements #115:
- renames the logic module `Seq` to `Sequence`;
- renames the logic type `'a seq` to `'a sequence` (for consistency).