### PR TITLE
Add a dune alias to check that `dune.inc`s files mention only git-tracked files

### DIFF
--- a/test/coercions/dune.inc
+++ b/test/coercions/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:bad_type_id.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:bad_type_id.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -37,6 +45,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:bad_type_multiple_args.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:bad_type_multiple_args.mli})))))
 
 (rule
  (deps
@@ -58,6 +74,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:basic.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:basic.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -77,6 +101,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:complex_cycle.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:complex_cycle.mli})))))
 
 (rule
  (deps
@@ -98,6 +130,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:constr_literal.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constr_literal.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -118,6 +158,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:double_definition.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:double_definition.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -137,4 +185,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:simple_cycle.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:simple_cycle.mli})))))
 

--- a/test/issues/dune.inc
+++ b/test/issues/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:include_module.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:include_module.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -37,6 +45,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:model_field_not_found.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:model_field_not_found.mli})))))
 
 (rule
  (deps
@@ -58,6 +74,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:model_is_not_record.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:model_is_not_record.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -77,6 +101,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:model_shadows_field.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:model_shadows_field.mli})))))
 
 (rule
  (deps
@@ -98,6 +130,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:no_return.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:no_return.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -117,6 +157,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:return_unit_and_ghost.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:return_unit_and_ghost.mli})))))
 
 (rule
  (deps
@@ -138,6 +186,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:stdlib_float_array_not_found.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:stdlib_float_array_not_found.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -157,4 +213,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:stdlib_float_array_t_not_found.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:stdlib_float_array_t_not_found.mli})))))
 

--- a/test/literals/dune.inc
+++ b/test/literals/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:char1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:char1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -38,6 +46,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:ints.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:ints.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -57,4 +73,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:invalid_literal.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invalid_literal.mli})))))
 

--- a/test/patterns/dune.inc
+++ b/test/patterns/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:allsorts.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:allsorts.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -37,6 +45,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:allsorts2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:allsorts2.mli})))))
 
 (rule
  (deps
@@ -58,6 +74,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:ambiguous.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:ambiguous.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -77,6 +101,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:expressions_raises.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:expressions_raises.mli})))))
 
 (rule
  (deps
@@ -98,6 +130,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:fun_list.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:fun_list.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -117,6 +157,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:fun_option.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:fun_option.mli})))))
 
 (rule
  (deps
@@ -138,6 +186,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:fun_option_partial.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:fun_option_partial.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -157,6 +213,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:fun_pair.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:fun_pair.mli})))))
 
 (rule
  (deps
@@ -178,6 +242,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:fun_triple.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:fun_triple.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -197,6 +269,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:inner_cast.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:inner_cast.mli})))))
 
 (rule
  (deps
@@ -218,6 +298,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_bool.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_bool.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -237,6 +325,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_char.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_char.mli})))))
 
 (rule
  (deps
@@ -258,6 +354,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_float.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_float.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -277,6 +381,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_guard.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_guard.mli})))))
 
 (rule
  (deps
@@ -298,6 +410,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_char.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_char.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -317,6 +437,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_int1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_int1.mli})))))
 
 (rule
  (deps
@@ -338,6 +466,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_int2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_int2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -357,6 +493,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_int3.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_int3.mli})))))
 
 (rule
  (deps
@@ -378,6 +522,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_int4.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_int4.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -397,6 +549,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_list.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_list.mli})))))
 
 (rule
  (deps
@@ -418,6 +578,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_pair1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_pair1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -437,6 +605,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_pair2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_pair2.mli})))))
 
 (rule
  (deps
@@ -458,6 +634,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_string1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_string1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -477,6 +661,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_inner_string2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_inner_string2.mli})))))
 
 (rule
  (deps
@@ -498,6 +690,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_int.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_int.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -517,6 +717,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_list.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_list.mli})))))
 
 (rule
  (deps
@@ -538,6 +746,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_list_list.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_list_list.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -557,6 +773,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_pair1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_pair1.mli})))))
 
 (rule
  (deps
@@ -578,6 +802,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_pair2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_pair2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -597,6 +829,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:nonexhaustive_type.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:nonexhaustive_type.mli})))))
 
 (rule
  (deps
@@ -618,6 +858,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:not_all_guarded1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:not_all_guarded1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -637,6 +885,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:not_all_guarded2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:not_all_guarded2.mli})))))
 
 (rule
  (deps
@@ -658,6 +914,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:redundant1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:redundant1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -678,6 +942,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:redundant2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:redundant2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -697,4 +969,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:redundant3.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:redundant3.mli})))))
 

--- a/test/pure/dune.inc
+++ b/test/pure/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:impure_not_promoted.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:impure_not_promoted.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -37,6 +45,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:pure_no_diverges.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:pure_no_diverges.mli})))))
 
 (rule
  (deps
@@ -58,6 +74,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:pure_no_exceptions1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:pure_no_exceptions1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -77,6 +101,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:pure_no_exceptions2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:pure_no_exceptions2.mli})))))
 
 (rule
  (deps
@@ -98,6 +130,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:pure_no_modifies.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:pure_no_modifies.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -117,4 +157,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:pure_promoted.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:pure_promoted.mli})))))
 

--- a/test/semantic/dune.inc
+++ b/test/semantic/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:invariant1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invariant1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -37,6 +45,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:invariant2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invariant2.mli})))))
 
 (rule
  (deps
@@ -58,6 +74,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:invariant3.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invariant3.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -77,4 +101,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:no_modifies_while_returning_unit.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:no_modifies_while_returning_unit.mli})))))
 

--- a/test/syntax/dune.inc
+++ b/test/syntax/dune.inc
@@ -19,6 +19,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:abstract_functions.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:abstract_functions.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -38,6 +46,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:allsorts_labels.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:allsorts_labels.mli})))))
 
 (rule
  (deps
@@ -59,6 +75,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:basic_functions_axioms.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:basic_functions_axioms.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -78,6 +102,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:bitvector.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:bitvector.mli})))))
 
 (rule
  (deps
@@ -99,6 +131,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:constants.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constants.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -118,6 +158,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:constructor_args.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constructor_args.mli})))))
 
 (rule
  (deps
@@ -139,6 +187,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:constructor_arity1.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constructor_arity1.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -158,6 +214,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:constructor_arity2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constructor_arity2.mli})))))
 
 (rule
  (deps
@@ -179,6 +243,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:constructor_arity3.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constructor_arity3.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -198,6 +270,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:constructor_arity4.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constructor_arity4.mli})))))
 
 (rule
  (deps
@@ -219,6 +299,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:constructor_arity5.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constructor_arity5.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -238,6 +326,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:empty_match.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:empty_match.mli})))))
 
 (rule
  (deps
@@ -259,6 +355,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:exceptions.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:exceptions.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -278,6 +382,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:expressions.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:expressions.mli})))))
 
 (rule
  (deps
@@ -299,6 +411,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:field_application.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:field_application.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -318,6 +438,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:ghost_arg1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:ghost_arg1.mli})))))
 
 (rule
  (deps
@@ -339,6 +467,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:ghost_arg2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:ghost_arg2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -358,6 +494,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:guard.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:guard.mli})))))
 
 (rule
  (deps
@@ -379,6 +523,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:infix.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:infix.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -398,6 +550,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:invalid_modifies.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invalid_modifies.mli})))))
 
 (rule
  (deps
@@ -419,6 +579,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:invariant5.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invariant5.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -438,6 +606,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:invariants.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invariants.mli})))))
 
 (rule
  (deps
@@ -459,6 +635,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:literals.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:literals.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -478,6 +662,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:match_guard.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:match_guard.mli})))))
 
 (rule
  (deps
@@ -499,6 +691,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:module_with.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:module_with.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -518,6 +718,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:modules1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:modules1.mli})))))
 
 (rule
  (deps
@@ -539,6 +747,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:modules2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:modules2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -559,6 +775,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:no_specification.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:no_specification.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -578,6 +802,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:open.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:open.mli})))))
 
 (rule
  (deps
@@ -601,6 +833,14 @@
    (with-accepted-exit-codes 2
     (run ocamlc -c %{dep:open2.mli})))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:open2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -623,6 +863,14 @@
    (with-accepted-exit-codes 2
     (run ocamlc -c %{dep:open3.mli})))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:open3.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -642,6 +890,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:open_gospelstdlib_module.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:open_gospelstdlib_module.mli})))))
 
 (rule
  (deps
@@ -665,6 +921,14 @@
    (with-accepted-exit-codes 2
     (run ocamlc -c %{dep:open_qualified.mli})))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:open_qualified.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -684,6 +948,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:partial_application.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:partial_application.mli})))))
 
 (rule
  (deps
@@ -705,6 +977,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:pattern_binding.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:pattern_binding.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -725,6 +1005,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:predicates.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:predicates.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -744,6 +1032,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:pure.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:pure.mli})))))
 
 (rule
  (deps
@@ -766,6 +1062,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:qualified.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:qualified.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -785,6 +1089,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:record_pattern1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:record_pattern1.mli})))))
 
 (rule
  (deps
@@ -806,6 +1118,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:record_pattern2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:record_pattern2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -825,6 +1145,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:record_pattern3.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:record_pattern3.mli})))))
 
 (rule
  (deps
@@ -846,6 +1174,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:recursive_invariants.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:recursive_invariants.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -865,6 +1201,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:stdlib_exceptions.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:stdlib_exceptions.mli})))))
 
 (rule
  (deps
@@ -886,6 +1230,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:type.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:type.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -905,6 +1257,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:type_decl.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:type_decl.mli})))))
 
 (rule
  (deps
@@ -926,6 +1286,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:types.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:types.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -946,6 +1314,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:types_functions.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:types_functions.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -965,4 +1341,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:types_functions2.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:types_functions2.mli})))))
 

--- a/test/typechecker/dune.inc
+++ b/test/typechecker/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:alpha_not_beta.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:alpha_not_beta.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -37,6 +45,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:any_not_bool.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:any_not_bool.mli})))))
 
 (rule
  (deps
@@ -58,6 +74,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:axiom.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:axiom.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -77,6 +101,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:axiom_float_not_integer.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:axiom_float_not_integer.mli})))))
 
 (rule
  (deps
@@ -98,6 +130,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:constructor_arity5.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:constructor_arity5.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -117,6 +157,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:duplicate_declaration.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:duplicate_declaration.mli})))))
 
 (rule
  (deps
@@ -138,6 +186,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:exception_arity.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:exception_arity.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -157,6 +213,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:exception_no_pattern.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:exception_no_pattern.mli})))))
 
 (rule
  (deps
@@ -178,6 +242,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:exn_arity.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:exn_arity.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -197,6 +269,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:faulty_header1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:faulty_header1.mli})))))
 
 (rule
  (deps
@@ -218,6 +298,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:faulty_header2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:faulty_header2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -237,6 +325,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:faulty_header3.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:faulty_header3.mli})))))
 
 (rule
  (deps
@@ -258,6 +354,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:float_not_int.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:float_not_int.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -277,6 +381,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:float_not_integer.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:float_not_integer.mli})))))
 
 (rule
  (deps
@@ -298,6 +410,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:function_float_not_integer.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:function_float_not_integer.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -317,6 +437,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:int_not_bool1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:int_not_bool1.mli})))))
 
 (rule
  (deps
@@ -338,6 +466,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:int_not_bool2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:int_not_bool2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -357,6 +493,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:integer_not_bool1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:integer_not_bool1.mli})))))
 
 (rule
  (deps
@@ -378,6 +522,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:integer_not_bool2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:integer_not_bool2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -397,6 +549,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:integer_not_bool3.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:integer_not_bool3.mli})))))
 
 (rule
  (deps
@@ -418,6 +578,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:integer_not_bool4.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:integer_not_bool4.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -437,6 +605,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:integer_not_int.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:integer_not_int.mli})))))
 
 (rule
  (deps
@@ -458,6 +634,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:invariant4.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:invariant4.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -477,6 +661,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg1.mli})))))
 
 (rule
  (deps
@@ -498,6 +690,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -517,6 +717,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg3.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg3.mli})))))
 
 (rule
  (deps
@@ -538,6 +746,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg4.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg4.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -557,6 +773,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg5.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg5.mli})))))
 
 (rule
  (deps
@@ -578,6 +802,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg6.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg6.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -598,6 +830,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg7.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg7.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -617,6 +857,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:labeled_arg8.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:labeled_arg8.mli})))))
 
 (rule
  (deps
@@ -639,6 +887,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:open.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:open.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -658,6 +914,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:partial_application.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:partial_application.mli})))))
 
 (rule
  (deps
@@ -679,6 +943,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:raises_float_not_integer.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:raises_float_not_integer.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -698,6 +970,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:record_pattern4.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:record_pattern4.mli})))))
 
 (rule
  (deps
@@ -719,6 +999,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:t1_not_t2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:t1_not_t2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -738,6 +1026,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:tuple_arity1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:tuple_arity1.mli})))))
 
 (rule
  (deps
@@ -759,6 +1055,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:tuple_arity2.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:tuple_arity2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -778,6 +1082,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:type_arity1.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:type_arity1.mli})))))
 
 (rule
  (deps
@@ -800,6 +1112,14 @@
    (with-accepted-exit-codes 2
     (run ocamlc -c %{dep:type_arity2.mli})))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:type_arity2.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -821,6 +1141,14 @@
    (with-accepted-exit-codes 2
     (run ocamlc -c %{dep:type_arity3.mli})))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:type_arity3.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -840,6 +1168,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:type_arity4.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:type_arity4.mli})))))
 
 (rule
  (deps
@@ -862,6 +1198,14 @@
    (with-accepted-exit-codes 2
     (run ocamlc -c %{dep:type_arity5.mli})))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:type_arity5.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -881,4 +1225,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:variant_integer.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:variant_integer.mli})))))
 

--- a/test/utils/dune_gen.ml
+++ b/test/utils/dune_gen.ml
@@ -66,8 +66,16 @@ let print_rule file =
    ; Syntax sanity check
    %s(run ocamlc -c %%{dep:%s})%s)))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %%{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%%{dep:%s})))))
+
 |}
-      deps file file file file exit_code_open file exit_code_close
+      deps file file file file exit_code_open file exit_code_close file
 
 let () =
   let files = Filename.current_dir_name |> Sys.readdir in

--- a/test/vocal/dune.inc
+++ b/test/vocal/dune.inc
@@ -18,6 +18,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:Arrays.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:Arrays.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -37,6 +45,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:CountingSort.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:CountingSort.mli})))))
 
 (rule
  (deps
@@ -58,6 +74,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:FM19.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:FM19.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -77,6 +101,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:HashTable.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:HashTable.mli})))))
 
 (rule
  (deps
@@ -98,6 +130,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:Lists.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:Lists.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -117,6 +157,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:Mjrty.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:Mjrty.mli})))))
 
 (rule
  (deps
@@ -138,6 +186,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:PairingHeap.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:PairingHeap.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -157,6 +213,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:PriorityQueue.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:PriorityQueue.mli})))))
 
 (rule
  (deps
@@ -178,6 +242,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:Queue.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:Queue.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -197,6 +269,14 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:RingBuffer.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:RingBuffer.mli})))))
 
 (rule
  (deps
@@ -218,6 +298,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:UnionFind.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:UnionFind.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -238,6 +326,14 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:Vector.mli}))))
 
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:Vector.mli})))))
+
 (rule
  (deps
   %{bin:gospel}
@@ -257,4 +353,12 @@
   (chdir %{project_root}
    ; Syntax sanity check
    (run ocamlc -c %{dep:ZipperList.mli}))))
+
+; A good alias to use in a pre-push hook
+(rule
+ (alias pre-push)
+ (action
+  (chdir %{project_root}
+   (ignore-stdout
+    (run git rev-parse --verify --quiet @:%{dep:ZipperList.mli})))))
 


### PR DESCRIPTION
Add a `pre-push` dune alias to check that all the files appearing in `dune.inc`s are indeed tracked in `git`, to (help) avoid pushing `dune.inc`s generated for local-only files.