### PR TITLE
Add a documentation tokens to pps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,8 @@
 - Avoid uncaught exception when displaying a warning for builtins (using
   `Location.none`)
   [\#283](https://github.com/ocaml-gospel/gospel/pull/283)
+- Gospel preprocessor no longer detach documentation below a declaration
+  [\#281](https://github.com/ocaml-gospel/gospel/pull/281)
 - Fixed pattern match analysis in exceptional postconditions
   [\#277](https://github/ocaml-gospel/gospel/pull/277)
 - Avoid uncaught exception when displaying a warning on a dummy

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.4)
+(lang dune 3.0)
 (name gospel)
 (using menhir 2.0)

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -68,6 +68,32 @@
       end_p.Lexing.pos_lnum end_p.pos_fname
       (String.make (end_p.pos_cnum - end_p.pos_bol - 1 (*]*)) ' ')
 
+  let print_documentation_attribute start_p end_p s =
+    Fmt.str "[@@@ocaml.doc\n\
+# %d \"%s\"\n\
+%s {|%s|}\n\
+# %d \"%s\"\n\
+%s]"
+    start_p.Lexing.pos_lnum start_p.pos_fname
+    (String.make (start_p.pos_cnum - start_p.pos_bol) ' ') s
+    end_p.Lexing.pos_lnum end_p.pos_fname
+    (String.make (end_p.pos_cnum - end_p.pos_bol - 1 (*]*)) ' ')
+
+  let print_empty_documentation end_p =
+    Fmt.str "[@@@ocaml.doc\n\
+# %d \"%s\"\n\
+%s]"
+    end_p.Lexing.pos_lnum end_p.pos_fname
+    (String.make (end_p.pos_cnum - end_p.pos_bol - 1 (*]*)) ' ')
+
+  let print_triplet o sp doc sp' start_p end_p s =
+   let docstring = match doc with
+   | Documentation (start_p, end_p, d) -> (print_documentation_attribute start_p end_p d)
+   | Empty_documentation end_p -> print_empty_documentation end_p
+   | _ -> assert false
+   in
+   Fmt.str "%s%s%s%s%s" o sp  docstring sp' (print_gospel `TwoAt start_p end_p s)
+
   let rec print = function
   | Ghost (start_p, _, g) :: Spec (inner_start_p, end_p, s) :: l ->
     Fmt.str "%s%s"

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -110,8 +110,25 @@
     Fmt.str "%s%s" (print_gospel `TwoAt start_p end_p s) (print l)
   | Other o :: Spaces sp :: Spec (start_p, end_p, s) :: l ->
     Fmt.str "%s%s%s%s" o sp (print_gospel `TwoAt start_p end_p s) (print l)
+  | Other o :: Spaces sp :: (Documentation (_, _, _) as doc) :: Spaces sp' :: Spec (start_p, end_p, s) :: l
+  | Other o :: Spaces sp :: ((Empty_documentation _)  as doc) :: Spaces sp' :: Spec (start_p, end_p, s) :: l ->
+    Fmt.str "%s%s" (print_triplet o sp doc sp' start_p end_p s) (print l)
+  | Other o :: (Documentation (_, _, _) as doc) :: Spaces sp' :: Spec (start_p, end_p, s) :: l
+  | Other o :: (Empty_documentation _ as doc) :: Spaces sp' :: Spec (start_p, end_p, s) :: l ->
+    let sp = "" in
+    Fmt.str "%s%s" (print_triplet o sp doc sp' start_p end_p s) (print l)
+  | Other o :: Spaces sp :: (Documentation (_, _, _) as doc) :: Spec (start_p, end_p, s) :: l
+  | Other o :: Spaces sp :: (Empty_documentation _ as doc) :: Spec (start_p, end_p, s) :: l ->
+    let sp' = "" in
+    Fmt.str "%s%s" (print_triplet o sp doc sp' start_p end_p s) (print l)
+  | Other o :: (Documentation (_, _, _) as doc) :: Spec (start_p, end_p, s) :: l
+  | Other o :: (Empty_documentation _  as doc) :: Spec (start_p, end_p, s) :: l ->
+    let sp, sp' = "", "" in
+    Fmt.str "%s%s" (print_triplet o sp doc sp' start_p end_p s) (print l)
   | (Other s | Spaces s) :: l ->
     Fmt.str "%s%s" s (print l)
+  | Documentation (_, _, s) :: l -> Fmt.str "(**%s*)%s" s (print l)
+  | Empty_documentation _ :: l -> Fmt.str "(**)%s" (print l)
   | [] -> ""
 
   let collapse_spaces l =

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -2,6 +2,8 @@
   type t =
     | Ghost of Lexing.position * Lexing.position * string
     | Spec of Lexing.position * Lexing.position * string
+    | Documentation of Lexing.position * Lexing.position * string
+    | Empty_documentation of Lexing.position
     | Other of string
     | Spaces of string
 

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -122,6 +122,22 @@ rule scan = parse
     { push (); Lexing.new_line lexbuf; Queue.push (Spaces nl) queue; scan lexbuf }
   | "(*@"
     { push (); gospel (Lexing.lexeme_start_p lexbuf) lexbuf }
+  | "(**)" {
+    push ();
+    let end_pos = Lexing.lexeme_end_p lexbuf in
+    Queue.push (Empty_documentation end_pos) queue;
+    scan lexbuf
+    }
+  | "(**" {
+    push ();
+    let start_pos = Lexing.lexeme_start_p lexbuf in
+    comment lexbuf;
+    let s = Buffer.contents buf in
+    Buffer.clear buf;
+    let end_pos = Lexing.lexeme_end_p lexbuf in
+    Queue.push (Documentation (start_pos, end_pos, s)) queue;
+    scan lexbuf
+    }
   | "(*"
       {
         Buffer.add_string buf "(*";

--- a/test/documentation/dune
+++ b/test/documentation/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:gospel}))

--- a/test/documentation/test_preprocess_documentation.t
+++ b/test/documentation/test_preprocess_documentation.t
@@ -1,0 +1,139 @@
+Testing interaction between `gospel pps` and Ocaml compiler. The issue is that
+`gospel pps` detached documentation comments. In order to check whether this is
+the case or not, we need to make the output of the gospel preprocessor go
+through OCaml compiler and then ask for a source that could have generated it
+(with the `-dsource` option).
+
+First, we create a small test artifact with the problematic interleaving of
+documentation comment and gospel specification:
+
+  $ cat > foo.mli << EOF
+  > val f : int -> int
+  > (** documentation *)
+  > (*@ y = f x *)
+  > EOF
+
+Now, we look at how the OCaml compiler understand the output of the gospel
+preprocessor. We also enable the compiler warning about unexpected docstring:
+
+  $ ocamlc -pp "gospel pps" -dsource -w +50 foo.mli
+  val f : int -> int[@@ocaml.doc {| documentation |}][@@gospel {| y = f x |}]
+
+We now test the locations.
+
+In order to test the locations, we will make an error in the gospel
+specifications after an multi-line informal documentation block:
+
+  $ cat > foo.mli << EOF
+  > val f : int -> int
+  > (** multi
+  >     (* line *)
+  >     documentation *)
+  > (*@ y = f x z *)
+  > EOF
+
+Gospel preprocessing should indicate the correct location with the `#` syntax:
+
+  $ gospel pps foo.mli
+  val f : int -> int
+  [@@ocaml.doc
+  # 2 "foo.mli"
+   {| multi
+      (* line *)
+      documentation |}
+  # 4 "foo.mli"
+                     ]
+  [@@gospel
+  # 5 "foo.mli"
+   {| y = f x z |}
+  # 5 "foo.mli"
+                 ]
+  
+
+
+
+Gospel typechecking should spot an error and locate it at the fifth line of the file:
+
+  $ gospel check foo.mli
+  File "foo.mli", line 5, characters 12-13:
+  5 | (*@ y = f x z *)
+                  ^
+  Error: Type checking error: parameter do not match with val type.
+  [125]
+
+
+Another corner case is the empty documentation attibute:
+
+  $ cat > foo.mli << EOF
+  > val f : int -> int
+  > (**)
+  > (*@ y = f x z *)
+  > EOF
+  $ gospel pps foo.mli
+  val f : int -> int
+  [@@ocaml.doc
+  # 2 "foo.mli"
+     ]
+  [@@gospel
+  # 3 "foo.mli"
+   {| y = f x z |}
+  # 3 "foo.mli"
+                 ]
+  
+
+
+
+And some other corner cases with different spacing:
+
+  $ cat > foo.mli << EOF
+  > val f : int -> int(*@ y = f x z *)
+  > EOF
+  $ gospel pps foo.mli
+  val f : int -> int[@@gospel
+  # 1 "foo.mli"
+                     {| y = f x z |}
+  # 1 "foo.mli"
+                                   ]
+  
+
+
+
+  $ cat > foo.mli << EOF
+  > val f : int -> int(** documentation *)
+  > (*@ y = f x *)
+  > EOF
+  $ gospel pps foo.mli
+  val f : int -> int[@@ocaml.doc
+  # 1 "foo.mli"
+                     {| documentation |}
+  # 1 "foo.mli"
+                                       ]
+  [@@gospel
+  # 2 "foo.mli"
+   {| y = f x |}
+  # 2 "foo.mli"
+               ]
+  
+
+
+
+  $ cat > foo.mli << EOF
+  > val f : int -> int(** documentation *)(*@ y = f x *)
+  > EOF
+  $ gospel pps foo.mli
+  val f : int -> int[@@ocaml.doc
+  # 1 "foo.mli"
+                     {| documentation |}
+  # 1 "foo.mli"
+                                       ][@@gospel
+  # 1 "foo.mli"
+                                         {| y = f x |}
+  # 1 "foo.mli"
+                                                     ]
+  
+
+
+
+Finally, just a little clean up after ourselves.
+
+  $ rm foo.mli


### PR DESCRIPTION
This PR proposes a fix for #288

It adds two new tokens to the lexer:
- a `Documentation` token with starting and ending position and the contents
- an `Empty_documentation` token with the ending position

Both are printed as documentation attributes when they appears between an Ocaml declaration and a gospel specification (the case where the documentation comments is considered as detached by the OCaml parser)

Tests are added to check that the documentation is not considered as detached anymore and to make sure that original position is preserved.
