### PR TITLE
Add a Github Action CI workflow to run all the tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install OCaml compiler
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.11
+          dune-cache: true
+
+      - name: Install dependencies
+        run: |
+          opam install . --deps-only
+
+      - name: Show configuration
+        run: |
+          opam exec -- ocamlc -config
+          opam config list
+          opam exec -- dune printenv
+          opam list
+
+      - name: Build the test suite
+        run: opam exec -- dune build
+
+      - name: Run the normal tests
+        run: opam exec -- dune runtest
+
+      - name: Run the noisy tests
+        run: opam exec -- dune build @test-cmis
+
+      - name: Install the OPAM package
+        run: |
+          opam install --with-test ./gospel.opam


### PR DESCRIPTION
This PR adds a new CI workflow that runs all the tests in an action.

The goals are to:
- test the installation of the OPAM package (not tested by OCaml-CI) to make sure we are ready before we release,
- test the noisy tests (that are not attached to `@runtest` because they are noisy),
- provide a fallback for when OCaml-CI is overwhelmed.

This should provide a more reliable way to avoid broken states than what #327 tried to introduce.