### PR TITLE
Consider comments as spaces while preprocessing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,9 @@
 
 ## Fixed
 
+- Consider comments as spaces while preprocessing (to ensure specification can
+  be attached to a ghost function or type, for instance)
+  [\#321](https://github/ocaml-gospel/gospel/pull/321)
 - Fix source-location tracking (directives and overridden filename)
   [\#319](https://github/ocaml-gospel/gospel/pull/319)
 - Set up location in parsing ghost specifications

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -193,9 +193,12 @@ rule scan = parse
     }
   | "(*"
       {
+        push ();
         Buffer.add_string buf "(*";
         comment lexbuf;
         Buffer.add_string buf "*)";
+        Queue.push (Spaces (Buffer.contents buf)) queue;
+        Buffer.clear buf;
         scan lexbuf
       }
   | "#" as c {


### PR DESCRIPTION
In the following specification:

```ocaml
(*@ type t *)
(*@ ephemeral *)
```

the preprocessor needs to recognize that `ephemeral` must be attached in a nested attribute to the first attribute containing `type t`. It does so by accepting `Space` between the two items, but not simple comments.

So this turn simple comments into another form of `Space` so that

```ocaml
(*@ type t *) (* a ghost type *)
(*@ ephemeral *)
```

is valid syntax.

Closes #320 (hopefully)