### PR TITLE
Display a warning when encountering an `include`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 
 ## Improved
 
+- Display a warning when encountering an `include`
+  [\#334](https://github.com/ocaml-gospel/gospel/pull/334)
 - Allow patterns in arguments and return type annotation in anonymous functions
   [\#309](https://github.com/ocaml-gospel/gospel/pull/309)
 - Propagate pattern locations to report errors to the precise patterns

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -527,6 +527,14 @@ let add_sig_contents muc sig_ =
       let nm = List.hd (List.rev opn_id) in
       let ns = ns_find_ns (get_top_import muc) opn_id in
       add_ns_top ~export:false (add_ns ~export:false muc nm ns) ns
+  | Sig_include _ ->
+      let warn ppf () =
+        Fmt.text ppf
+          "`include`s are currently ignored by the gospel type-checker"
+      in
+      Fmt.epr "@[%t@]@." (fun ppf ->
+          W.(pp_gen pp_warning warn ppf sig_.sig_loc ()));
+      muc
   | _ -> muc
 (* TODO *)
 

--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -199,5 +199,6 @@ let pp_gen pp_sort pp_kind ppf loc k =
         ]
         pp_sort k pp_kind k
 
+let pp_warning ppf _ = styled_list [ `Yellow; `Bold ] string ppf "Warning"
 let pp_error ppf _ = styled_list [ `Red; `Bold ] string ppf "Error"
 let pp ppf (loc, k) = pp_gen pp_error pp_kind ppf loc k

--- a/test/issues/include_module.mli
+++ b/test/issues/include_module.mli
@@ -10,7 +10,12 @@ end
 type nonrec t = t
 
 (* {gospel_expected|
-   [125] File "include_module.mli", line 10, characters 16-17:
+   [125] File "include_module.mli", line 6, characters 0-24:
+         6 | include sig
+         7 |   type t
+         8 | end
+         Warning: `include`s are currently ignored by the gospel type-checker.
+         File "include_module.mli", line 10, characters 16-17:
          10 | type nonrec t = t
                               ^
          Error: Symbol t not found in scope


### PR DESCRIPTION
This is based on #326 to have access to the `pp_gen` pretty-printer.

That would be a (partial) way to address #302.