### PR TITLE
Set up location in parsing ghost specifications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,8 @@
 
 ## Fixed
 
+- Set up location in parsing ghost specifications
+  [\#310](https://github/ocaml-gospel/gospel/pull/310)
 - Check that all patterns in a disjunction bind the same variables
   [\#300](https://github/ocaml-gospel/gospel/pull/300)
 - Handle the special case of `MODULE_ALIASES` in `stdlib.mli` in the parser

--- a/src/uattr2spec.ml
+++ b/src/uattr2spec.ml
@@ -98,6 +98,8 @@ let val_description ~filename v =
 let ghost_spec ~filename attr =
   let spec, loc = get_spec_content attr in
   let lb = Lexing.from_string spec in
+  Lexing.set_position lb loc.loc_start;
+  Lexing.set_filename lb filename;
   let sigs = try Parse.interface lb with _ -> W.error ~loc W.Syntax_error in
   match sigs with
   | [ { psig_desc = Psig_type (r, [ t ]); _ } ] ->

--- a/test/typechecker/duplicate_declaration.mli
+++ b/test/typechecker/duplicate_declaration.mli
@@ -3,6 +3,8 @@ type t
 (*@ type t *)
 
 (* {gospel_expected|
-   [125] Internal error: no filename location for the following error
+   [125] File "duplicate_declaration.mli", line 3, characters 9-10:
+         3 | (*@ type t *)
+                      ^
          Error: A declaration for `t' already exists in this context.
    |gospel_expected} *)


### PR DESCRIPTION
Initialise the location at the beginning of parsing ghost specifications so that the locations are correct in the AST.
This should tackle the issues reported as `Internal error`s (note the capital `I`: these are the messages displayed when the filename in an error location is empty; the `internal error`s displayed (by `Cmdliner`) when running into uncaught exceptions are not fixed, unfortunately).

I’ll add the changelog entry and the update to the `duplicate_declaration.mli` test when the PR is close to merging, to avoid conflicts, so I mark this one as _draft_.