### PR TITLE
Stop lexing at MODULE_ALIASES in stdlib.mli

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,8 @@
 
 ## Fixed
 
+- Handle the special case of `MODULE_ALIASES` in `stdlib.mli` in the parser
+  [\#306](https://github/ocaml-gospel/gospel/pull/306)
 - Take recursivity into account when typing type declarations
   [\#304](https://github/ocaml-gospel/gospel/pull/304)
 - Support pattern with cast

--- a/src/parser_frontend.ml
+++ b/src/parser_frontend.ml
@@ -12,7 +12,6 @@ module W = Warnings
 open Ppxlib
 
 let stdlib = "Stdlib"
-let stdlib_file = "stdlib.mli"
 let gospelstdlib = "Gospelstdlib"
 let gospelstdlib_file = "gospelstdlib.mli"
 
@@ -42,31 +41,10 @@ let parse_ocaml_lb lb =
     let loc = Location.{ loc_start; loc_end; loc_ghost = false } in
     W.error ~loc W.Syntax_error
 
-let string_equal_sub s1 s2 i =
-  let n = String.length s1 in
-  let rec aux j = j = n - 1 || (s1.[j] = s2.[i + j] && aux (succ j)) in
-  aux 0
-
-(** This is bad, but it's not my fault. See
-    https://github.com/ocaml/ocaml/blob/trunk/stdlib/remove_module_aliases.awk *)
-let remove_after_module_aliases s =
-  let magic_string = "(*MODULE_ALIASES*)" in
-  let rec find i =
-    if string_equal_sub magic_string s i then i else find (pred i)
-  in
-  let index = find (String.length s - String.length magic_string) in
-  String.sub s 0 (index - 1)
-
 let parse_ocaml file =
   let lb =
     if String.equal file gospelstdlib_file then
       Lexing.from_string Gospelstdlib.contents
-    else if String.equal (Filename.basename file) stdlib_file then
-      let ic = open_in file in
-      in_channel_length ic
-      |> really_input_string ic
-      |> remove_after_module_aliases
-      |> Lexing.from_string
     else open_in file |> Lexing.from_channel
   in
   Location.init lb file;

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -7,6 +7,8 @@
     | Other of string
     | Spaces of string
 
+  let stdlib_file = "stdlib.mli"
+
   let queue = Queue.create ()
   let buf = Buffer.create 1024
 
@@ -180,6 +182,14 @@ rule scan = parse
     let end_pos = Lexing.lexeme_end_p lexbuf in
     Queue.push (Documentation (start_pos, end_pos, s)) queue;
     scan lexbuf
+    }
+  (* When lexing stdlib, we stop here just like ocamldep *)
+  | "(*MODULE_ALIASES*)" as s {
+    if Filename.basename (Lexing.lexeme_start_p lexbuf).pos_fname = stdlib_file
+    then flush ()
+    else (
+      Buffer.add_string buf s;
+      scan lexbuf)
     }
   | "(*"
       {


### PR DESCRIPTION
Fixes #257

Co-authored-by: @shym
