### PR TITLE
A ppx to display gospel contents as documentation with odoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam install . --deps-only
+          opam install . --deps-only --with-test
 
       - name: Show configuration
         run: |

--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -1,2 +1,3 @@
 src/Opprintast.ml
 test/issues/*.mli
+test/ppx/*expected*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Introduce a generic `pp_gen` pretty-printer for error messages, so that
   external tools can pretty-print errors in the same style
   [\#326](https://github.com/ocaml-gospel/gospel/pull/326)
+- Add ppx rewriter to display gospel contents as documentation with odoc
+  [\#288](https://github.com/ocaml-gospel/gospel/pull/288)
 - Add specific error message for patterns with guard on every clause.
   [\#220](https://github.com/ocaml-gospel/gospel/pull/220)
 - Added `when` guards in pattern-matching

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ $ gospel check max_array.mli
 OK
 ```
 
+Gospel also provides a ppx rewriter to allow odoc to display the contents of
+gospel specifications and declarations as documentation. This ppx rewriter
+works under the assumption that the source preprocessor has been run first. The
+dune stanza reads as follows:
+
+```dune
+(library
+ (name lib_name)
+ (preprocess
+  (pps gospel.ppx -- -pp "gospel pps")))
+```
+
+Be aware that it is the user's responsability to run the gospel type-checker when needed.
+
 ### Tools using Gospel
 
 > You are using Gospel as a frontend? [Let us

--- a/gospel.opam
+++ b/gospel.opam
@@ -43,4 +43,5 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "ppx_deriving" {>= "5.2.1"}
   "pp_loc" {>= "2.1.0"}
+  "odoc" {with-test}
 ]

--- a/src/ppx_odoc_of_gospel/dune
+++ b/src/ppx_odoc_of_gospel/dune
@@ -1,0 +1,5 @@
+(library
+ (name ppx_odoc_of_gospel)
+ (public_name gospel.ppx)
+ (kind ppx_rewriter)
+ (libraries ppxlib fmt))

--- a/src/ppx_odoc_of_gospel/ppx_odoc_of_gospel.ml
+++ b/src/ppx_odoc_of_gospel/ppx_odoc_of_gospel.ml
@@ -1,0 +1,103 @@
+open Ppxlib
+
+let is_gospel attr = attr.attr_name.txt = "gospel"
+
+(* Prefix a string with whitespace the length of gospel special comment marker *)
+let align = "   "
+let eol_and_align = "\n   "
+
+let gospel_txt_of_attributes attr =
+  let rec aux attr =
+    if is_gospel attr then
+      match attr.attr_payload with
+      | PStr
+          [
+            {
+              pstr_desc =
+                Pstr_eval
+                  ( {
+                      pexp_desc = Pexp_constant (Pconst_string (txt, loc, _));
+                      _;
+                    },
+                    attrs );
+              _;
+            };
+          ] ->
+          { txt; loc } :: (List.map aux attrs |> List.flatten)
+      | _ -> []
+    else []
+  in
+  let rec last_loc_end = function
+    | [] -> failwith "unreachable case in last_loc_end"
+    | [ x ] -> x.loc.loc_end
+    | _ :: xs -> last_loc_end xs
+  in
+  match aux attr with
+  | [] -> None
+  | x :: _ as xs ->
+      let txt =
+        align
+        ^ String.concat eol_and_align ((List.map (fun { txt; _ } -> txt)) xs)
+      and loc_end = last_loc_end xs in
+      Some { txt; loc = { x.loc with loc_end } }
+
+let wrap_gospel header txt =
+  let header =
+    match header with
+    | `Declaration -> "Gospel declaration:\n"
+    | `Specification -> "Gospel specification:\n"
+  in
+  Fmt.str "{@gospel[\n%s%s]}" header txt
+
+let payload_of_string ~loc txt =
+  let open Ast_helper in
+  let content = Const.string ~loc txt in
+  let expression = Pexp_constant content |> Exp.mk ~loc in
+  let structure_item = Str.eval ~loc expression in
+  PStr [ structure_item ]
+
+let attr_label = function
+  | `Declaration -> "ocaml.text"
+  | `Specification -> "ocaml.doc"
+
+let doc_of_gospel header attr =
+  if is_gospel attr then
+    let attr_name = { txt = attr_label header; loc = attr.attr_loc }
+    and info = gospel_txt_of_attributes attr in
+    Option.map
+      (fun info ->
+        let txt = wrap_gospel header info.txt in
+        let attr_payload = payload_of_string ~loc:info.loc txt
+        and attr_loc = attr.attr_loc in
+        { attr_name; attr_payload; attr_loc })
+      info
+  else None
+
+let doc_of_gospel_declaration = doc_of_gospel `Declaration
+let doc_of_gospel_specification = doc_of_gospel `Specification
+
+(* Attributes with a gospel tag in a signature are gospel declarations,
+   that is gospel functions, predicates and axioms *)
+let rec signature = function
+  | [] -> []
+  | ({ psig_desc = Psig_attribute a; psig_loc = loc } as x) :: xs -> (
+      match doc_of_gospel_declaration a with
+      | Some a ->
+          x :: { psig_desc = Psig_attribute a; psig_loc = loc } :: signature xs
+      | None -> x :: signature xs)
+  | x :: xs -> x :: signature xs
+
+(* Attributes with a gospel tag in the [attributes] node of the ast are
+   attached to an OCaml declaration (a value or a type). That means they are
+   specifications. *)
+let attributes attrs = attrs @ List.filter_map doc_of_gospel_specification attrs
+
+let merge =
+  object
+    inherit Ast_traverse.map as super
+    method! signature s = super#signature s |> signature
+    method! attributes attrs = super#attributes attrs |> attributes
+  end
+
+let preprocess_intf = merge#signature
+let () = Driver.register_transformation ~preprocess_intf "odoc_of_gospel"

--- a/src/ppx_odoc_of_gospel/ppx_odoc_of_gospel.mli
+++ b/src/ppx_odoc_of_gospel/ppx_odoc_of_gospel.mli
@@ -1,0 +1,1 @@
+(* Left empty on purpose. *)

--- a/test/ppx/dune
+++ b/test/ppx/dune
@@ -1,0 +1,21 @@
+(cram
+ (deps %{bin:gospel} %{bin:odoc} pp.exe odoc_of_gospel.mli))
+
+(executable
+ (name pp)
+ (modules pp)
+ (libraries gospel.ppx ppxlib))
+
+(rule
+ (targets odoc_of_gospel.actual.mli)
+ (deps
+  (:pp pp.exe)
+  (:input odoc_of_gospel.mli)
+  (:gospel %{bin:gospel}))
+ (action
+  (run %{pp} --intf %{input} -pp "%{gospel} pps" -o %{targets})))
+
+(rule
+ (alias runtest)
+ (action
+  (diff odoc_of_gospel.expected.mli odoc_of_gospel.actual.mli)))

--- a/test/ppx/odoc_of_gospel.expected.mli
+++ b/test/ppx/odoc_of_gospel.expected.mli
@@ -1,0 +1,44 @@
+[@@@ocaml.text " Module informal documentation "]
+[@@@ocaml.text " An axiom declaration "]
+[@@@gospel {| axiom a : true |}]
+[@@@ocaml.text "{@gospel[\nGospel declaration:\n    axiom a : true ]}"]
+[@@@ocaml.text " A logical function declaration without definition "]
+[@@@gospel {| function f : integer -> integer |}]
+[@@@ocaml.text
+  "{@gospel[\nGospel declaration:\n    function f : integer -> integer ]}"]
+[@@@ocaml.text " A logical function definition "]
+[@@@gospel {| function g (i : integer) : integer = i + 1 |}]
+[@@@ocaml.text
+  "{@gospel[\nGospel declaration:\n    function g (i : integer) : integer = i + 1 ]}"]
+[@@@ocaml.text " A logical function declaration with assertions "]
+[@@@gospel
+  {| function h (i : integer) : integer = i - 1 |}[@@gospel
+                                                    {| requires i > 0
+    ensures result >= 0 |}]
+  [@@ocaml.doc
+    "{@gospel[\nGospel specification:\n    requires i > 0\n    ensures result >= 0 ]}"]]
+[@@@ocaml.text
+  "{@gospel[\nGospel declaration:\n    function h (i : integer) : integer = i - 1 \n    requires i > 0\n    ensures result >= 0 ]}"]
+[@@@ocaml.text " A logical predicate definition "]
+[@@@gospel {| predicate p (i : integer) = i = 42 |}]
+[@@@ocaml.text
+  "{@gospel[\nGospel declaration:\n    predicate p (i : integer) = i = 42 ]}"]
+[@@@ocaml.text " A ghost type declaration "]
+[@@@gospel {| type casper |}]
+[@@@ocaml.text "{@gospel[\nGospel declaration:\n    type casper ]}"]
+type 'a t[@@ocaml.doc {| A program type declaration with specifications |}]
+[@@gospel {| model m : 'a sequence
+    invariant true |}][@@ocaml.doc
+                                                           "{@gospel[\nGospel specification:\n    model m : 'a sequence\n    invariant true ]}"]
+val prog_fun : int -> int[@@ocaml.doc
+                           {| A program function with specifications |}]
+[@@gospel {| y = prog_fun x
+    requires true
+    ensures true |}][@@ocaml.doc
+                                                                    "{@gospel[\nGospel specification:\n    y = prog_fun x\n    requires true\n    ensures true ]}"]
+val multiple_gospel_attribute : int -> int[@@gospel
+                                            {| y = multiple_gospel_attribute x |}]
+[@@gospel {| requires true |}][@@gospel {| ensures true |}][@@ocaml.doc
+                                                             "{@gospel[\nGospel specification:\n    y = multiple_gospel_attribute x ]}"]
+[@@ocaml.doc "{@gospel[\nGospel specification:\n    requires true ]}"]
+[@@ocaml.doc "{@gospel[\nGospel specification:\n    ensures true ]}"]

--- a/test/ppx/odoc_of_gospel.mli
+++ b/test/ppx/odoc_of_gospel.mli
@@ -1,0 +1,43 @@
+(** Module informal documentation *)
+
+(** An axiom declaration *)
+
+(*@ axiom a : true *)
+
+(** A logical function declaration without definition *)
+
+(*@ function f : integer -> integer *)
+
+(** A logical function definition *)
+
+(*@ function g (i : integer) : integer = i + 1 *)
+
+(** A logical function declaration with assertions *)
+
+(*@ function h (i : integer) : integer = i - 1 *)
+(*@ requires i > 0
+    ensures result >= 0 *)
+
+(** A logical predicate definition *)
+
+(*@ predicate p (i : integer) = i = 42 *)
+
+(** A ghost type declaration *)
+
+(*@ type casper *)
+
+type 'a t
+(** A program type declaration with specifications *)
+(*@ model m : 'a sequence
+    invariant true *)
+
+val prog_fun : int -> int
+(** A program function with specifications *)
+(*@ y = prog_fun x
+    requires true
+    ensures true *)
+
+val multiple_gospel_attribute : int -> int
+(*@ y = multiple_gospel_attribute x *)
+(*@ requires true *)
+(*@ ensures true *)

--- a/test/ppx/odoc_output.t
+++ b/test/ppx/odoc_output.t
@@ -1,0 +1,101 @@
+In this file, we are testing output from Odoc after the ppx rewriting.
+
+First, we compile the file, running the source preprocessor and the ppx:
+
+  $ ocamlc -bin-annot -pp "gospel pps" -ppx "./pp.exe -as-ppx" odoc_of_gospel.mli
+
+Then run Odoc
+
+  $ odoc compile odoc_of_gospel.cmti
+
+We test the html and the latex outputs
+
+  $ odoc html-generate odoc_of_gospel.odoc -o tmp
+  $ odoc latex-generate odoc_of_gospel.odoc -o tmp
+
+As the output is not stable through odoc versions, we just check that the files
+are generated:
+
+  $ find tmp
+  tmp
+  tmp/Odoc_of_gospel.tex
+  tmp/Odoc_of_gospel
+  tmp/Odoc_of_gospel/index.html
+
+This is not the case for the man output, here we can test the output.
+Though, to be sure the diff is meaningful, let's set terminal's number of
+columns:
+
+  $ export COLUMNS=80
+  $ odoc man-generate odoc_of_gospel.odoc -o tmp
+  $ man tmp/Odoc_of_gospel.3o
+  
+  Odoc_of_gospel(3)                OCaml Library               Odoc_of_gospel(3)
+  
+  Name
+         Odoc_of_gospel
+  
+  Synopsis
+    Module Odoc_of_gospel
+  
+         Module informal documentation
+  
+  Documentation
+         An axiom declaration
+  
+         Gospel declaration:
+             axiom a : true
+  
+         A logical function declaration without definition
+  
+         Gospel declaration:
+             function f : integer -> integer
+  
+         A logical function definition
+  
+         Gospel declaration:
+             function g (i : integer) : integer = i + 1
+  
+         A logical function declaration with assertions
+  
+         Gospel declaration:
+             function h (i : integer) : integer = i - 1
+             requires i > 0
+             ensures result >= 0
+  
+         A logical predicate definition
+  
+         Gospel declaration:
+             predicate p (i : integer) = i = 42
+  
+         A ghost type declaration
+  
+         Gospel declaration:
+             type casper
+  
+         type 'a t
+           A program type declaration with specifications
+  
+           Gospel specification:
+             model m : 'a sequence
+             invariant true
+  
+         val prog_fun : int -> int
+           A program function with specifications
+  
+           Gospel specification:
+             y = prog_fun x
+             requires true
+             ensures true
+  
+         val multiple_gospel_attribute : int -> int
+           Gospel specification:
+             y = multiple_gospel_attribute x
+  
+           Gospel specification:
+             requires true
+  
+           Gospel specification:
+             ensures true
+  
+  Odoc                                                         Odoc_of_gospel(3)

--- a/test/ppx/pp.ml
+++ b/test/ppx/pp.ml
@@ -1,0 +1,1 @@
+let () = Ppxlib.Driver.standalone ()


### PR DESCRIPTION
This PR proposes to add a ppx rewriter to build documentation attributes from
the contents of the gospel ones.

The documentation attributes are added, they don't replace the gospel ones.

Also, as we are post-parsing there is no problem of having more than two
documentations attributes. That means that if a signature item has already two
documentations attributes from the parsing, building one with the gospel
contents does not raise any problem (especially, odoc will treat all of them)

This PR proposes to name the ppx `gospel.ppx` so the dune file would look like that:

```dune
(library
  (name library_name)
  (preprocess
  (pps  gospel.ppx -- -pp "gospel pps")))
```