### PR TITLE
Take recursivity into account when typing type declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,8 @@
 
 ## Fixed
 
+- Take recursivity into account when typing type declarations
+  [\#304](https://github/ocaml-gospel/gospel/pull/304)
 - Support pattern with cast
   [\#301](https://github/ocaml-gospel/gospel/pull/301)
 - Use payload location for specification text

--- a/test/issues/t6.mli
+++ b/test/issues/t6.mli
@@ -1,3 +1,8 @@
+(* Fixing this issue properly would require:
+   - defining a Gospel [include_description] in [Tast] instead of reusing Ppxlib's
+   - adding a [process_include] in [Typing] (adapting [process_open])
+*)
+
 include sig
   type t
 end
@@ -5,8 +10,8 @@ end
 type nonrec t = t
 
 (* {gospel_expected|
-   [125] File "t6.mli", line 5, characters 16-17:
-         5 | type nonrec t = t
-                             ^
-         Error: The type declaration for `t' contains a cycle.
+   [125] File "t6.mli", line 10, characters 16-17:
+         10 | type nonrec t = t
+                              ^
+         Error: Symbol t not found.
    |gospel_expected} *)

--- a/test/positive/dune.inc
+++ b/test/positive/dune.inc
@@ -408,6 +408,25 @@
  (deps
   (:checker %{project_root}/test/gospel_check.exe))
  (action
+  (with-outputs-to module_with.mli.output
+   (run %{checker} %{dep:module_with.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff module_with.mli module_with.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:module_with.mli}))))
+
+(rule
+ (deps
+  (:checker %{project_root}/test/gospel_check.exe))
+ (action
   (with-outputs-to modules.mli.output
    (run %{checker} %{dep:modules.mli}))))
 

--- a/test/positive/module_with.mli
+++ b/test/positive/module_with.mli
@@ -1,0 +1,13 @@
+module type A = sig
+  type t
+end
+
+module type B = sig
+  type t
+
+  module C : A with type t = t
+end
+
+(* {gospel_expected|
+   [0] OK
+   |gospel_expected} *)


### PR DESCRIPTION
Before, type declarations were considered always recursive.
Route the recursivity information to the function typing type declarations and feed it `Nonrecursive` when the function is reused to type module constraints

Add the (now positive) example that was reported in #225.

Add, while we’re at it, what should be done to fix issue t6.

Closes #225