### PR TITLE
Improve generated `dune.inc` files

### DIFF
--- a/test/coercions/negative/dune.inc
+++ b/test/coercions/negative/dune.inc
@@ -1,55 +1,60 @@
 (rule
- (target bad_type_id.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:bad_type_id.mli}))))
+  (with-outputs-to bad_type_id.mli.output
+   (run %{checker} %{dep:bad_type_id.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:bad_type_id.mli} %{dep:bad_type_id.mli.output})))
+ (action
+  (diff bad_type_id.mli bad_type_id.mli.output)))
 
 (rule
- (target bad_type_multiple_args.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:bad_type_multiple_args.mli}))))
+  (with-outputs-to bad_type_multiple_args.mli.output
+   (run %{checker} %{dep:bad_type_multiple_args.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:bad_type_multiple_args.mli} %{dep:bad_type_multiple_args.mli.output})))
+ (action
+  (diff bad_type_multiple_args.mli bad_type_multiple_args.mli.output)))
 
 (rule
- (target complex_cycle.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:complex_cycle.mli}))))
+  (with-outputs-to complex_cycle.mli.output
+   (run %{checker} %{dep:complex_cycle.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:complex_cycle.mli} %{dep:complex_cycle.mli.output})))
+ (action
+  (diff complex_cycle.mli complex_cycle.mli.output)))
 
 (rule
- (target double_definition.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:double_definition.mli}))))
+  (with-outputs-to double_definition.mli.output
+   (run %{checker} %{dep:double_definition.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:double_definition.mli} %{dep:double_definition.mli.output})))
+ (action
+  (diff double_definition.mli double_definition.mli.output)))
 
 (rule
- (target simple_cycle.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:simple_cycle.mli}))))
+  (with-outputs-to simple_cycle.mli.output
+   (run %{checker} %{dep:simple_cycle.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:simple_cycle.mli} %{dep:simple_cycle.mli.output})))
+ (action
+  (diff simple_cycle.mli simple_cycle.mli.output)))
 

--- a/test/coercions/negative/dune.inc
+++ b/test/coercions/negative/dune.inc
@@ -11,6 +11,13 @@
   (diff bad_type_id.mli bad_type_id.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:bad_type_id.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -21,6 +28,13 @@
  (alias runtest)
  (action
   (diff bad_type_multiple_args.mli bad_type_multiple_args.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:bad_type_multiple_args.mli}))))
 
 (rule
  (deps
@@ -35,6 +49,13 @@
   (diff complex_cycle.mli complex_cycle.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:complex_cycle.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -47,6 +68,13 @@
   (diff double_definition.mli double_definition.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:double_definition.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -57,4 +85,11 @@
  (alias runtest)
  (action
   (diff simple_cycle.mli simple_cycle.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:simple_cycle.mli}))))
 

--- a/test/coercions/positive/dune.inc
+++ b/test/coercions/positive/dune.inc
@@ -1,11 +1,12 @@
 (rule
- (target basic.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:basic.mli}))))
+  (with-outputs-to basic.mli.output
+   (run %{checker} %{dep:basic.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:basic.mli} %{dep:basic.mli.output})))
+ (action
+  (diff basic.mli basic.mli.output)))
 

--- a/test/coercions/positive/dune.inc
+++ b/test/coercions/positive/dune.inc
@@ -10,3 +10,10 @@
  (action
   (diff basic.mli basic.mli.output)))
 
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:basic.mli}))))
+

--- a/test/gen/gen.ml
+++ b/test/gen/gen.ml
@@ -1,19 +1,43 @@
+(* Generates the dune configuration for the current directory of tests
+
+   Takes dependencies as arguments, to be read as a sequence of pairs,
+   such that:
+     gen.exe a.mli b.mli c.mli "d.mli e.mli"
+   will generate the configuration with a.mli depending on b.mli and
+   c.mli depending on both d.mli and e.mli. *)
+
+let dependencies =
+  let n = Array.length Sys.argv in
+  assert (n mod 2 = 1);
+  let n = n / 2 in
+  let tbl = Hashtbl.create n in
+  for i = 1 to n do
+    Hashtbl.add tbl Sys.argv.((i * 2) - 1) Sys.argv.(i * 2)
+  done;
+  tbl
+
 let print_rule file =
   if Filename.extension file = ".mli" then
+    let deps =
+      match Hashtbl.find_all dependencies file with
+      | [] -> ""
+      | ds -> "\n  " ^ String.concat "\n  " ds
+    in
     Printf.printf
       {|(rule
- (target %s.output)
- (deps (source_tree .))
+ (deps
+  (:checker %%{project_root}/test/gospel_check.exe)%s)
  (action
-   (with-outputs-to %%{target}
-      (run %%{project_root}/test/gospel_check.exe %%{dep:%s}))))
+  (with-outputs-to %s.output
+   (run %%{checker} %%{dep:%s}))))
 
 (rule
  (alias runtest)
- (action (diff %%{dep:%s} %%{dep:%s.output})))
+ (action
+  (diff %s %s.output)))
 
 |}
-      file file file file
+      deps file file file file
 
 let () =
   let files = Filename.current_dir_name |> Sys.readdir in

--- a/test/int_literals/negative/dune.inc
+++ b/test/int_literals/negative/dune.inc
@@ -11,6 +11,13 @@
   (diff bad_constr_arg.mli bad_constr_arg.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:bad_constr_arg.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -21,4 +28,11 @@
  (alias runtest)
  (action
   (diff invalid_literal.mli invalid_literal.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:invalid_literal.mli}))))
 

--- a/test/int_literals/negative/dune.inc
+++ b/test/int_literals/negative/dune.inc
@@ -1,22 +1,24 @@
 (rule
- (target bad_constr_arg.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:bad_constr_arg.mli}))))
+  (with-outputs-to bad_constr_arg.mli.output
+   (run %{checker} %{dep:bad_constr_arg.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:bad_constr_arg.mli} %{dep:bad_constr_arg.mli.output})))
+ (action
+  (diff bad_constr_arg.mli bad_constr_arg.mli.output)))
 
 (rule
- (target invalid_literal.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:invalid_literal.mli}))))
+  (with-outputs-to invalid_literal.mli.output
+   (run %{checker} %{dep:invalid_literal.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:invalid_literal.mli} %{dep:invalid_literal.mli.output})))
+ (action
+  (diff invalid_literal.mli invalid_literal.mli.output)))
 

--- a/test/int_literals/positive/dune.inc
+++ b/test/int_literals/positive/dune.inc
@@ -1,11 +1,12 @@
 (rule
- (target ints.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:ints.mli}))))
+  (with-outputs-to ints.mli.output
+   (run %{checker} %{dep:ints.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:ints.mli} %{dep:ints.mli.output})))
+ (action
+  (diff ints.mli ints.mli.output)))
 

--- a/test/int_literals/positive/dune.inc
+++ b/test/int_literals/positive/dune.inc
@@ -10,3 +10,10 @@
  (action
   (diff ints.mli ints.mli.output)))
 
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:ints.mli}))))
+

--- a/test/negative/dune
+++ b/test/negative/dune
@@ -7,7 +7,7 @@
  (action
   (with-stdout-to
    %{targets}
-   (run ../gen/gen.exe))))
+   (run ../gen/gen.exe t10.mli t9.mli))))
 
 (rule
  (alias runtest)

--- a/test/negative/dune
+++ b/test/negative/dune
@@ -7,7 +7,17 @@
  (action
   (with-stdout-to
    %{targets}
-   (run ../gen/gen.exe t10.mli t9.mli))))
+   (run
+    ../gen/gen.exe
+    t10.mli
+    t9.mli
+    --
+    t39.mli
+    2
+    type_arity2.mli
+    2
+    type_arity3.mli
+    2))))
 
 (rule
  (alias runtest)

--- a/test/negative/dune.inc
+++ b/test/negative/dune.inc
@@ -11,6 +11,13 @@
   (diff char1.mli char1.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:char1.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -21,6 +28,13 @@
  (alias runtest)
  (action
   (diff constants1.mli constants1.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:constants1.mli}))))
 
 (rule
  (deps
@@ -35,6 +49,13 @@
   (diff constructor_arity1.mli constructor_arity1.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:constructor_arity1.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -45,6 +66,13 @@
  (alias runtest)
  (action
   (diff constructor_arity2.mli constructor_arity2.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:constructor_arity2.mli}))))
 
 (rule
  (deps
@@ -59,6 +87,13 @@
   (diff constructor_arity3.mli constructor_arity3.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:constructor_arity3.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -69,6 +104,13 @@
  (alias runtest)
  (action
   (diff constructor_arity4.mli constructor_arity4.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:constructor_arity4.mli}))))
 
 (rule
  (deps
@@ -83,6 +125,13 @@
   (diff duplicate_declaration.mli duplicate_declaration.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:duplicate_declaration.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -93,6 +142,13 @@
  (alias runtest)
  (action
   (diff empty_match.mli empty_match.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:empty_match.mli}))))
 
 (rule
  (deps
@@ -107,6 +163,13 @@
   (diff exception_no_pattern.mli exception_no_pattern.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:exception_no_pattern.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -117,6 +180,13 @@
  (alias runtest)
  (action
   (diff exn_arity.mli exn_arity.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:exn_arity.mli}))))
 
 (rule
  (deps
@@ -131,6 +201,13 @@
   (diff field_application.mli field_application.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:field_application.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -141,6 +218,13 @@
  (alias runtest)
  (action
   (diff invariant1.mli invariant1.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:invariant1.mli}))))
 
 (rule
  (deps
@@ -155,6 +239,13 @@
   (diff invariant2.mli invariant2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:invariant2.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -165,6 +256,13 @@
  (alias runtest)
  (action
   (diff invariant3.mli invariant3.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:invariant3.mli}))))
 
 (rule
  (deps
@@ -179,6 +277,13 @@
   (diff invariant4.mli invariant4.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:invariant4.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -191,6 +296,13 @@
   (diff invariant5.mli invariant5.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:invariant5.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -201,6 +313,13 @@
  (alias runtest)
  (action
   (diff t1.mli t1.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t1.mli}))))
 
 (rule
  (deps
@@ -216,6 +335,13 @@
   (diff t10.mli t10.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t10.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -226,6 +352,13 @@
  (alias runtest)
  (action
   (diff t11.mli t11.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t11.mli}))))
 
 (rule
  (deps
@@ -240,6 +373,13 @@
   (diff t12.mli t12.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t12.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -250,6 +390,13 @@
  (alias runtest)
  (action
   (diff t13.mli t13.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t13.mli}))))
 
 (rule
  (deps
@@ -264,6 +411,13 @@
   (diff t14.mli t14.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t14.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -274,6 +428,13 @@
  (alias runtest)
  (action
   (diff t15.mli t15.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t15.mli}))))
 
 (rule
  (deps
@@ -288,6 +449,13 @@
   (diff t16.mli t16.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t16.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -298,6 +466,13 @@
  (alias runtest)
  (action
   (diff t17.mli t17.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t17.mli}))))
 
 (rule
  (deps
@@ -312,6 +487,13 @@
   (diff t18.mli t18.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t18.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -322,6 +504,13 @@
  (alias runtest)
  (action
   (diff t19.mli t19.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t19.mli}))))
 
 (rule
  (deps
@@ -336,6 +525,13 @@
   (diff t2.mli t2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t2.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -346,6 +542,13 @@
  (alias runtest)
  (action
   (diff t20.mli t20.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t20.mli}))))
 
 (rule
  (deps
@@ -360,6 +563,13 @@
   (diff t21.mli t21.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t21.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -370,6 +580,13 @@
  (alias runtest)
  (action
   (diff t22.mli t22.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t22.mli}))))
 
 (rule
  (deps
@@ -384,6 +601,13 @@
   (diff t23.mli t23.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t23.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -394,6 +618,13 @@
  (alias runtest)
  (action
   (diff t24.mli t24.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t24.mli}))))
 
 (rule
  (deps
@@ -408,6 +639,13 @@
   (diff t25.mli t25.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t25.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -418,6 +656,13 @@
  (alias runtest)
  (action
   (diff t26.mli t26.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t26.mli}))))
 
 (rule
  (deps
@@ -432,6 +677,13 @@
   (diff t27.mli t27.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t27.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -442,6 +694,13 @@
  (alias runtest)
  (action
   (diff t28.mli t28.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t28.mli}))))
 
 (rule
  (deps
@@ -456,6 +715,13 @@
   (diff t29.mli t29.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t29.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -466,6 +732,13 @@
  (alias runtest)
  (action
   (diff t3.mli t3.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t3.mli}))))
 
 (rule
  (deps
@@ -480,6 +753,13 @@
   (diff t30.mli t30.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t30.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -490,6 +770,13 @@
  (alias runtest)
  (action
   (diff t31.mli t31.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t31.mli}))))
 
 (rule
  (deps
@@ -504,6 +791,13 @@
   (diff t32.mli t32.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t32.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -514,6 +808,13 @@
  (alias runtest)
  (action
   (diff t33.mli t33.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t33.mli}))))
 
 (rule
  (deps
@@ -528,6 +829,13 @@
   (diff t34.mli t34.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t34.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -538,6 +846,13 @@
  (alias runtest)
  (action
   (diff t35.mli t35.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t35.mli}))))
 
 (rule
  (deps
@@ -552,6 +867,13 @@
   (diff t36.mli t36.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t36.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -562,6 +884,13 @@
  (alias runtest)
  (action
   (diff t37.mli t37.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t37.mli}))))
 
 (rule
  (deps
@@ -576,6 +905,13 @@
   (diff t38.mli t38.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t38.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -586,6 +922,14 @@
  (alias runtest)
  (action
   (diff t39.mli t39.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (with-accepted-exit-codes 2
+    (run ocamlc -c %{dep:t39.mli})))))
 
 (rule
  (deps
@@ -600,6 +944,13 @@
   (diff t4.mli t4.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t4.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -610,6 +961,13 @@
  (alias runtest)
  (action
   (diff t5.mli t5.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t5.mli}))))
 
 (rule
  (deps
@@ -624,6 +982,13 @@
   (diff t6.mli t6.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t6.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -634,6 +999,13 @@
  (alias runtest)
  (action
   (diff t7.mli t7.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t7.mli}))))
 
 (rule
  (deps
@@ -648,6 +1020,13 @@
   (diff t8.mli t8.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t8.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -658,6 +1037,13 @@
  (alias runtest)
  (action
   (diff t9.mli t9.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:t9.mli}))))
 
 (rule
  (deps
@@ -672,6 +1058,13 @@
   (diff type_arity1.mli type_arity1.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:type_arity1.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -684,6 +1077,14 @@
   (diff type_arity2.mli type_arity2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (with-accepted-exit-codes 2
+    (run ocamlc -c %{dep:type_arity2.mli})))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -694,4 +1095,12 @@
  (alias runtest)
  (action
   (diff type_arity3.mli type_arity3.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (with-accepted-exit-codes 2
+    (run ocamlc -c %{dep:type_arity3.mli})))))
 

--- a/test/negative/dune.inc
+++ b/test/negative/dune.inc
@@ -1,638 +1,697 @@
 (rule
- (target char1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:char1.mli}))))
+  (with-outputs-to char1.mli.output
+   (run %{checker} %{dep:char1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:char1.mli} %{dep:char1.mli.output})))
+ (action
+  (diff char1.mli char1.mli.output)))
 
 (rule
- (target constants1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:constants1.mli}))))
+  (with-outputs-to constants1.mli.output
+   (run %{checker} %{dep:constants1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:constants1.mli} %{dep:constants1.mli.output})))
+ (action
+  (diff constants1.mli constants1.mli.output)))
 
 (rule
- (target constructor_arity1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:constructor_arity1.mli}))))
+  (with-outputs-to constructor_arity1.mli.output
+   (run %{checker} %{dep:constructor_arity1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:constructor_arity1.mli} %{dep:constructor_arity1.mli.output})))
+ (action
+  (diff constructor_arity1.mli constructor_arity1.mli.output)))
 
 (rule
- (target constructor_arity2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:constructor_arity2.mli}))))
+  (with-outputs-to constructor_arity2.mli.output
+   (run %{checker} %{dep:constructor_arity2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:constructor_arity2.mli} %{dep:constructor_arity2.mli.output})))
+ (action
+  (diff constructor_arity2.mli constructor_arity2.mli.output)))
 
 (rule
- (target constructor_arity3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:constructor_arity3.mli}))))
+  (with-outputs-to constructor_arity3.mli.output
+   (run %{checker} %{dep:constructor_arity3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:constructor_arity3.mli} %{dep:constructor_arity3.mli.output})))
+ (action
+  (diff constructor_arity3.mli constructor_arity3.mli.output)))
 
 (rule
- (target constructor_arity4.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:constructor_arity4.mli}))))
+  (with-outputs-to constructor_arity4.mli.output
+   (run %{checker} %{dep:constructor_arity4.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:constructor_arity4.mli} %{dep:constructor_arity4.mli.output})))
+ (action
+  (diff constructor_arity4.mli constructor_arity4.mli.output)))
 
 (rule
- (target duplicate_declaration.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:duplicate_declaration.mli}))))
+  (with-outputs-to duplicate_declaration.mli.output
+   (run %{checker} %{dep:duplicate_declaration.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:duplicate_declaration.mli} %{dep:duplicate_declaration.mli.output})))
+ (action
+  (diff duplicate_declaration.mli duplicate_declaration.mli.output)))
 
 (rule
- (target empty_match.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:empty_match.mli}))))
+  (with-outputs-to empty_match.mli.output
+   (run %{checker} %{dep:empty_match.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:empty_match.mli} %{dep:empty_match.mli.output})))
+ (action
+  (diff empty_match.mli empty_match.mli.output)))
 
 (rule
- (target exception_no_pattern.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:exception_no_pattern.mli}))))
+  (with-outputs-to exception_no_pattern.mli.output
+   (run %{checker} %{dep:exception_no_pattern.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:exception_no_pattern.mli} %{dep:exception_no_pattern.mli.output})))
+ (action
+  (diff exception_no_pattern.mli exception_no_pattern.mli.output)))
 
 (rule
- (target exn_arity.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:exn_arity.mli}))))
+  (with-outputs-to exn_arity.mli.output
+   (run %{checker} %{dep:exn_arity.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:exn_arity.mli} %{dep:exn_arity.mli.output})))
+ (action
+  (diff exn_arity.mli exn_arity.mli.output)))
 
 (rule
- (target field_application.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:field_application.mli}))))
+  (with-outputs-to field_application.mli.output
+   (run %{checker} %{dep:field_application.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:field_application.mli} %{dep:field_application.mli.output})))
+ (action
+  (diff field_application.mli field_application.mli.output)))
 
 (rule
- (target invariant1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:invariant1.mli}))))
+  (with-outputs-to invariant1.mli.output
+   (run %{checker} %{dep:invariant1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:invariant1.mli} %{dep:invariant1.mli.output})))
+ (action
+  (diff invariant1.mli invariant1.mli.output)))
 
 (rule
- (target invariant2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:invariant2.mli}))))
+  (with-outputs-to invariant2.mli.output
+   (run %{checker} %{dep:invariant2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:invariant2.mli} %{dep:invariant2.mli.output})))
+ (action
+  (diff invariant2.mli invariant2.mli.output)))
 
 (rule
- (target invariant3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:invariant3.mli}))))
+  (with-outputs-to invariant3.mli.output
+   (run %{checker} %{dep:invariant3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:invariant3.mli} %{dep:invariant3.mli.output})))
+ (action
+  (diff invariant3.mli invariant3.mli.output)))
 
 (rule
- (target invariant4.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:invariant4.mli}))))
+  (with-outputs-to invariant4.mli.output
+   (run %{checker} %{dep:invariant4.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:invariant4.mli} %{dep:invariant4.mli.output})))
+ (action
+  (diff invariant4.mli invariant4.mli.output)))
 
 (rule
- (target invariant5.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:invariant5.mli}))))
+  (with-outputs-to invariant5.mli.output
+   (run %{checker} %{dep:invariant5.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:invariant5.mli} %{dep:invariant5.mli.output})))
+ (action
+  (diff invariant5.mli invariant5.mli.output)))
 
 (rule
- (target t1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t1.mli}))))
+  (with-outputs-to t1.mli.output
+   (run %{checker} %{dep:t1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t1.mli} %{dep:t1.mli.output})))
+ (action
+  (diff t1.mli t1.mli.output)))
 
 (rule
- (target t10.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe)
+  t9.mli)
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t10.mli}))))
+  (with-outputs-to t10.mli.output
+   (run %{checker} %{dep:t10.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t10.mli} %{dep:t10.mli.output})))
+ (action
+  (diff t10.mli t10.mli.output)))
 
 (rule
- (target t11.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t11.mli}))))
+  (with-outputs-to t11.mli.output
+   (run %{checker} %{dep:t11.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t11.mli} %{dep:t11.mli.output})))
+ (action
+  (diff t11.mli t11.mli.output)))
 
 (rule
- (target t12.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t12.mli}))))
+  (with-outputs-to t12.mli.output
+   (run %{checker} %{dep:t12.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t12.mli} %{dep:t12.mli.output})))
+ (action
+  (diff t12.mli t12.mli.output)))
 
 (rule
- (target t13.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t13.mli}))))
+  (with-outputs-to t13.mli.output
+   (run %{checker} %{dep:t13.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t13.mli} %{dep:t13.mli.output})))
+ (action
+  (diff t13.mli t13.mli.output)))
 
 (rule
- (target t14.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t14.mli}))))
+  (with-outputs-to t14.mli.output
+   (run %{checker} %{dep:t14.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t14.mli} %{dep:t14.mli.output})))
+ (action
+  (diff t14.mli t14.mli.output)))
 
 (rule
- (target t15.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t15.mli}))))
+  (with-outputs-to t15.mli.output
+   (run %{checker} %{dep:t15.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t15.mli} %{dep:t15.mli.output})))
+ (action
+  (diff t15.mli t15.mli.output)))
 
 (rule
- (target t16.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t16.mli}))))
+  (with-outputs-to t16.mli.output
+   (run %{checker} %{dep:t16.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t16.mli} %{dep:t16.mli.output})))
+ (action
+  (diff t16.mli t16.mli.output)))
 
 (rule
- (target t17.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t17.mli}))))
+  (with-outputs-to t17.mli.output
+   (run %{checker} %{dep:t17.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t17.mli} %{dep:t17.mli.output})))
+ (action
+  (diff t17.mli t17.mli.output)))
 
 (rule
- (target t18.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t18.mli}))))
+  (with-outputs-to t18.mli.output
+   (run %{checker} %{dep:t18.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t18.mli} %{dep:t18.mli.output})))
+ (action
+  (diff t18.mli t18.mli.output)))
 
 (rule
- (target t19.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t19.mli}))))
+  (with-outputs-to t19.mli.output
+   (run %{checker} %{dep:t19.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t19.mli} %{dep:t19.mli.output})))
+ (action
+  (diff t19.mli t19.mli.output)))
 
 (rule
- (target t2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t2.mli}))))
+  (with-outputs-to t2.mli.output
+   (run %{checker} %{dep:t2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t2.mli} %{dep:t2.mli.output})))
+ (action
+  (diff t2.mli t2.mli.output)))
 
 (rule
- (target t20.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t20.mli}))))
+  (with-outputs-to t20.mli.output
+   (run %{checker} %{dep:t20.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t20.mli} %{dep:t20.mli.output})))
+ (action
+  (diff t20.mli t20.mli.output)))
 
 (rule
- (target t21.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t21.mli}))))
+  (with-outputs-to t21.mli.output
+   (run %{checker} %{dep:t21.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t21.mli} %{dep:t21.mli.output})))
+ (action
+  (diff t21.mli t21.mli.output)))
 
 (rule
- (target t22.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t22.mli}))))
+  (with-outputs-to t22.mli.output
+   (run %{checker} %{dep:t22.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t22.mli} %{dep:t22.mli.output})))
+ (action
+  (diff t22.mli t22.mli.output)))
 
 (rule
- (target t23.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t23.mli}))))
+  (with-outputs-to t23.mli.output
+   (run %{checker} %{dep:t23.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t23.mli} %{dep:t23.mli.output})))
+ (action
+  (diff t23.mli t23.mli.output)))
 
 (rule
- (target t24.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t24.mli}))))
+  (with-outputs-to t24.mli.output
+   (run %{checker} %{dep:t24.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t24.mli} %{dep:t24.mli.output})))
+ (action
+  (diff t24.mli t24.mli.output)))
 
 (rule
- (target t25.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t25.mli}))))
+  (with-outputs-to t25.mli.output
+   (run %{checker} %{dep:t25.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t25.mli} %{dep:t25.mli.output})))
+ (action
+  (diff t25.mli t25.mli.output)))
 
 (rule
- (target t26.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t26.mli}))))
+  (with-outputs-to t26.mli.output
+   (run %{checker} %{dep:t26.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t26.mli} %{dep:t26.mli.output})))
+ (action
+  (diff t26.mli t26.mli.output)))
 
 (rule
- (target t27.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t27.mli}))))
+  (with-outputs-to t27.mli.output
+   (run %{checker} %{dep:t27.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t27.mli} %{dep:t27.mli.output})))
+ (action
+  (diff t27.mli t27.mli.output)))
 
 (rule
- (target t28.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t28.mli}))))
+  (with-outputs-to t28.mli.output
+   (run %{checker} %{dep:t28.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t28.mli} %{dep:t28.mli.output})))
+ (action
+  (diff t28.mli t28.mli.output)))
 
 (rule
- (target t29.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t29.mli}))))
+  (with-outputs-to t29.mli.output
+   (run %{checker} %{dep:t29.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t29.mli} %{dep:t29.mli.output})))
+ (action
+  (diff t29.mli t29.mli.output)))
 
 (rule
- (target t3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t3.mli}))))
+  (with-outputs-to t3.mli.output
+   (run %{checker} %{dep:t3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t3.mli} %{dep:t3.mli.output})))
+ (action
+  (diff t3.mli t3.mli.output)))
 
 (rule
- (target t30.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t30.mli}))))
+  (with-outputs-to t30.mli.output
+   (run %{checker} %{dep:t30.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t30.mli} %{dep:t30.mli.output})))
+ (action
+  (diff t30.mli t30.mli.output)))
 
 (rule
- (target t31.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t31.mli}))))
+  (with-outputs-to t31.mli.output
+   (run %{checker} %{dep:t31.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t31.mli} %{dep:t31.mli.output})))
+ (action
+  (diff t31.mli t31.mli.output)))
 
 (rule
- (target t32.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t32.mli}))))
+  (with-outputs-to t32.mli.output
+   (run %{checker} %{dep:t32.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t32.mli} %{dep:t32.mli.output})))
+ (action
+  (diff t32.mli t32.mli.output)))
 
 (rule
- (target t33.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t33.mli}))))
+  (with-outputs-to t33.mli.output
+   (run %{checker} %{dep:t33.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t33.mli} %{dep:t33.mli.output})))
+ (action
+  (diff t33.mli t33.mli.output)))
 
 (rule
- (target t34.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t34.mli}))))
+  (with-outputs-to t34.mli.output
+   (run %{checker} %{dep:t34.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t34.mli} %{dep:t34.mli.output})))
+ (action
+  (diff t34.mli t34.mli.output)))
 
 (rule
- (target t35.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t35.mli}))))
+  (with-outputs-to t35.mli.output
+   (run %{checker} %{dep:t35.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t35.mli} %{dep:t35.mli.output})))
+ (action
+  (diff t35.mli t35.mli.output)))
 
 (rule
- (target t36.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t36.mli}))))
+  (with-outputs-to t36.mli.output
+   (run %{checker} %{dep:t36.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t36.mli} %{dep:t36.mli.output})))
+ (action
+  (diff t36.mli t36.mli.output)))
 
 (rule
- (target t37.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t37.mli}))))
+  (with-outputs-to t37.mli.output
+   (run %{checker} %{dep:t37.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t37.mli} %{dep:t37.mli.output})))
+ (action
+  (diff t37.mli t37.mli.output)))
 
 (rule
- (target t38.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t38.mli}))))
+  (with-outputs-to t38.mli.output
+   (run %{checker} %{dep:t38.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t38.mli} %{dep:t38.mli.output})))
+ (action
+  (diff t38.mli t38.mli.output)))
 
 (rule
- (target t39.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t39.mli}))))
+  (with-outputs-to t39.mli.output
+   (run %{checker} %{dep:t39.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t39.mli} %{dep:t39.mli.output})))
+ (action
+  (diff t39.mli t39.mli.output)))
 
 (rule
- (target t4.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t4.mli}))))
+  (with-outputs-to t4.mli.output
+   (run %{checker} %{dep:t4.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t4.mli} %{dep:t4.mli.output})))
+ (action
+  (diff t4.mli t4.mli.output)))
 
 (rule
- (target t5.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t5.mli}))))
+  (with-outputs-to t5.mli.output
+   (run %{checker} %{dep:t5.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t5.mli} %{dep:t5.mli.output})))
+ (action
+  (diff t5.mli t5.mli.output)))
 
 (rule
- (target t6.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t6.mli}))))
+  (with-outputs-to t6.mli.output
+   (run %{checker} %{dep:t6.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t6.mli} %{dep:t6.mli.output})))
+ (action
+  (diff t6.mli t6.mli.output)))
 
 (rule
- (target t7.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t7.mli}))))
+  (with-outputs-to t7.mli.output
+   (run %{checker} %{dep:t7.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t7.mli} %{dep:t7.mli.output})))
+ (action
+  (diff t7.mli t7.mli.output)))
 
 (rule
- (target t8.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t8.mli}))))
+  (with-outputs-to t8.mli.output
+   (run %{checker} %{dep:t8.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t8.mli} %{dep:t8.mli.output})))
+ (action
+  (diff t8.mli t8.mli.output)))
 
 (rule
- (target t9.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:t9.mli}))))
+  (with-outputs-to t9.mli.output
+   (run %{checker} %{dep:t9.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:t9.mli} %{dep:t9.mli.output})))
+ (action
+  (diff t9.mli t9.mli.output)))
 
 (rule
- (target type_arity1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:type_arity1.mli}))))
+  (with-outputs-to type_arity1.mli.output
+   (run %{checker} %{dep:type_arity1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:type_arity1.mli} %{dep:type_arity1.mli.output})))
+ (action
+  (diff type_arity1.mli type_arity1.mli.output)))
 
 (rule
- (target type_arity2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:type_arity2.mli}))))
+  (with-outputs-to type_arity2.mli.output
+   (run %{checker} %{dep:type_arity2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:type_arity2.mli} %{dep:type_arity2.mli.output})))
+ (action
+  (diff type_arity2.mli type_arity2.mli.output)))
 
 (rule
- (target type_arity3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:type_arity3.mli}))))
+  (with-outputs-to type_arity3.mli.output
+   (run %{checker} %{dep:type_arity3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:type_arity3.mli} %{dep:type_arity3.mli.output})))
+ (action
+  (diff type_arity3.mli type_arity3.mli.output)))
 

--- a/test/patterns/negative/dune.inc
+++ b/test/patterns/negative/dune.inc
@@ -11,6 +11,13 @@
   (diff ambiguous.mli ambiguous.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:ambiguous.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -21,6 +28,13 @@
  (alias runtest)
  (action
   (diff base.mli base.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:base.mli}))))
 
 (rule
  (deps
@@ -35,6 +49,13 @@
   (diff booleans.mli booleans.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:booleans.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -45,6 +66,13 @@
  (alias runtest)
  (action
   (diff char2.mli char2.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:char2.mli}))))
 
 (rule
  (deps
@@ -59,6 +87,13 @@
   (diff etuple.mli etuple.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:etuple.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -69,6 +104,13 @@
  (alias runtest)
  (action
   (diff float.mli float.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:float.mli}))))
 
 (rule
  (deps
@@ -83,6 +125,13 @@
   (diff guard1.mli guard1.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:guard1.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -93,6 +142,13 @@
  (alias runtest)
  (action
   (diff guard2.mli guard2.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:guard2.mli}))))
 
 (rule
  (deps
@@ -107,6 +163,13 @@
   (diff guard3.mli guard3.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:guard3.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -117,6 +180,13 @@
  (alias runtest)
  (action
   (diff guard4.mli guard4.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:guard4.mli}))))
 
 (rule
  (deps
@@ -131,6 +201,13 @@
   (diff guard5.mli guard5.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:guard5.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -141,6 +218,13 @@
  (alias runtest)
  (action
   (diff int.mli int.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:int.mli}))))
 
 (rule
  (deps
@@ -155,6 +239,13 @@
   (diff int2.mli int2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:int2.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -165,6 +256,13 @@
  (alias runtest)
  (action
   (diff int3.mli int3.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:int3.mli}))))
 
 (rule
  (deps
@@ -179,6 +277,13 @@
   (diff interval.mli interval.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:interval.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -189,6 +294,13 @@
  (alias runtest)
  (action
   (diff list1.mli list1.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:list1.mli}))))
 
 (rule
  (deps
@@ -203,6 +315,13 @@
   (diff list2.mli list2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:list2.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -213,6 +332,13 @@
  (alias runtest)
  (action
   (diff neg2.mli neg2.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:neg2.mli}))))
 
 (rule
  (deps
@@ -227,6 +353,13 @@
   (diff neg3.mli neg3.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:neg3.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -237,6 +370,13 @@
  (alias runtest)
  (action
   (diff pair.mli pair.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:pair.mli}))))
 
 (rule
  (deps
@@ -251,6 +391,13 @@
   (diff record.mli record.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:record.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -261,6 +408,13 @@
  (alias runtest)
  (action
   (diff redundant1.mli redundant1.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:redundant1.mli}))))
 
 (rule
  (deps
@@ -275,6 +429,13 @@
   (diff redundant2.mli redundant2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:redundant2.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -285,6 +446,13 @@
  (alias runtest)
  (action
   (diff redundant3.mli redundant3.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:redundant3.mli}))))
 
 (rule
  (deps
@@ -299,6 +467,13 @@
   (diff str.mli str.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:str.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -311,6 +486,13 @@
   (diff tuple.mli tuple.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:tuple.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -321,4 +503,11 @@
  (alias runtest)
  (action
   (diff tuple2.mli tuple2.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:tuple2.mli}))))
 

--- a/test/patterns/negative/dune.inc
+++ b/test/patterns/negative/dune.inc
@@ -1,297 +1,324 @@
 (rule
- (target ambiguous.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:ambiguous.mli}))))
+  (with-outputs-to ambiguous.mli.output
+   (run %{checker} %{dep:ambiguous.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:ambiguous.mli} %{dep:ambiguous.mli.output})))
+ (action
+  (diff ambiguous.mli ambiguous.mli.output)))
 
 (rule
- (target base.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:base.mli}))))
+  (with-outputs-to base.mli.output
+   (run %{checker} %{dep:base.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:base.mli} %{dep:base.mli.output})))
+ (action
+  (diff base.mli base.mli.output)))
 
 (rule
- (target booleans.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:booleans.mli}))))
+  (with-outputs-to booleans.mli.output
+   (run %{checker} %{dep:booleans.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:booleans.mli} %{dep:booleans.mli.output})))
+ (action
+  (diff booleans.mli booleans.mli.output)))
 
 (rule
- (target char2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:char2.mli}))))
+  (with-outputs-to char2.mli.output
+   (run %{checker} %{dep:char2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:char2.mli} %{dep:char2.mli.output})))
+ (action
+  (diff char2.mli char2.mli.output)))
 
 (rule
- (target etuple.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:etuple.mli}))))
+  (with-outputs-to etuple.mli.output
+   (run %{checker} %{dep:etuple.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:etuple.mli} %{dep:etuple.mli.output})))
+ (action
+  (diff etuple.mli etuple.mli.output)))
 
 (rule
- (target float.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:float.mli}))))
+  (with-outputs-to float.mli.output
+   (run %{checker} %{dep:float.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:float.mli} %{dep:float.mli.output})))
+ (action
+  (diff float.mli float.mli.output)))
 
 (rule
- (target guard1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:guard1.mli}))))
+  (with-outputs-to guard1.mli.output
+   (run %{checker} %{dep:guard1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:guard1.mli} %{dep:guard1.mli.output})))
+ (action
+  (diff guard1.mli guard1.mli.output)))
 
 (rule
- (target guard2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:guard2.mli}))))
+  (with-outputs-to guard2.mli.output
+   (run %{checker} %{dep:guard2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:guard2.mli} %{dep:guard2.mli.output})))
+ (action
+  (diff guard2.mli guard2.mli.output)))
 
 (rule
- (target guard3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:guard3.mli}))))
+  (with-outputs-to guard3.mli.output
+   (run %{checker} %{dep:guard3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:guard3.mli} %{dep:guard3.mli.output})))
+ (action
+  (diff guard3.mli guard3.mli.output)))
 
 (rule
- (target guard4.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:guard4.mli}))))
+  (with-outputs-to guard4.mli.output
+   (run %{checker} %{dep:guard4.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:guard4.mli} %{dep:guard4.mli.output})))
+ (action
+  (diff guard4.mli guard4.mli.output)))
 
 (rule
- (target guard5.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:guard5.mli}))))
+  (with-outputs-to guard5.mli.output
+   (run %{checker} %{dep:guard5.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:guard5.mli} %{dep:guard5.mli.output})))
+ (action
+  (diff guard5.mli guard5.mli.output)))
 
 (rule
- (target int.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:int.mli}))))
+  (with-outputs-to int.mli.output
+   (run %{checker} %{dep:int.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:int.mli} %{dep:int.mli.output})))
+ (action
+  (diff int.mli int.mli.output)))
 
 (rule
- (target int2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:int2.mli}))))
+  (with-outputs-to int2.mli.output
+   (run %{checker} %{dep:int2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:int2.mli} %{dep:int2.mli.output})))
+ (action
+  (diff int2.mli int2.mli.output)))
 
 (rule
- (target int3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:int3.mli}))))
+  (with-outputs-to int3.mli.output
+   (run %{checker} %{dep:int3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:int3.mli} %{dep:int3.mli.output})))
+ (action
+  (diff int3.mli int3.mli.output)))
 
 (rule
- (target interval.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:interval.mli}))))
+  (with-outputs-to interval.mli.output
+   (run %{checker} %{dep:interval.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:interval.mli} %{dep:interval.mli.output})))
+ (action
+  (diff interval.mli interval.mli.output)))
 
 (rule
- (target list1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:list1.mli}))))
+  (with-outputs-to list1.mli.output
+   (run %{checker} %{dep:list1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:list1.mli} %{dep:list1.mli.output})))
+ (action
+  (diff list1.mli list1.mli.output)))
 
 (rule
- (target list2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:list2.mli}))))
+  (with-outputs-to list2.mli.output
+   (run %{checker} %{dep:list2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:list2.mli} %{dep:list2.mli.output})))
+ (action
+  (diff list2.mli list2.mli.output)))
 
 (rule
- (target neg2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:neg2.mli}))))
+  (with-outputs-to neg2.mli.output
+   (run %{checker} %{dep:neg2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:neg2.mli} %{dep:neg2.mli.output})))
+ (action
+  (diff neg2.mli neg2.mli.output)))
 
 (rule
- (target neg3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:neg3.mli}))))
+  (with-outputs-to neg3.mli.output
+   (run %{checker} %{dep:neg3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:neg3.mli} %{dep:neg3.mli.output})))
+ (action
+  (diff neg3.mli neg3.mli.output)))
 
 (rule
- (target pair.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:pair.mli}))))
+  (with-outputs-to pair.mli.output
+   (run %{checker} %{dep:pair.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:pair.mli} %{dep:pair.mli.output})))
+ (action
+  (diff pair.mli pair.mli.output)))
 
 (rule
- (target record.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:record.mli}))))
+  (with-outputs-to record.mli.output
+   (run %{checker} %{dep:record.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:record.mli} %{dep:record.mli.output})))
+ (action
+  (diff record.mli record.mli.output)))
 
 (rule
- (target redundant1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:redundant1.mli}))))
+  (with-outputs-to redundant1.mli.output
+   (run %{checker} %{dep:redundant1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:redundant1.mli} %{dep:redundant1.mli.output})))
+ (action
+  (diff redundant1.mli redundant1.mli.output)))
 
 (rule
- (target redundant2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:redundant2.mli}))))
+  (with-outputs-to redundant2.mli.output
+   (run %{checker} %{dep:redundant2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:redundant2.mli} %{dep:redundant2.mli.output})))
+ (action
+  (diff redundant2.mli redundant2.mli.output)))
 
 (rule
- (target redundant3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:redundant3.mli}))))
+  (with-outputs-to redundant3.mli.output
+   (run %{checker} %{dep:redundant3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:redundant3.mli} %{dep:redundant3.mli.output})))
+ (action
+  (diff redundant3.mli redundant3.mli.output)))
 
 (rule
- (target str.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:str.mli}))))
+  (with-outputs-to str.mli.output
+   (run %{checker} %{dep:str.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:str.mli} %{dep:str.mli.output})))
+ (action
+  (diff str.mli str.mli.output)))
 
 (rule
- (target tuple.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:tuple.mli}))))
+  (with-outputs-to tuple.mli.output
+   (run %{checker} %{dep:tuple.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:tuple.mli} %{dep:tuple.mli.output})))
+ (action
+  (diff tuple.mli tuple.mli.output)))
 
 (rule
- (target tuple2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:tuple2.mli}))))
+  (with-outputs-to tuple2.mli.output
+   (run %{checker} %{dep:tuple2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:tuple2.mli} %{dep:tuple2.mli.output})))
+ (action
+  (diff tuple2.mli tuple2.mli.output)))
 

--- a/test/patterns/positive/dune.inc
+++ b/test/patterns/positive/dune.inc
@@ -1,11 +1,12 @@
 (rule
- (target positive-patterns.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:positive-patterns.mli}))))
+  (with-outputs-to positive-patterns.mli.output
+   (run %{checker} %{dep:positive-patterns.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:positive-patterns.mli} %{dep:positive-patterns.mli.output})))
+ (action
+  (diff positive-patterns.mli positive-patterns.mli.output)))
 

--- a/test/patterns/positive/dune.inc
+++ b/test/patterns/positive/dune.inc
@@ -10,3 +10,10 @@
  (action
   (diff positive-patterns.mli positive-patterns.mli.output)))
 
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:positive-patterns.mli}))))
+

--- a/test/positive/dune
+++ b/test/positive/dune
@@ -7,7 +7,18 @@
  (action
   (with-stdout-to
    %{targets}
-   (run ../gen/gen.exe))))
+   (run
+    ../gen/gen.exe
+    a2.mli
+    a1.mli
+    a3.mli
+    "a1.mli a2.mli"
+    b.mli
+    a.mli
+    c.mli
+    "a.mli b.mli"
+    test1.mli
+    test.mli))))
 
 (rule
  (alias runtest)

--- a/test/positive/dune
+++ b/test/positive/dune
@@ -18,7 +18,14 @@
     c.mli
     "a.mli b.mli"
     test1.mli
-    test.mli))))
+    test.mli
+    --
+    a2.mli
+    2
+    b.mli
+    2
+    c.mli
+    2))))
 
 (rule
  (alias runtest)

--- a/test/positive/dune.inc
+++ b/test/positive/dune.inc
@@ -1,374 +1,413 @@
 (rule
- (target FM19.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:FM19.mli}))))
+  (with-outputs-to FM19.mli.output
+   (run %{checker} %{dep:FM19.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:FM19.mli} %{dep:FM19.mli.output})))
+ (action
+  (diff FM19.mli FM19.mli.output)))
 
 (rule
- (target a.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:a.mli}))))
+  (with-outputs-to a.mli.output
+   (run %{checker} %{dep:a.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:a.mli} %{dep:a.mli.output})))
+ (action
+  (diff a.mli a.mli.output)))
 
 (rule
- (target a1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:a1.mli}))))
+  (with-outputs-to a1.mli.output
+   (run %{checker} %{dep:a1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:a1.mli} %{dep:a1.mli.output})))
+ (action
+  (diff a1.mli a1.mli.output)))
 
 (rule
- (target a2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe)
+  a1.mli)
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:a2.mli}))))
+  (with-outputs-to a2.mli.output
+   (run %{checker} %{dep:a2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:a2.mli} %{dep:a2.mli.output})))
+ (action
+  (diff a2.mli a2.mli.output)))
 
 (rule
- (target a3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe)
+  a1.mli a2.mli)
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:a3.mli}))))
+  (with-outputs-to a3.mli.output
+   (run %{checker} %{dep:a3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:a3.mli} %{dep:a3.mli.output})))
+ (action
+  (diff a3.mli a3.mli.output)))
 
 (rule
- (target abstract_functions.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:abstract_functions.mli}))))
+  (with-outputs-to abstract_functions.mli.output
+   (run %{checker} %{dep:abstract_functions.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:abstract_functions.mli} %{dep:abstract_functions.mli.output})))
+ (action
+  (diff abstract_functions.mli abstract_functions.mli.output)))
 
 (rule
- (target b.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe)
+  a.mli)
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:b.mli}))))
+  (with-outputs-to b.mli.output
+   (run %{checker} %{dep:b.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:b.mli} %{dep:b.mli.output})))
+ (action
+  (diff b.mli b.mli.output)))
 
 (rule
- (target basic_functions_axioms.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:basic_functions_axioms.mli}))))
+  (with-outputs-to basic_functions_axioms.mli.output
+   (run %{checker} %{dep:basic_functions_axioms.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:basic_functions_axioms.mli} %{dep:basic_functions_axioms.mli.output})))
+ (action
+  (diff basic_functions_axioms.mli basic_functions_axioms.mli.output)))
 
 (rule
- (target bitvector.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:bitvector.mli}))))
+  (with-outputs-to bitvector.mli.output
+   (run %{checker} %{dep:bitvector.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:bitvector.mli} %{dep:bitvector.mli.output})))
+ (action
+  (diff bitvector.mli bitvector.mli.output)))
 
 (rule
- (target c.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe)
+  a.mli b.mli)
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:c.mli}))))
+  (with-outputs-to c.mli.output
+   (run %{checker} %{dep:c.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:c.mli} %{dep:c.mli.output})))
+ (action
+  (diff c.mli c.mli.output)))
 
 (rule
- (target complex_vals.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:complex_vals.mli}))))
+  (with-outputs-to complex_vals.mli.output
+   (run %{checker} %{dep:complex_vals.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:complex_vals.mli} %{dep:complex_vals.mli.output})))
+ (action
+  (diff complex_vals.mli complex_vals.mli.output)))
 
 (rule
- (target constants.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:constants.mli}))))
+  (with-outputs-to constants.mli.output
+   (run %{checker} %{dep:constants.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:constants.mli} %{dep:constants.mli.output})))
+ (action
+  (diff constants.mli constants.mli.output)))
 
 (rule
- (target exceptions.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:exceptions.mli}))))
+  (with-outputs-to exceptions.mli.output
+   (run %{checker} %{dep:exceptions.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:exceptions.mli} %{dep:exceptions.mli.output})))
+ (action
+  (diff exceptions.mli exceptions.mli.output)))
 
 (rule
- (target fib.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:fib.mli}))))
+  (with-outputs-to fib.mli.output
+   (run %{checker} %{dep:fib.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:fib.mli} %{dep:fib.mli.output})))
+ (action
+  (diff fib.mli fib.mli.output)))
 
 (rule
- (target infix.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:infix.mli}))))
+  (with-outputs-to infix.mli.output
+   (run %{checker} %{dep:infix.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:infix.mli} %{dep:infix.mli.output})))
+ (action
+  (diff infix.mli infix.mli.output)))
 
 (rule
- (target invariants.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:invariants.mli}))))
+  (with-outputs-to invariants.mli.output
+   (run %{checker} %{dep:invariants.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:invariants.mli} %{dep:invariants.mli.output})))
+ (action
+  (diff invariants.mli invariants.mli.output)))
 
 (rule
- (target literals.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:literals.mli}))))
+  (with-outputs-to literals.mli.output
+   (run %{checker} %{dep:literals.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:literals.mli} %{dep:literals.mli.output})))
+ (action
+  (diff literals.mli literals.mli.output)))
 
 (rule
- (target log2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:log2.mli}))))
+  (with-outputs-to log2.mli.output
+   (run %{checker} %{dep:log2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:log2.mli} %{dep:log2.mli.output})))
+ (action
+  (diff log2.mli log2.mli.output)))
 
 (rule
- (target logical.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:logical.mli}))))
+  (with-outputs-to logical.mli.output
+   (run %{checker} %{dep:logical.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:logical.mli} %{dep:logical.mli.output})))
+ (action
+  (diff logical.mli logical.mli.output)))
 
 (rule
- (target modules.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:modules.mli}))))
+  (with-outputs-to modules.mli.output
+   (run %{checker} %{dep:modules.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:modules.mli} %{dep:modules.mli.output})))
+ (action
+  (diff modules.mli modules.mli.output)))
 
 (rule
- (target more_types.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:more_types.mli}))))
+  (with-outputs-to more_types.mli.output
+   (run %{checker} %{dep:more_types.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:more_types.mli} %{dep:more_types.mli.output})))
+ (action
+  (diff more_types.mli more_types.mli.output)))
 
 (rule
- (target no_header.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:no_header.mli}))))
+  (with-outputs-to no_header.mli.output
+   (run %{checker} %{dep:no_header.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:no_header.mli} %{dep:no_header.mli.output})))
+ (action
+  (diff no_header.mli no_header.mli.output)))
 
 (rule
- (target open_existing_type.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:open_existing_type.mli}))))
+  (with-outputs-to open_existing_type.mli.output
+   (run %{checker} %{dep:open_existing_type.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:open_existing_type.mli} %{dep:open_existing_type.mli.output})))
+ (action
+  (diff open_existing_type.mli open_existing_type.mli.output)))
 
 (rule
- (target pattern_matching.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:pattern_matching.mli}))))
+  (with-outputs-to pattern_matching.mli.output
+   (run %{checker} %{dep:pattern_matching.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:pattern_matching.mli} %{dep:pattern_matching.mli.output})))
+ (action
+  (diff pattern_matching.mli pattern_matching.mli.output)))
 
 (rule
- (target record_functions.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:record_functions.mli}))))
+  (with-outputs-to record_functions.mli.output
+   (run %{checker} %{dep:record_functions.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:record_functions.mli} %{dep:record_functions.mli.output})))
+ (action
+  (diff record_functions.mli record_functions.mli.output)))
 
 (rule
- (target recursive_type_invariant.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:recursive_type_invariant.mli}))))
+  (with-outputs-to recursive_type_invariant.mli.output
+   (run %{checker} %{dep:recursive_type_invariant.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:recursive_type_invariant.mli} %{dep:recursive_type_invariant.mli.output})))
+ (action
+  (diff recursive_type_invariant.mli recursive_type_invariant.mli.output)))
 
 (rule
- (target stdlib_exceptions.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:stdlib_exceptions.mli}))))
+  (with-outputs-to stdlib_exceptions.mli.output
+   (run %{checker} %{dep:stdlib_exceptions.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:stdlib_exceptions.mli} %{dep:stdlib_exceptions.mli.output})))
+ (action
+  (diff stdlib_exceptions.mli stdlib_exceptions.mli.output)))
 
 (rule
- (target test.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:test.mli}))))
+  (with-outputs-to test.mli.output
+   (run %{checker} %{dep:test.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:test.mli} %{dep:test.mli.output})))
+ (action
+  (diff test.mli test.mli.output)))
 
 (rule
- (target test1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe)
+  test.mli)
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:test1.mli}))))
+  (with-outputs-to test1.mli.output
+   (run %{checker} %{dep:test1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:test1.mli} %{dep:test1.mli.output})))
+ (action
+  (diff test1.mli test1.mli.output)))
 
 (rule
- (target test2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:test2.mli}))))
+  (with-outputs-to test2.mli.output
+   (run %{checker} %{dep:test2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:test2.mli} %{dep:test2.mli.output})))
+ (action
+  (diff test2.mli test2.mli.output)))
 
 (rule
- (target tuple_result.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:tuple_result.mli}))))
+  (with-outputs-to tuple_result.mli.output
+   (run %{checker} %{dep:tuple_result.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:tuple_result.mli} %{dep:tuple_result.mli.output})))
+ (action
+  (diff tuple_result.mli tuple_result.mli.output)))
 
 (rule
- (target type_decl.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:type_decl.mli}))))
+  (with-outputs-to type_decl.mli.output
+   (run %{checker} %{dep:type_decl.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:type_decl.mli} %{dep:type_decl.mli.output})))
+ (action
+  (diff type_decl.mli type_decl.mli.output)))
 
 (rule
- (target vals.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:vals.mli}))))
+  (with-outputs-to vals.mli.output
+   (run %{checker} %{dep:vals.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:vals.mli} %{dep:vals.mli.output})))
+ (action
+  (diff vals.mli vals.mli.output)))
 
 (rule
- (target variant_patterns.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:variant_patterns.mli}))))
+  (with-outputs-to variant_patterns.mli.output
+   (run %{checker} %{dep:variant_patterns.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:variant_patterns.mli} %{dep:variant_patterns.mli.output})))
+ (action
+  (diff variant_patterns.mli variant_patterns.mli.output)))
 

--- a/test/positive/dune.inc
+++ b/test/positive/dune.inc
@@ -11,6 +11,13 @@
   (diff FM19.mli FM19.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:FM19.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -23,6 +30,13 @@
   (diff a.mli a.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:a.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -33,6 +47,13 @@
  (alias runtest)
  (action
   (diff a1.mli a1.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:a1.mli}))))
 
 (rule
  (deps
@@ -48,6 +69,14 @@
   (diff a2.mli a2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (with-accepted-exit-codes 2
+    (run ocamlc -c %{dep:a2.mli})))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe)
   a1.mli a2.mli)
@@ -61,6 +90,13 @@
   (diff a3.mli a3.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:a3.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -71,6 +107,13 @@
  (alias runtest)
  (action
   (diff abstract_functions.mli abstract_functions.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:abstract_functions.mli}))))
 
 (rule
  (deps
@@ -86,6 +129,14 @@
   (diff b.mli b.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (with-accepted-exit-codes 2
+    (run ocamlc -c %{dep:b.mli})))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -98,6 +149,13 @@
   (diff basic_functions_axioms.mli basic_functions_axioms.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:basic_functions_axioms.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -108,6 +166,13 @@
  (alias runtest)
  (action
   (diff bitvector.mli bitvector.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:bitvector.mli}))))
 
 (rule
  (deps
@@ -123,6 +188,14 @@
   (diff c.mli c.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (with-accepted-exit-codes 2
+    (run ocamlc -c %{dep:c.mli})))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -133,6 +206,13 @@
  (alias runtest)
  (action
   (diff complex_vals.mli complex_vals.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:complex_vals.mli}))))
 
 (rule
  (deps
@@ -147,6 +227,13 @@
   (diff constants.mli constants.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:constants.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -157,6 +244,13 @@
  (alias runtest)
  (action
   (diff exceptions.mli exceptions.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:exceptions.mli}))))
 
 (rule
  (deps
@@ -171,6 +265,13 @@
   (diff fib.mli fib.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:fib.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -181,6 +282,13 @@
  (alias runtest)
  (action
   (diff infix.mli infix.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:infix.mli}))))
 
 (rule
  (deps
@@ -195,6 +303,13 @@
   (diff invariants.mli invariants.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:invariants.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -205,6 +320,13 @@
  (alias runtest)
  (action
   (diff literals.mli literals.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:literals.mli}))))
 
 (rule
  (deps
@@ -219,6 +341,13 @@
   (diff log2.mli log2.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:log2.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -229,6 +358,13 @@
  (alias runtest)
  (action
   (diff logical.mli logical.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:logical.mli}))))
 
 (rule
  (deps
@@ -243,6 +379,13 @@
   (diff modules.mli modules.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:modules.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -253,6 +396,13 @@
  (alias runtest)
  (action
   (diff more_types.mli more_types.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:more_types.mli}))))
 
 (rule
  (deps
@@ -267,6 +417,13 @@
   (diff no_header.mli no_header.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:no_header.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -277,6 +434,13 @@
  (alias runtest)
  (action
   (diff open_existing_type.mli open_existing_type.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:open_existing_type.mli}))))
 
 (rule
  (deps
@@ -291,6 +455,13 @@
   (diff pattern_matching.mli pattern_matching.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:pattern_matching.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -301,6 +472,13 @@
  (alias runtest)
  (action
   (diff record_functions.mli record_functions.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:record_functions.mli}))))
 
 (rule
  (deps
@@ -315,6 +493,13 @@
   (diff recursive_type_invariant.mli recursive_type_invariant.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:recursive_type_invariant.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -327,6 +512,13 @@
   (diff stdlib_exceptions.mli stdlib_exceptions.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:stdlib_exceptions.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -337,6 +529,13 @@
  (alias runtest)
  (action
   (diff test.mli test.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:test.mli}))))
 
 (rule
  (deps
@@ -352,6 +551,13 @@
   (diff test1.mli test1.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:test1.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -362,6 +568,13 @@
  (alias runtest)
  (action
   (diff test2.mli test2.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:test2.mli}))))
 
 (rule
  (deps
@@ -376,6 +589,13 @@
   (diff tuple_result.mli tuple_result.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:tuple_result.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -386,6 +606,13 @@
  (alias runtest)
  (action
   (diff type_decl.mli type_decl.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:type_decl.mli}))))
 
 (rule
  (deps
@@ -400,6 +627,13 @@
   (diff vals.mli vals.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:vals.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -410,4 +644,11 @@
  (alias runtest)
  (action
   (diff variant_patterns.mli variant_patterns.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:variant_patterns.mli}))))
 

--- a/test/pure/negative/dune.inc
+++ b/test/pure/negative/dune.inc
@@ -1,55 +1,60 @@
 (rule
- (target impure1.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:impure1.mli}))))
+  (with-outputs-to impure1.mli.output
+   (run %{checker} %{dep:impure1.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:impure1.mli} %{dep:impure1.mli.output})))
+ (action
+  (diff impure1.mli impure1.mli.output)))
 
 (rule
- (target impure2.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:impure2.mli}))))
+  (with-outputs-to impure2.mli.output
+   (run %{checker} %{dep:impure2.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:impure2.mli} %{dep:impure2.mli.output})))
+ (action
+  (diff impure2.mli impure2.mli.output)))
 
 (rule
- (target impure3.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:impure3.mli}))))
+  (with-outputs-to impure3.mli.output
+   (run %{checker} %{dep:impure3.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:impure3.mli} %{dep:impure3.mli.output})))
+ (action
+  (diff impure3.mli impure3.mli.output)))
 
 (rule
- (target impure4.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:impure4.mli}))))
+  (with-outputs-to impure4.mli.output
+   (run %{checker} %{dep:impure4.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:impure4.mli} %{dep:impure4.mli.output})))
+ (action
+  (diff impure4.mli impure4.mli.output)))
 
 (rule
- (target not_pure.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:not_pure.mli}))))
+  (with-outputs-to not_pure.mli.output
+   (run %{checker} %{dep:not_pure.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:not_pure.mli} %{dep:not_pure.mli.output})))
+ (action
+  (diff not_pure.mli not_pure.mli.output)))
 

--- a/test/pure/negative/dune.inc
+++ b/test/pure/negative/dune.inc
@@ -11,6 +11,13 @@
   (diff impure1.mli impure1.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:impure1.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -21,6 +28,13 @@
  (alias runtest)
  (action
   (diff impure2.mli impure2.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:impure2.mli}))))
 
 (rule
  (deps
@@ -35,6 +49,13 @@
   (diff impure3.mli impure3.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:impure3.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -47,6 +68,13 @@
   (diff impure4.mli impure4.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:impure4.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -57,4 +85,11 @@
  (alias runtest)
  (action
   (diff not_pure.mli not_pure.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:not_pure.mli}))))
 

--- a/test/pure/positive/dune.inc
+++ b/test/pure/positive/dune.inc
@@ -10,3 +10,10 @@
  (action
   (diff pure.mli pure.mli.output)))
 
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:pure.mli}))))
+

--- a/test/pure/positive/dune.inc
+++ b/test/pure/positive/dune.inc
@@ -1,11 +1,12 @@
 (rule
- (target pure.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:pure.mli}))))
+  (with-outputs-to pure.mli.output
+   (run %{checker} %{dep:pure.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:pure.mli} %{dep:pure.mli.output})))
+ (action
+  (diff pure.mli pure.mli.output)))
 

--- a/test/vocal/dune.inc
+++ b/test/vocal/dune.inc
@@ -11,6 +11,13 @@
   (diff Arrays.mli Arrays.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:Arrays.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -21,6 +28,13 @@
  (alias runtest)
  (action
   (diff CountingSort.mli CountingSort.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:CountingSort.mli}))))
 
 (rule
  (deps
@@ -35,6 +49,13 @@
   (diff HashTable.mli HashTable.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:HashTable.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -45,6 +66,13 @@
  (alias runtest)
  (action
   (diff Lists.mli Lists.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:Lists.mli}))))
 
 (rule
  (deps
@@ -59,6 +87,13 @@
   (diff Mjrty.mli Mjrty.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:Mjrty.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -69,6 +104,13 @@
  (alias runtest)
  (action
   (diff PairingHeap.mli PairingHeap.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:PairingHeap.mli}))))
 
 (rule
  (deps
@@ -83,6 +125,13 @@
   (diff PriorityQueue.mli PriorityQueue.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:PriorityQueue.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -93,6 +142,13 @@
  (alias runtest)
  (action
   (diff Queue.mli Queue.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:Queue.mli}))))
 
 (rule
  (deps
@@ -107,6 +163,13 @@
   (diff RingBuffer.mli RingBuffer.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:RingBuffer.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -117,6 +180,13 @@
  (alias runtest)
  (action
   (diff UnionFind.mli UnionFind.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:UnionFind.mli}))))
 
 (rule
  (deps
@@ -131,6 +201,13 @@
   (diff Vector.mli Vector.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:Vector.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -141,4 +218,11 @@
  (alias runtest)
  (action
   (diff ZipperList.mli ZipperList.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:ZipperList.mli}))))
 

--- a/test/vocal/dune.inc
+++ b/test/vocal/dune.inc
@@ -1,132 +1,144 @@
 (rule
- (target Arrays.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:Arrays.mli}))))
+  (with-outputs-to Arrays.mli.output
+   (run %{checker} %{dep:Arrays.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:Arrays.mli} %{dep:Arrays.mli.output})))
+ (action
+  (diff Arrays.mli Arrays.mli.output)))
 
 (rule
- (target CountingSort.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:CountingSort.mli}))))
+  (with-outputs-to CountingSort.mli.output
+   (run %{checker} %{dep:CountingSort.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:CountingSort.mli} %{dep:CountingSort.mli.output})))
+ (action
+  (diff CountingSort.mli CountingSort.mli.output)))
 
 (rule
- (target HashTable.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:HashTable.mli}))))
+  (with-outputs-to HashTable.mli.output
+   (run %{checker} %{dep:HashTable.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:HashTable.mli} %{dep:HashTable.mli.output})))
+ (action
+  (diff HashTable.mli HashTable.mli.output)))
 
 (rule
- (target Lists.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:Lists.mli}))))
+  (with-outputs-to Lists.mli.output
+   (run %{checker} %{dep:Lists.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:Lists.mli} %{dep:Lists.mli.output})))
+ (action
+  (diff Lists.mli Lists.mli.output)))
 
 (rule
- (target Mjrty.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:Mjrty.mli}))))
+  (with-outputs-to Mjrty.mli.output
+   (run %{checker} %{dep:Mjrty.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:Mjrty.mli} %{dep:Mjrty.mli.output})))
+ (action
+  (diff Mjrty.mli Mjrty.mli.output)))
 
 (rule
- (target PairingHeap.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:PairingHeap.mli}))))
+  (with-outputs-to PairingHeap.mli.output
+   (run %{checker} %{dep:PairingHeap.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:PairingHeap.mli} %{dep:PairingHeap.mli.output})))
+ (action
+  (diff PairingHeap.mli PairingHeap.mli.output)))
 
 (rule
- (target PriorityQueue.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:PriorityQueue.mli}))))
+  (with-outputs-to PriorityQueue.mli.output
+   (run %{checker} %{dep:PriorityQueue.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:PriorityQueue.mli} %{dep:PriorityQueue.mli.output})))
+ (action
+  (diff PriorityQueue.mli PriorityQueue.mli.output)))
 
 (rule
- (target Queue.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:Queue.mli}))))
+  (with-outputs-to Queue.mli.output
+   (run %{checker} %{dep:Queue.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:Queue.mli} %{dep:Queue.mli.output})))
+ (action
+  (diff Queue.mli Queue.mli.output)))
 
 (rule
- (target RingBuffer.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:RingBuffer.mli}))))
+  (with-outputs-to RingBuffer.mli.output
+   (run %{checker} %{dep:RingBuffer.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:RingBuffer.mli} %{dep:RingBuffer.mli.output})))
+ (action
+  (diff RingBuffer.mli RingBuffer.mli.output)))
 
 (rule
- (target UnionFind.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:UnionFind.mli}))))
+  (with-outputs-to UnionFind.mli.output
+   (run %{checker} %{dep:UnionFind.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:UnionFind.mli} %{dep:UnionFind.mli.output})))
+ (action
+  (diff UnionFind.mli UnionFind.mli.output)))
 
 (rule
- (target Vector.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:Vector.mli}))))
+  (with-outputs-to Vector.mli.output
+   (run %{checker} %{dep:Vector.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:Vector.mli} %{dep:Vector.mli.output})))
+ (action
+  (diff Vector.mli Vector.mli.output)))
 
 (rule
- (target ZipperList.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:ZipperList.mli}))))
+  (with-outputs-to ZipperList.mli.output
+   (run %{checker} %{dep:ZipperList.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:ZipperList.mli} %{dep:ZipperList.mli.output})))
+ (action
+  (diff ZipperList.mli ZipperList.mli.output)))
 

--- a/test/warnings/dune.inc
+++ b/test/warnings/dune.inc
@@ -1,22 +1,24 @@
 (rule
- (target no_modifies_value_of_unit.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:no_modifies_value_of_unit.mli}))))
+  (with-outputs-to no_modifies_value_of_unit.mli.output
+   (run %{checker} %{dep:no_modifies_value_of_unit.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:no_modifies_value_of_unit.mli} %{dep:no_modifies_value_of_unit.mli.output})))
+ (action
+  (diff no_modifies_value_of_unit.mli no_modifies_value_of_unit.mli.output)))
 
 (rule
- (target no_modifies_while_returning_unit.mli.output)
- (deps (source_tree .))
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
  (action
-   (with-outputs-to %{target}
-      (run %{project_root}/test/gospel_check.exe %{dep:no_modifies_while_returning_unit.mli}))))
+  (with-outputs-to no_modifies_while_returning_unit.mli.output
+   (run %{checker} %{dep:no_modifies_while_returning_unit.mli}))))
 
 (rule
  (alias runtest)
- (action (diff %{dep:no_modifies_while_returning_unit.mli} %{dep:no_modifies_while_returning_unit.mli.output})))
+ (action
+  (diff no_modifies_while_returning_unit.mli no_modifies_while_returning_unit.mli.output)))
 

--- a/test/warnings/dune.inc
+++ b/test/warnings/dune.inc
@@ -11,6 +11,13 @@
   (diff no_modifies_value_of_unit.mli no_modifies_value_of_unit.mli.output)))
 
 (rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:no_modifies_value_of_unit.mli}))))
+
+(rule
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
@@ -21,4 +28,11 @@
  (alias runtest)
  (action
   (diff no_modifies_while_returning_unit.mli no_modifies_while_returning_unit.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:no_modifies_while_returning_unit.mli}))))
 


### PR DESCRIPTION
This PR:

- improves the dependencies declared for the test files: instead of
  using `(source_tree .)`, `gen.exe` now takes as arguments the
  dependencies (rarely used in the current test suite); it also
  explicit adds the gospel checker as a dependency, which should
  ensure all the tests are run again when gospel changes (it seemed to
  be an issue),
- adds a `@test-cmis` alias that will feed all the test `.mli` files
  to `ocamlc`, to ensure they are syntactically correct and, when
  relevant, well typed,
- generates cleaner `dune.inc`, by using a bit more of dune inference.