### PR TITLE
Display an “Internal error” on dummy positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,9 @@
 
 ## Fixed
 
+- Avoid uncaught exception when displaying a warning on a dummy
+  position
+  [\#262](https://github.com/ocaml-gospel/gospel/pull/262)
 - Constants can now be referenced in specifications.
   [\#211](https://github.com/ocaml-gospel/gospel/pull/211)
 - Infix operators in specificaion headers are now accepted.

--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -151,26 +151,37 @@ let styled_list l pp = List.fold_left (fun acc x -> styled x acc) pp l
 
 let pp ppf (loc, k) =
   let input_filename = loc.loc_start.pos_fname in
-  let input = Pp_loc.Input.file input_filename in
-  (* because of the preprocessor (gospel pps), we may obtain locations that:
-     - have correct line numbers and correct offsets within a line (pos_cnum -
-       pos_bol) (where "correct" means that they refer to the user-written file
-       before preprocessing); but
-     - where the [pos_cnum] and [pos_bol] fields refer to offsets within the
-       file *after* preprocessing rather than *before*.
+  if input_filename = "" then
+    pf ppf
+      "Internal error: no filename location for the following error\n\
+       %a: @[%a.@]"
+      (styled_list [ `Red; `Bold ] string)
+      "Error" pp_kind k
+  else
+    let input = Pp_loc.Input.file input_filename in
+    (* because of the preprocessor (gospel pps), we may obtain locations that:
+       - have correct line numbers and correct offsets within a line (pos_cnum -
+         pos_bol) (where "correct" means that they refer to the user-written file
+         before preprocessing); but
+       - where the [pos_cnum] and [pos_bol] fields refer to offsets within the
+         file *after* preprocessing rather than *before*.
 
-     We thus use helpers from [Pp_loc.Position] to recompute full positions from
-     line/column numbers with respect to the input file before preprocessing.
-  *)
-  let repair_pos (p : Lexing.position) : Lexing.position =
-    Pp_loc.Position.of_line_col p.pos_lnum (p.pos_cnum - p.pos_bol + 1)
-    |> Pp_loc.Position.to_lexing ~filename:input_filename input
-  in
-  let start_pos, end_pos = (repair_pos loc.loc_start, repair_pos loc.loc_end) in
-  pf ppf "%a@\n%a%a: @[%a.@]"
-    (styled `Bold Location.print)
-    { loc_start = start_pos; loc_end = end_pos; loc_ghost = false }
-    (Pp_loc.pp ~max_lines:10 ~input)
-    [ (Pp_loc.Position.of_lexing start_pos, Pp_loc.Position.of_lexing end_pos) ]
-    (styled_list [ `Red; `Bold ] string)
-    "Error" pp_kind k
+       We thus use helpers from [Pp_loc.Position] to recompute full positions from
+       line/column numbers with respect to the input file before preprocessing.
+    *)
+    let repair_pos (p : Lexing.position) : Lexing.position =
+      Pp_loc.Position.of_line_col p.pos_lnum (p.pos_cnum - p.pos_bol + 1)
+      |> Pp_loc.Position.to_lexing ~filename:input_filename input
+    in
+    let start_pos, end_pos =
+      (repair_pos loc.loc_start, repair_pos loc.loc_end)
+    in
+    pf ppf "%a@\n%a%a: @[%a.@]"
+      (styled `Bold Location.print)
+      { loc_start = start_pos; loc_end = end_pos; loc_ghost = false }
+      (Pp_loc.pp ~max_lines:10 ~input)
+      [
+        (Pp_loc.Position.of_lexing start_pos, Pp_loc.Position.of_lexing end_pos);
+      ]
+      (styled_list [ `Red; `Bold ] string)
+      "Error" pp_kind k

--- a/test/negative/dune.inc
+++ b/test/negative/dune.inc
@@ -65,6 +65,17 @@
  (action (diff %{dep:constructor_arity4.mli} %{dep:constructor_arity4.mli.output})))
 
 (rule
+ (target duplicate_declaration.mli.output)
+ (deps (source_tree .))
+ (action
+   (with-outputs-to %{target}
+      (run %{project_root}/test/gospel_check.exe %{dep:duplicate_declaration.mli}))))
+
+(rule
+ (alias runtest)
+ (action (diff %{dep:duplicate_declaration.mli} %{dep:duplicate_declaration.mli.output})))
+
+(rule
  (target empty_match.mli.output)
  (deps (source_tree .))
  (action

--- a/test/negative/duplicate_declaration.mli
+++ b/test/negative/duplicate_declaration.mli
@@ -1,0 +1,20 @@
+type t
+
+(*@ type t *)
+
+(* {gospel_expected|
+   [125] gospel: internal error, uncaught exception:
+                 Sys_error(": No such file or directory")
+                 Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 403, characters 28-54
+                 Called from Stdlib.open_in_bin in file "stdlib.ml" (inlined), line 411, characters 2-47
+                 Called from Pp_loc.Input.file.(fun) in file "lib/pp_loc.ml", line 73, characters 16-32
+                 Called from Pp_loc.Input.open_raw in file "lib/pp_loc.ml", line 107, characters 17-21
+                 Called from Pp_loc.Position.to_lexing.(fun) in file "lib/pp_loc.ml", line 161, characters 23-43
+                 Called from Gospel__Warnings.pp in file "src/warnings.ml", line 169, characters 54-76
+                 Called from Stdlib__Format.output_acc in file "format.ml", line 1360, characters 4-20
+                 Called from Dune__exe__Check.run_file in file "bin/check.ml", line 58, characters 4-25
+                 Called from Dune__exe__Check.run.(fun) in file "bin/check.ml", line 62, characters 33-53
+                 Called from Dune__exe__Cli.run_check in file "bin/cli.ml", line 42, characters 10-47
+                 Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
+                 Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
+   |gospel_expected} *)

--- a/test/negative/duplicate_declaration.mli
+++ b/test/negative/duplicate_declaration.mli
@@ -3,18 +3,6 @@ type t
 (*@ type t *)
 
 (* {gospel_expected|
-   [125] gospel: internal error, uncaught exception:
-                 Sys_error(": No such file or directory")
-                 Raised by primitive operation at Stdlib.open_in_gen in file "stdlib.ml", line 403, characters 28-54
-                 Called from Stdlib.open_in_bin in file "stdlib.ml" (inlined), line 411, characters 2-47
-                 Called from Pp_loc.Input.file.(fun) in file "lib/pp_loc.ml", line 73, characters 16-32
-                 Called from Pp_loc.Input.open_raw in file "lib/pp_loc.ml", line 107, characters 17-21
-                 Called from Pp_loc.Position.to_lexing.(fun) in file "lib/pp_loc.ml", line 161, characters 23-43
-                 Called from Gospel__Warnings.pp in file "src/warnings.ml", line 169, characters 54-76
-                 Called from Stdlib__Format.output_acc in file "format.ml", line 1360, characters 4-20
-                 Called from Dune__exe__Check.run_file in file "bin/check.ml", line 58, characters 4-25
-                 Called from Dune__exe__Check.run.(fun) in file "bin/check.ml", line 62, characters 33-53
-                 Called from Dune__exe__Cli.run_check in file "bin/cli.ml", line 42, characters 10-47
-                 Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
-                 Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 34, characters 37-44
+   [125] Internal error: no filename location for the following error
+         Error: A declaration for `t' already exists in this context.
    |gospel_expected} *)


### PR DESCRIPTION
Instead of running into an exception, display an ”Internal error” message when a warning is attached to a dummy position

I didn’t investigate why such dummy positions are generated.