### PR TITLE
Propagate pattern locations to the final representation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
 
 ## Improved
 
+- Propagate pattern locations to report errors to the precise patterns
+  [\#308](https://github.com/ocaml-gospel/gospel/pull/308)
 - Support partial application of functions and enforce OCaml syntax
   for constructor application
   [\#290](https://github.com/ocaml-gospel/gospel/pull/290)

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -317,18 +317,18 @@ let pattern dp =
       vs
   in
   let rec pattern_node dp =
-    let ty = ty_of_dty dp.dp_dty in
+    let ty = ty_of_dty dp.dp_dty and loc = dp.dp_loc in
     match dp.dp_node with
-    | DPwild -> p_wild ty
-    | DPvar pid -> p_var (get_var pid ty)
-    | DPconst c -> p_const c
-    | DPapp (ls, dpl) -> p_app ls (List.map pattern_node dpl) ty
+    | DPwild -> p_wild ty loc
+    | DPvar pid -> p_var (get_var pid ty) loc
+    | DPconst c -> p_const c loc
+    | DPapp (ls, dpl) -> p_app ls (List.map pattern_node dpl) ty loc
     | DPor (dp1, dp2) ->
         let dp1 = pattern_node dp1 in
         let dp2 = pattern_node dp2 in
-        p_or dp1 dp2
-    | DPas (dp, pid) -> p_as (pattern_node dp) (get_var pid ty)
-    | DPinterval (c1, c2) -> p_interval c1 c2
+        p_or dp1 dp2 loc
+    | DPas (dp, pid) -> p_as (pattern_node dp) (get_var pid ty) loc
+    | DPinterval (c1, c2) -> p_interval c1 c2 loc
     | DPcast (dp, _) -> pattern_node dp
   in
   let p = pattern_node dp in

--- a/src/tterm.ml
+++ b/src/tterm.ml
@@ -16,7 +16,7 @@ module Ident = Identifier.Ident
 type pattern = {
   p_node : pattern_node;
   p_ty : ty;
-  p_loc : Location.t option; [@printer Fmt.option Utils.Fmt.pp_loc]
+  p_loc : Location.t; [@printer Utils.Fmt.pp_loc]
 }
 [@@deriving show]
 

--- a/src/tterm_helper.ml
+++ b/src/tterm_helper.ml
@@ -114,7 +114,7 @@ let ls_app_inst ls tl ty loc =
 
 (** Pattern constructors *)
 
-let mk_pattern p_node p_ty = { p_node; p_ty; p_loc = None }
+let mk_pattern p_node p_ty p_loc = { p_node; p_ty; p_loc }
 let p_wild ty = mk_pattern Pwild ty
 let p_var vs = mk_pattern (Pvar vs) vs.vs_ty
 let p_app ls pl ty = mk_pattern (Papp (ls, pl)) ty

--- a/src/tterm_helper.mli
+++ b/src/tterm_helper.mli
@@ -21,14 +21,14 @@ val t_type : term -> ty
 val t_ty_check : term -> ty option -> unit
 val ls_arg_inst : lsymbol -> term list -> ty Mtv.t
 val ls_app_inst : lsymbol -> term list -> ty option -> Location.t -> ty Mtv.t
-val mk_pattern : pattern_node -> ty -> pattern
-val p_wild : ty -> pattern
-val p_var : vsymbol -> pattern
-val p_app : lsymbol -> pattern list -> ty -> pattern
-val p_or : pattern -> pattern -> pattern
-val p_as : pattern -> vsymbol -> pattern
-val p_interval : char -> char -> pattern
-val p_const : Parsetree.constant -> pattern
+val mk_pattern : pattern_node -> ty -> Location.t -> pattern
+val p_wild : ty -> Location.t -> pattern
+val p_var : vsymbol -> Location.t -> pattern
+val p_app : lsymbol -> pattern list -> ty -> Location.t -> pattern
+val p_or : pattern -> pattern -> Location.t -> pattern
+val p_as : pattern -> vsymbol -> Location.t -> pattern
+val p_interval : char -> char -> Location.t -> pattern
+val p_const : Parsetree.constant -> Location.t -> pattern
 val mk_term : term_node -> ty option -> Location.t -> term
 val t_var : vsymbol -> Location.t -> term
 val t_const : constant -> ty -> Location.t -> term

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -1006,7 +1006,7 @@ First, create a test artifact:
                                             ]
                                           ))
                                        };
-                                     p_loc =  },
+                                     p_loc = foo.mli:25:8 },
                                    { Tterm.p_node =
                                      (Tterm.Papp (
                                         { Symbols.ls_name = infix ::;
@@ -1056,7 +1056,7 @@ First, create a test artifact:
                                                   },
                                                 []))
                                              };
-                                           p_loc =  };
+                                           p_loc = foo.mli:25:13 };
                                           { Tterm.p_node =
                                             (Tterm.Papp (
                                                { Symbols.ls_name = [];
@@ -1099,7 +1099,7 @@ First, create a test artifact:
                                                    ]
                                                  ))
                                               };
-                                            p_loc =  }
+                                            p_loc = foo.mli:25:18 }
                                           ]
                                         ));
                                      p_ty =
@@ -1119,7 +1119,7 @@ First, create a test artifact:
                                             ]
                                           ))
                                        };
-                                     p_loc =  }
+                                     p_loc = foo.mli:25:13 }
                                    ));
                                 p_ty =
                                 { Ttypes.ty_node =
@@ -1136,7 +1136,7 @@ First, create a test artifact:
                                        ]
                                      ))
                                   };
-                                p_loc =  },
+                                p_loc = foo.mli:25:8 },
                               None,
                               { Tterm.t_node =
                                 (Tterm.Tapp (
@@ -1214,7 +1214,7 @@ First, create a test artifact:
                                               ts_args = []; ts_alias = None },
                                             []))
                                          };
-                                       p_loc =  };
+                                       p_loc = foo.mli:26:8 };
                                       { Tterm.p_node =
                                         (Tterm.Pas (
                                            { Tterm.p_node =
@@ -1287,7 +1287,7 @@ First, create a test artifact:
                                                           ts_alias = None },
                                                         []))
                                                      };
-                                                   p_loc =  };
+                                                   p_loc = foo.mli:26:14 };
                                                   { Tterm.p_node = Tterm.Pwild;
                                                     p_ty =
                                                     { Ttypes.ty_node =
@@ -1311,7 +1311,7 @@ First, create a test artifact:
                                                            ]
                                                          ))
                                                       };
-                                                    p_loc =  }
+                                                    p_loc = foo.mli:26:19 }
                                                   ]
                                                 ));
                                              p_ty =
@@ -1331,7 +1331,7 @@ First, create a test artifact:
                                                     ]
                                                   ))
                                                };
-                                             p_loc =  },
+                                             p_loc = foo.mli:26:14 },
                                            { Symbols.vs_name = t_2;
                                              vs_ty =
                                              { Ttypes.ty_node =
@@ -1369,7 +1369,7 @@ First, create a test artifact:
                                                ]
                                              ))
                                           };
-                                        p_loc =  }
+                                        p_loc = foo.mli:26:13 }
                                       ]
                                     ));
                                  p_ty =
@@ -1387,7 +1387,7 @@ First, create a test artifact:
                                         ]
                                       ))
                                    };
-                                 p_loc =  },
+                                 p_loc = foo.mli:26:8 },
                                None,
                                { Tterm.t_node =
                                  (Tterm.Tif (

--- a/test/patterns/ambiguous.mli
+++ b/test/patterns/ambiguous.mli
@@ -8,9 +8,8 @@ val f : int -> int
    be removed *)
 
 (* {gospel_expected|
-   [125] File "ambiguous.mli", line 3, characters 12-72:
-         3 | ............match x with
+   [125] File "ambiguous.mli", line 4, characters 6-11:
          4 |     | _ | _ when x = 1 -> true
-         5 |     | _ -> false...
+                   ^^^^^
          Error: Ambiguous or-pattern under guard.
    |gospel_expected} *)


### PR DESCRIPTION
Preserve locations in patterns during the last translation (from `dpattern` to `Tterm.pattern`)
Allow the typechecker to pinpoint the precise locations of errors, rather than pointing to the whole enclosing expression
Update the tests accordingly