### PR TITLE
Introduce a generic `pp_gen` pretty-printer for error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Added
 
+- Introduce a generic `pp_gen` pretty-printer for error messages, so that
+  external tools can pretty-print errors in the same style
+  [\#326](https://github.com/ocaml-gospel/gospel/pull/326)
 - Add specific error message for patterns with guard on every clause.
   [\#220](https://github.com/ocaml-gospel/gospel/pull/220)
 - Added `when` guards in pattern-matching

--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -156,20 +156,20 @@ let pp_kind ppf = function
 
 let styled_list l pp = List.fold_left (fun acc x -> styled x acc) pp l
 
-let pp ppf (loc, k) =
+(** [pp_gen pp_sort pp_kind ppf loc k] display the message of the given sort
+    (warning, error, etc.) at the location obtained after fixing [loc] (it might
+    have been broken by preprocessing *)
+let pp_gen pp_sort pp_kind ppf loc k =
   let input_filename = loc.loc_start.pos_fname in
   match input_filename with
   | "" ->
       pf ppf
         "Internal error: no filename location for the following error@.%a: \
          @[%a.@]"
-        (styled_list [ `Red; `Bold ] string)
-        "Error" pp_kind k
+        pp_sort k pp_kind k
   | "_none_" ->
       (* This location is used for builtins such as [list] *)
-      pf ppf "%a: @[%a.@]"
-        (styled_list [ `Red; `Bold ] string)
-        "Error" pp_kind k
+      pf ppf "%a: @[%a.@]" pp_sort k pp_kind k
   | _ ->
       let input = Pp_loc.Input.file input_filename in
       (* because of the preprocessor (gospel pps), we may obtain locations that:
@@ -197,5 +197,7 @@ let pp ppf (loc, k) =
           ( Pp_loc.Position.of_lexing start_pos,
             Pp_loc.Position.of_lexing end_pos );
         ]
-        (styled_list [ `Red; `Bold ] string)
-        "Error" pp_kind k
+        pp_sort k pp_kind k
+
+let pp_error ppf _ = styled_list [ `Red; `Bold ] string ppf "Error"
+let pp ppf (loc, k) = pp_gen pp_error pp_kind ppf loc k


### PR DESCRIPTION
Generalise the error pretty-printer so that its logic to fix the locations (due to preprocessing messing them up) can be reused directly by other tools using gospel as a library