### PR TITLE
Fix pps with documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@
 
 ## Fixed
 
+- Documentation comments between declarations and specifications are not
+  detached anymore
+  [\#266](https://github.com/ocamlc-gospel/gospel/pull/266)
 - Avoid uncaught exception when displaying a warning on a dummy
   position
   [\#262](https://github.com/ocaml-gospel/gospel/pull/262)

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,4 @@
-(lang dune 2.4)
+(lang dune 2.7)
 (name gospel)
 (using menhir 2.0)
+(cram enable)

--- a/test/documentation/dune
+++ b/test/documentation/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps
+  (package gospel)))

--- a/test/documentation/test_preprocess_documentation.t
+++ b/test/documentation/test_preprocess_documentation.t
@@ -1,0 +1,28 @@
+Testing interaction between `gospel pps` and Ocaml compiler. The issue is that
+`gospel pps` detached documentation comments. In order to check whether this is
+the case or not, we need to make the output of the gospel preprocessor go
+through OCaml compiler and then ask for a source that could have generated it
+(with the `-dsource` option).
+
+First, we create a small test artifact with the problematic interleaving of
+documentation comment and gospel specification:
+
+  $ cat > foo.mli << EOF
+  > val f : int -> int
+  > (** documentation *)
+  > (*@ y = f x *)
+  > EOF
+
+Now, we look at how the OCaml compiler understand the output of the gospel
+preprocessor. We also enable the compiler warning about unexpected docstring,
+and cleanup stderr because the name of the file in the error message will
+change at each build. Note that this cleanup relies on the number of lines of
+the interface `foo.mli`, with a longer content, it will not work as expected:
+
+  $ ocamlc -pp "dune exec -- gospel pps" -dsource -w +50 foo.mli 2>&1 | tail -n 2
+  Warning 50 [unexpected-docstring]: unattached documentation comment (ignored)
+  val f : int -> int[@@gospel {| y = f x |}]
+
+Finally, just a little clean up after ourselves.
+
+  $ rm foo.mli

--- a/test/documentation/test_preprocess_documentation.t
+++ b/test/documentation/test_preprocess_documentation.t
@@ -14,14 +14,10 @@ documentation comment and gospel specification:
   > EOF
 
 Now, we look at how the OCaml compiler understand the output of the gospel
-preprocessor. We also enable the compiler warning about unexpected docstring,
-and cleanup stderr because the name of the file in the error message will
-change at each build. Note that this cleanup relies on the number of lines of
-the interface `foo.mli`, with a longer content, it will not work as expected:
+preprocessor. We also enable the compiler warning about unexpected docstring:
 
-  $ ocamlc -pp "dune exec -- gospel pps" -dsource -w +50 foo.mli 2>&1 | tail -n 2
-  Warning 50 [unexpected-docstring]: unattached documentation comment (ignored)
-  val f : int -> int[@@gospel {| y = f x |}]
+  $ ocamlc -pp "dune exec -- gospel pps" -dsource -w +50 foo.mli
+  val f : int -> int[@@ocaml.doc " documentation "][@@gospel {| y = f x |}]
 
 Finally, just a little clean up after ourselves.
 


### PR DESCRIPTION
This PR's intent is to fix #266 

A Documentation token is added to the lexer, so that we can print the ones between an OCaml declaration and gospel specifications directly as attributes. The other are printed as documentation comments, so that OCaml parser deal with them appropriately.