### PR TITLE
Remove Lghost constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,8 @@
 
 ## Internals
 
+- Remove `Lghost` constructors both in UAST and TAST.
+  [\#271](https://github.com/ocaml-gospel/gospel/pull/271)
 - Fixed the order of exceptional postconditions in the AST.
   [\#200](https://github.com/ocaml-gospel/gospel/pull/200)
 - Refactored the error handling: Gospel now only raises a single `Gospel.Error`

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -311,7 +311,7 @@ let pattern dp =
   let get_var pid ty =
     try Mstr.find pid.Preid.pid_str !vars
     with Not_found ->
-      let vs = create_vsymbol pid ty in
+      let vs = create_vsymbol pid ty Nonghost in
       (* TODO the variable found is of type ty *)
       vars := Mstr.add pid.pid_str vs !vars;
       vs
@@ -372,7 +372,7 @@ and term_node ~loc env prop dty dterm_node =
   | DTlet (pid, dt1, dt2) ->
       let prop = prop || dty = None in
       let t1 = term env false dt1 in
-      let vs = create_vsymbol pid (t_type t1) in
+      let vs = create_vsymbol pid (t_type t1) Nonghost in
       let env = Mstr.add pid.pid_str vs env in
       let t2 = term env prop dt2 in
       t_let vs t1 t2 loc
@@ -388,7 +388,7 @@ and term_node ~loc env prop dty dterm_node =
   | DTold dt -> t_old (term env prop dt) loc
   | DTquant (q, bl, dt) ->
       let add_var (env, vsl) (pid, dty) =
-        let vs = create_vsymbol pid (ty_of_dty dty) in
+        let vs = create_vsymbol pid (ty_of_dty dty) Nonghost in
         (Mstr.add pid.pid_str vs env, vs :: vsl)
       in
       let env, vsl = List.fold_left add_var (env, []) bl in

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -12,10 +12,14 @@ open Ppxlib
 open Ttypes
 module Ident = Identifier.Ident
 
-(* Variable Symbols *)
-type vsymbol = { vs_name : Ident.t; vs_ty : ty } [@@deriving show]
+type ghost = Nonghost | Ghost [@@deriving show]
 
-let create_vsymbol pid ty = { vs_name = Ident.of_preid pid; vs_ty = ty }
+(* Variable Symbols *)
+type vsymbol = { vs_name : Ident.t; vs_ty : ty; ghost : ghost }
+[@@deriving show]
+
+let create_vsymbol pid ty ghost =
+  { vs_name = Ident.of_preid pid; vs_ty = ty; ghost }
 
 module Vs = struct
   type t = vsymbol

--- a/src/tast.ml
+++ b/src/tast.ml
@@ -19,7 +19,6 @@ type lb_arg =
   | Lnone of vsymbol  (** x *)
   | Loptional of vsymbol  (** ?x *)
   | Lnamed of vsymbol  (** ~x *)
-  | Lghost of vsymbol  (** \[x: t\] *)
 [@@deriving show]
 
 type val_spec = {
@@ -186,7 +185,6 @@ type type_exception = {
 [@@deriving show]
 
 type rec_flag = Nonrecursive | Recursive [@@deriving show]
-type ghost = Nonghost | Ghost [@@deriving show]
 
 type with_constraint =
   | Wty of Ident.t * type_declaration

--- a/src/tast_helper.ml
+++ b/src/tast_helper.ml
@@ -6,11 +6,11 @@ module W = Warnings
 
 let vs_of_lb_arg = function
   | Lunit -> invalid_arg "vs_of_lb_arg Lunit"
-  | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> vs
+  | Lnone vs | Loptional vs | Lnamed vs -> vs
 
 let ty_of_lb_arg = function
   | Lunit -> ty_unit
-  | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> vs.vs_ty
+  | Lnone vs | Loptional vs | Lnamed vs -> vs.vs_ty
 
 let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
     sp_diverge sp_pure sp_equiv sp_text sp_loc =

--- a/src/tast_printer.ml
+++ b/src/tast_printer.ml
@@ -89,10 +89,11 @@ let print_type_declaration fmt td =
 
 let print_lb_arg fmt = function
   | Lunit -> pp fmt "()"
+  | Lnone vs when vs.ghost = Ghost ->
+      pp fmt "[%a: %a]" print_vs vs print_ty vs.vs_ty
   | Lnone vs -> print_vs fmt vs
   | Loptional vs -> pp fmt "?%a" print_vs vs
   | Lnamed vs -> pp fmt "~%a" print_vs vs
-  | Lghost vs -> pp fmt "[%a: %a]" print_vs vs print_ty vs.vs_ty
 
 let print_xposts f xposts =
   if xposts = [] then ()

--- a/src/tterm_printer.ml
+++ b/src/tterm_printer.ml
@@ -14,8 +14,10 @@ open Ttypes
 open Utils
 open Fmt
 
-let print_vs fmt { vs_name; vs_ty } =
-  pp fmt "@[%a:%a@]" Ident.pp vs_name print_ty vs_ty
+let print_vs fmt { vs_name; vs_ty; ghost } =
+  if ghost = Ghost then
+    pp fmt "@[@ghost %a:%a@]" Ident.pp vs_name print_ty vs_ty
+  else pp fmt "@[%a:%a@]" Ident.pp vs_name print_ty vs_ty
 
 let print_ls_decl fmt { ls_name; ls_args; ls_value; _ } =
   let is_func = Option.is_some ls_value in

--- a/src/uast.mli
+++ b/src/uast.mli
@@ -21,12 +21,13 @@ type pty =
   | PTtuple of pty list
   | PTarrow of labelled_arg * pty * pty
 
+and ghost = Nonghost | Ghost of pty
+
 and labelled_arg =
   | Lunit
-  | Lnone of Preid.t
+  | Lnone of Preid.t * ghost
   | Loptional of Preid.t
   | Lnamed of Preid.t
-  | Lghost of Preid.t * pty
 
 (* Patterns *)
 

--- a/src/uparser.mly
+++ b/src/uparser.mly
@@ -251,20 +251,20 @@ fun_arg:
 | LEFTPAR RIGHTPAR
   { Lunit }
 | lident
-  { Lnone $1 }
+  { Lnone ($1, Nonghost) }
 | TILDE lident
   { Lnamed $2 }
 | QUESTION lident
   { Loptional $2 }
 | LEFTSQ id=lident COLON ty=typ RIGHTSQ
-  { Lghost (id, ty) }
+  { Lnone (id, Ghost ty) }
 ;
 
 ret_value:
 | lident
-  { Lnone $1 }
+  { Lnone ($1, Nonghost) }
 | LEFTSQ id=lident COLON ty=typ RIGHTSQ
-  { Lghost (id, ty) }
+  { Lnone (id, Ghost ty) }
 ;
 
 ret_name:
@@ -476,7 +476,7 @@ typ:
     { PTarrow (Loptional id, aty, rty) }
 | typ ARROW typ
     { let l = mk_loc $loc in
-      PTarrow (Lnone (id_anonymous l), $1, $3) }
+      PTarrow (Lnone ((id_anonymous l), Nonghost), $1, $3) }
 | ty_arg STAR ty_tuple
     { PTtuple ($1 :: $3) }
 ;

--- a/src/upretty_printer.ml
+++ b/src/upretty_printer.ml
@@ -23,10 +23,10 @@ let rec qualid fmt (q : qualid) =
 let labelled_arg fmt (l : labelled_arg) =
   match l with
   | Lunit -> pp fmt "()"
-  | Lnone pid -> Preid.pp fmt pid
+  | Lnone (pid, Nonghost) -> Preid.pp fmt pid
+  | Lnone (pid, Ghost _) -> pp fmt "@[[%a : TY]@]" Preid.pp pid
   | Loptional pid -> pp fmt "@[?%a@]" Preid.pp pid
   | Lnamed pid -> pp fmt "@[~%a@]" Preid.pp pid
-  | Lghost (pid, _) -> pp fmt "@[[%a : TY]@]" Preid.pp pid
 
 let spec f fmt x = pp fmt "@[(*@@ %a@ *)@]" f x
 let term fmt _ = pp fmt "@[TERM ... @]"


### PR DESCRIPTION
This PR address part of #128, namely removing the `Lghost` label and storing the corresponding piece of information elsewhere. In order to keep track of the ghost information, we've added:
- a `ghost` field to `vsymbol`
- a `ghost` argument (holding an optional type information) to `Uast.Lnone` 