### PR TITLE
Rephrase ambiguous-patterns error

### DIFF
--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -138,7 +138,10 @@ let pp_kind ppf = function
         "This pattern-matching may not be exhaustive because of the guard.@\n\
          Here is an example of a case that may not be matched:@\n\
         \  %s" p
-  | Ambiguous_pattern -> pf ppf "Ambiguous or-pattern under guard"
+  | Ambiguous_pattern ->
+      pf ppf
+        "Or-patterns are prohibited under guards to avoid ambiguities@ (see \
+         OCaml compiler warning 57)"
   | Pattern_fully_guarded ->
       pf ppf "All clauses in this pattern-matching are guarded"
   | Pattern_redundant p ->

--- a/test/patterns/ambiguous.mli
+++ b/test/patterns/ambiguous.mli
@@ -11,5 +11,6 @@ val f : int -> int
    [125] File "ambiguous.mli", line 4, characters 6-11:
          4 |     | _ | _ when x = 1 -> true
                    ^^^^^
-         Error: Ambiguous or-pattern under guard.
+         Error: Or-patterns are prohibited under guards to avoid ambiguities
+                (see OCaml compiler warning 57).
    |gospel_expected} *)


### PR DESCRIPTION
Alternative patterns under guards are not considered ambiguous by the OCaml compiler so accept them also in Gospel patterns

This is intentionally based on #312, to see the impact on the cleaned-up test suite. Only one test ran into this feature.

Closes #314