### PR TITLE
Reformulate "Symbol not found" error to mention scope

### DIFF
--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -109,7 +109,11 @@ let pp_kind ppf = function
   | Invalid_int_literal (s, c) ->
       pf ppf "Invalid int literal: `%s%a'" s (option char) c
   | Symbol_not_found sl ->
-      pf ppf "Symbol %a not found" (list ~sep:(const string ".") string) sl
+      pf ppf
+        "Symbol %a not found in scope@ (see \"Symbols in scope\" documentation \
+         page)"
+        (list ~sep:(const string ".") string)
+        sl
   | Bad_record_field f -> pf ppf "The record field `%s' does not exist" f
   | Public_type_invariant t -> pf ppf "Invariant on public type `%s'" t
   | Circular_open -> pf ppf "This `open' introduces a dependency cycle"

--- a/test/issues/include_module.mli
+++ b/test/issues/include_module.mli
@@ -13,5 +13,6 @@ type nonrec t = t
    [125] File "include_module.mli", line 10, characters 16-17:
          10 | type nonrec t = t
                               ^
-         Error: Symbol t not found.
+         Error: Symbol t not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)

--- a/test/issues/stdlib_float_array_t_not_found.mli
+++ b/test/issues/stdlib_float_array_t_not_found.mli
@@ -6,5 +6,6 @@ val f : Stdlib.Float.Array.t -> int
    [125] File "stdlib_float_array_t_not_found.mli", line 1, characters 8-28:
          1 | val f : Stdlib.Float.Array.t -> int
                      ^^^^^^^^^^^^^^^^^^^^
-         Error: Symbol Stdlib.Float.Array.t not found.
+         Error: Symbol Stdlib.Float.Array.t not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)

--- a/test/pure/impure_not_promoted.mli
+++ b/test/pure/impure_not_promoted.mli
@@ -12,5 +12,6 @@ val g : int -> int
    [125] File "impure_not_promoted.mli", line 6, characters 13-14:
          6 |     requires f x > 0
                           ^
-         Error: Symbol f not found.
+         Error: Symbol f not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)

--- a/test/syntax/field_application.mli
+++ b/test/syntax/field_application.mli
@@ -9,5 +9,6 @@ val f : t -> int
    [125] File "field_application.mli", line 5, characters 18-19:
          5 |       ensures r = a x
                                ^
-         Error: Symbol a not found.
+         Error: Symbol a not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)

--- a/test/syntax/invalid_modifies.mli
+++ b/test/syntax/invalid_modifies.mli
@@ -11,5 +11,6 @@ val invalid_modifies : unit -> unit
    [125] File "invalid_modifies.mli", line 4, characters 13-14:
          4 |     modifies x
                           ^
-         Error: Symbol x not found.
+         Error: Symbol x not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)

--- a/test/syntax/invariant5.mli
+++ b/test/syntax/invariant5.mli
@@ -5,5 +5,6 @@ type 'a t = private { a : 'a }
    [125] File "invariant5.mli", line 2, characters 14-18:
          2 | (*@ invariant self.a = self.a *)
                            ^^^^
-         Error: Symbol self not found.
+         Error: Symbol self not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)

--- a/test/syntax/record_pattern2.mli
+++ b/test/syntax/record_pattern2.mli
@@ -21,5 +21,6 @@ type t = { x : int }
    [125] File "record_pattern2.mli", line 15, characters 7-8:
          15 |     | {y} -> y
                      ^
-         Error: Symbol y not found.
+         Error: Symbol y not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)

--- a/test/syntax/record_pattern3.mli
+++ b/test/syntax/record_pattern3.mli
@@ -19,5 +19,6 @@ type t = { x : int }
    [125] File "record_pattern3.mli", line 15, characters 11-12:
          15 |     | { x; z } -> x
                          ^
-         Error: Symbol z not found.
+         Error: Symbol z not found in scope
+                (see "Symbols in scope" documentation page).
    |gospel_expected} *)


### PR DESCRIPTION
Point users to the documentation in which scopes are used for which clauses

Requires #323 to bring the said documentation page

Closes #318