### PR TITLE
Pretty-prints core types in `dumpast`

### DIFF
--- a/src/tast.ml
+++ b/src/tast.ml
@@ -44,7 +44,7 @@ type val_spec = {
 
 type val_description = {
   vd_name : Ident.t;
-  vd_type : core_type; [@printer fun fmt _ -> fprintf fmt "<core_type>"]
+  vd_type : core_type; [@printer Pprintast.core_type]
   vd_prim : string list;  (** primitive declaration *)
   vd_attrs : attributes; [@printer fun fmt _ -> fprintf fmt "<attributes>"]
   vd_args : lb_arg list;

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -124,7 +124,7 @@ First, create a test artifact:
       sig_loc = foo.mli:3:0 };
     { Tast.sig_desc =
       (Tast.Sig_val (
-         { Tast.vd_name = create; vd_type = <core_type>; vd_prim = [];
+         { Tast.vd_name = create; vd_type = int -> 'a t; vd_prim = [];
            vd_attrs = <attributes>;
            vd_args =
            [(Tast.Lnone
@@ -1737,7 +1737,7 @@ First, create a test artifact:
       sig_loc = foo.mli:24:4 };
     { Tast.sig_desc =
       (Tast.Sig_val (
-         { Tast.vd_name = add; vd_type = <core_type>; vd_prim = [];
+         { Tast.vd_name = add; vd_type = 'a -> 'a t -> unit; vd_prim = [];
            vd_attrs = <attributes>;
            vd_args =
            [(Tast.Lnone


### PR DESCRIPTION
Pretty-printed core types are a lot more compact than pretty-printed gospel types, so pretty-printing them can help decode the gospel version (and ensure they are consistent)