### PR TITLE
Use standard lowercase `true` and `false` for booleans

### DIFF
--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -84,12 +84,12 @@ let fs_unit =
 
 let fs_bool_true =
   fsymbol ~constr:true ~field:false
-    (Ident.create ~loc:Location.none "True")
+    (Ident.create ~loc:Location.none "true")
     [] ty_bool
 
 let fs_bool_false =
   fsymbol ~constr:true ~field:false
-    (Ident.create ~loc:Location.none "False")
+    (Ident.create ~loc:Location.none "false")
     [] ty_bool
 
 let fs_apply =

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -658,7 +658,7 @@ First, create a test artifact:
                         t_ty = None; t_attrs = []; t_loc = foo.mli:18:59 },
                       { Tterm.t_node =
                         (Tterm.Tapp (
-                           { Symbols.ls_name = True; ls_args = [];
+                           { Symbols.ls_name = true; ls_args = [];
                              ls_value =
                              (Some { Ttypes.ty_node =
                                      (Ttypes.Tyapp (
@@ -678,7 +678,7 @@ First, create a test artifact:
                         t_attrs = []; t_loc = foo.mli:18:59 },
                       { Tterm.t_node =
                         (Tterm.Tapp (
-                           { Symbols.ls_name = False; ls_args = [];
+                           { Symbols.ls_name = false; ls_args = [];
                              ls_value =
                              (Some { Ttypes.ty_node =
                                      (Ttypes.Tyapp (
@@ -1140,7 +1140,7 @@ First, create a test artifact:
                               None,
                               { Tterm.t_node =
                                 (Tterm.Tapp (
-                                   { Symbols.ls_name = True; ls_args = [];
+                                   { Symbols.ls_name = true; ls_args = [];
                                      ls_value =
                                      (Some { Ttypes.ty_node =
                                              (Ttypes.Tyapp (
@@ -1644,7 +1644,7 @@ First, create a test artifact:
                                       t_loc = foo.mli:26:30 },
                                     { Tterm.t_node =
                                       (Tterm.Tapp (
-                                         { Symbols.ls_name = True;
+                                         { Symbols.ls_name = true;
                                            ls_args = [];
                                            ls_value =
                                            (Some { Ttypes.ty_node =
@@ -1667,7 +1667,7 @@ First, create a test artifact:
                                       t_attrs = []; t_loc = foo.mli:26:30 },
                                     { Tterm.t_node =
                                       (Tterm.Tapp (
-                                         { Symbols.ls_name = False;
+                                         { Symbols.ls_name = false;
                                            ls_args = [];
                                            ls_value =
                                            (Some { Ttypes.ty_node =
@@ -1709,7 +1709,7 @@ First, create a test artifact:
                          t_attrs = []; t_loc = foo.mli:24:49 };
                         { Tterm.t_node =
                           (Tterm.Tapp (
-                             { Symbols.ls_name = True; ls_args = [];
+                             { Symbols.ls_name = true; ls_args = [];
                                ls_value =
                                (Some { Ttypes.ty_node =
                                        (Ttypes.Tyapp (
@@ -2172,7 +2172,7 @@ First, create a test artifact:
                                         t_attrs = []; t_loc = foo.mli:32:28 };
                                        { Tterm.t_node =
                                          (Tterm.Tapp (
-                                            { Symbols.ls_name = True;
+                                            { Symbols.ls_name = true;
                                               ls_args = [];
                                               ls_value =
                                               (Some { Ttypes.ty_node =

--- a/test/patterns/nonexhaustive_bool.mli
+++ b/test/patterns/nonexhaustive_bool.mli
@@ -23,5 +23,5 @@ val f : bool -> int
          8 |       | true -> true
          Error: This pattern-matching is not exhaustive.
                 Here is an example of a case that is not matched:
-                  False.
+                  false.
    |gospel_expected} *)

--- a/test/patterns/nonexhaustive_pair1.mli
+++ b/test/patterns/nonexhaustive_pair1.mli
@@ -13,5 +13,5 @@ type t = bool * int
          6 |       | false, x -> false
          Error: This pattern-matching is not exhaustive.
                 Here is an example of a case that is not matched:
-                  True, 1i.
+                  true, 1i.
    |gospel_expected} *)


### PR DESCRIPTION
Parsing used the standard lowercase syntax but pretty-printing was using uppercase versions

Closes #315