### PR TITLE
CI: Skip the full changelog workflow when no changelog is needed

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,11 +9,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}
+
     steps:
     - uses: actions/checkout@v1
 
     - name: git diff
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}
       env:
         BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |


### PR DESCRIPTION
Instead of starting a job that will check out the code and do nothing with it, skip the whole workflow when the label is set