### PR TITLE
Forbid `old` operator in precondition clauses (`requires` and `checks`)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 
 ## Improved
 
+- Forbid `old` operator in precondition clauses (`requires` and `checks`)
+  [\#335](https://github.com/ocaml-gospel/gospel/pull/335)
 - Display a warning when encountering an `include`
   [\#334](https://github.com/ocaml-gospel/gospel/pull/334)
 - Allow patterns in arguments and return type annotation in anonymous functions

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -507,9 +507,13 @@ let rec dterm whereami kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   | Uast.Tattr (at, t) ->
       let dt = dterm whereami kid crcm ns denv t in
       mk_dterm ~loc (DTattr (dt, [ at ])) dt.dt_dty
-  | Uast.Told t ->
-      let dt = dterm whereami kid crcm ns denv t in
-      mk_dterm ~loc (DTold dt) dt.dt_dty
+  | Uast.Told t -> (
+      match whereami with
+      | Requires -> W.(error ~loc (Old_in_precond "requires"))
+      | Checks -> W.(error ~loc (Old_in_precond "checks"))
+      | _ ->
+          let dt = dterm whereami kid crcm ns denv t in
+          mk_dterm ~loc (DTold dt) dt.dt_dty)
   | Uast.Trecord qtl ->
       let cs, pjl, fll = parse_record ~loc kid ns qtl in
       let get_term pj =

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -20,6 +20,18 @@ open Symbols
 
 (** Utils *)
 
+type whereami =
+  | Axiom
+  | Checks
+  | Consumes
+  | Ensures
+  | Function_or_predicate
+  | Invariant
+  | Modifies
+  | Raises
+  | Requires
+  | Variant
+
 let pid_of_label = function
   | Lunit -> invalid_arg "pid_of_label Lunit"
   | Lnone p | Loptional p | Lnamed p | Lghost (p, _) -> p
@@ -245,10 +257,10 @@ let binop = function
   | Uast.Timplies -> Timplies
   | Uast.Tiff -> Tiff
 
-let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
+let rec dterm whereami kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   let mk_dterm ~loc dt_node dty = { dt_node; dt_dty = dty; dt_loc = loc } in
   let apply dt1 t2 =
-    let dt2 = dterm kid crcm ns denv t2 in
+    let dt2 = dterm whereami kid crcm ns denv t2 in
     let dty = dty_fresh () in
     unify dt1 (Some (Tapp (ts_arrow, [ dty_of_dterm dt2; dty ])));
     let dt_app = DTapp (fs_apply, [ dt1; dt2 ]) in
@@ -264,7 +276,7 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   let gen_app ~loc ls tl =
     let nls = List.length ls.ls_args and ntl = List.length tl in
     let args, extra = split_at_i nls tl in
-    let dtl = List.map (dterm kid crcm ns denv) args in
+    let dtl = List.map (dterm whereami kid crcm ns denv) args in
     let dtyl, dty = specialize_ls ls in
     if ntl < nls then
       let dtyl1, dtyl2 = split_at_i ntl dtyl in
@@ -318,7 +330,7 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
     | Uast.Tpreid q -> qualid_app q (t2 :: tl)
     | Uast.Tapply (t11, t12) -> unfold_app t11 t12 (t2 :: tl)
     | _ ->
-        let dt1 = dterm kid crcm ns denv t1 in
+        let dt1 = dterm whereami kid crcm ns denv t1 in
         map_apply dt1 (t2 :: tl)
   in
   match term_desc with
@@ -356,13 +368,13 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   | Uast.Tidapp (q, tl) -> qualid_app q tl
   | Uast.Tapply (t1, t2) -> unfold_app t1 t2 []
   | Uast.Tnot t ->
-      let dt = dterm kid crcm ns denv t in
+      let dt = dterm whereami kid crcm ns denv t in
       dfmla_unify dt;
       mk_dterm ~loc (DTnot dt) dt.dt_dty
   | Uast.Tif (t1, t2, t3) ->
-      let dt1 = dterm kid crcm ns denv t1 in
-      let dt2 = dterm kid crcm ns denv t2 in
-      let dt3 = dterm kid crcm ns denv t3 in
+      let dt1 = dterm whereami kid crcm ns denv t1 in
+      let dt2 = dterm whereami kid crcm ns denv t2 in
+      let dt3 = dterm whereami kid crcm ns denv t3 in
       let dt1 = dfmla_expected crcm dt1 in
       let dty = max_dty crcm [ dt2; dt3 ] in
       let dt2 = dterm_expected_op crcm dt2 dty in
@@ -371,9 +383,9 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   | Uast.Ttuple [] -> fun_app ~loc fs_unit []
   | Uast.Ttuple tl -> fun_app ~loc (fs_tuple (List.length tl)) tl
   | Uast.Tlet (pid, t1, t2) ->
-      let dt1 = dterm kid crcm ns denv t1 in
+      let dt1 = dterm whereami kid crcm ns denv t1 in
       let denv = denv_add_var denv pid.pid_str (dty_of_dterm dt1) in
-      let dt2 = dterm kid crcm ns denv t2 in
+      let dt2 = dterm whereami kid crcm ns denv t2 in
       mk_dterm ~loc (DTlet (pid, dt1, dt2)) dt2.dt_dty
   | Uast.Tinfix (t1, op1, t23) ->
       let apply de1 op de2 =
@@ -397,7 +409,7 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
       let rec chain _ de1 op1 t23 =
         match t23 with
         | { term_desc = Uast.Tinfix (t2, op2, t3); term_loc = loc23 } ->
-            let de2 = dterm kid crcm ns denv t2 in
+            let de2 = dterm whereami kid crcm ns denv t2 in
             (* TODO: improve locations of subterms. See loc_cutoff function in why3 typing.ml *)
             (* let loc12 = loc_cutoff loc loc23 t2.term_loc in *)
             let de12 = apply de1 op1 de2 in
@@ -405,12 +417,12 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
             dfmla_unify de12;
             dfmla_unify de23;
             mk_dterm ~loc (DTbinop (Tand, de12, de23)) None
-        | _ -> apply de1 op1 (dterm kid crcm ns denv t23)
+        | _ -> apply de1 op1 (dterm whereami kid crcm ns denv t23)
       in
-      chain loc (dterm kid crcm ns denv t1) op1 t23
+      chain loc (dterm whereami kid crcm ns denv t1) op1 t23
   | Uast.Tbinop (t1, op, t2) ->
-      let dt1 = dterm kid crcm ns denv t1 in
-      let dt2 = dterm kid crcm ns denv t2 in
+      let dt1 = dterm whereami kid crcm ns denv t1 in
+      let dt2 = dterm whereami kid crcm ns denv t2 in
       dfmla_unify dt1;
       dfmla_unify dt2;
       mk_dterm ~loc (DTbinop (binop op, dt1, dt2)) None
@@ -420,7 +432,7 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
       in
       let vl = List.map (fun (pid, pty) -> (pid, get_dty pty)) vl in
       let denv = denv_add_var_quant denv vl in
-      let dt = dterm kid crcm ns denv t in
+      let dt = dterm whereami kid crcm ns denv t in
       let dty, q =
         match q with
         | Uast.Tforall ->
@@ -444,7 +456,7 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
           (fun denv (dp, _) -> Mstr.union choose_snd denv dp.dp_vars)
           denv args
       in
-      let dt = dterm kid crcm ns denv t in
+      let dt = dterm whereami kid crcm ns denv t in
       let dt =
         match pty with
         | Some pty -> dterm_expected crcm dt (dty_of_pty ns pty)
@@ -457,18 +469,18 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
       in
       mk_dterm ~loc (DTlambda (List.map fst args, dt)) dty
   | Uast.Tcase (t, ptl) ->
-      let dt = dterm kid crcm ns denv t in
+      let dt = dterm whereami kid crcm ns denv t in
       let dt_dty = dty_of_dterm dt in
       let branch (p, g, t) =
         let dp = dpattern kid ns p in
         dpattern_unify dp dt_dty;
         let choose_snd _ _ x = Some x in
         let denv = Mstr.union choose_snd denv dp.dp_vars in
-        let dt = dterm kid crcm ns denv t in
+        let dt = dterm whereami kid crcm ns denv t in
         let dg =
           match g with
           | None -> None
-          | Some g -> Some (dterm kid crcm ns denv g)
+          | Some g -> Some (dterm whereami kid crcm ns denv g)
         in
         (dp, dg, dt)
       in
@@ -486,22 +498,22 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
       in
       mk_dterm ~loc (DTcase (dt, pdtl)) dty
   | Uast.Tcast (t, pty) ->
-      let dt = dterm kid crcm ns denv t in
+      let dt = dterm whereami kid crcm ns denv t in
       let dty = dty_of_pty ns pty in
       dterm_expected crcm dt dty
   | Uast.Tscope (q, t) ->
       let ns = find_q_ns ns q in
-      dterm kid crcm ns denv t
+      dterm whereami kid crcm ns denv t
   | Uast.Tattr (at, t) ->
-      let dt = dterm kid crcm ns denv t in
+      let dt = dterm whereami kid crcm ns denv t in
       mk_dterm ~loc (DTattr (dt, [ at ])) dt.dt_dty
   | Uast.Told t ->
-      let dt = dterm kid crcm ns denv t in
+      let dt = dterm whereami kid crcm ns denv t in
       mk_dterm ~loc (DTold dt) dt.dt_dty
   | Uast.Trecord qtl ->
       let cs, pjl, fll = parse_record ~loc kid ns qtl in
       let get_term pj =
-        try dterm kid crcm ns denv (Mls.find pj fll)
+        try dterm whereami kid crcm ns denv (Mls.find pj fll)
         with Not_found ->
           W.error ~loc (W.Unknown_record_field pj.ls_name.id_str)
       in
@@ -509,22 +521,22 @@ let rec dterm kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   | Uast.Tupdate (t, qtl) ->
       let cs, pjl, fll = parse_record ~loc kid ns qtl in
       let get_term pj =
-        try dterm kid crcm ns denv (Mls.find pj fll)
+        try dterm whereami kid crcm ns denv (Mls.find pj fll)
         with Not_found -> fun_app ~loc:t.term_loc pj [ t ]
       in
       mk_app ~loc:t.term_loc cs (List.map get_term pjl)
 
-let dterm kid crcm ns env t =
+let dterm whereami kid crcm ns env t =
   let denv = Mstr.map (fun vs -> dty_of_ty vs.vs_ty) env in
-  dterm kid crcm ns denv t
+  dterm whereami kid crcm ns denv t
 
-let term_with_unify kid crcm ty ns env t =
-  let dt = dterm kid crcm ns env t in
+let term_with_unify whereami kid crcm ty ns env t =
+  let dt = dterm whereami kid crcm ns env t in
   dterm_unify dt (dty_of_ty ty);
   term env dt
 
-let fmla kid crcm ns env t =
-  let dt = dterm kid crcm ns env t in
+let fmla whereami kid crcm ns env t =
+  let dt = dterm whereami kid crcm ns env t in
   let tt = fmla env dt in
   { tt with t_loc = t.term_loc }
 
@@ -557,7 +569,9 @@ let process_type_spec kid crcm ns ty spec =
     | Some vs -> Mstr.singleton vs.vs_name.id_str vs
     | None -> Mstr.empty
   in
-  let invariants = List.map (fmla kid crcm ns env) (snd spec.ty_invariant) in
+  let invariants =
+    List.map (fmla Invariant kid crcm ns env) (snd spec.ty_invariant)
+  in
   type_spec spec.ty_ephemeral fields (self_vs, invariants) spec.ty_text
     spec.ty_loc
 
@@ -818,13 +832,17 @@ let process_val_spec kid crcm ns id args ret vs =
 
   let env, args = process_args header.sp_hd_args args Mstr.empty [] in
 
-  let pre = List.map (fmla kid crcm ns env) vs.sp_pre in
-  let checks = List.map (fmla kid crcm ns env) vs.sp_checks in
+  let pre = List.map (fmla Requires kid crcm ns env) vs.sp_pre in
+  let checks = List.map (fmla Checks kid crcm ns env) vs.sp_checks in
   let wr =
-    List.map (fun t -> dterm kid crcm ns env t |> term env) vs.sp_writes
+    List.map
+      (fun t -> dterm Modifies kid crcm ns env t |> term env)
+      vs.sp_writes
   in
   let cs =
-    List.map (fun t -> dterm kid crcm ns env t |> term env) vs.sp_consumes
+    List.map
+      (fun t -> dterm Consumes kid crcm ns env t |> term env)
+      vs.sp_consumes
   in
 
   let process_xpost (loc, exn) =
@@ -884,7 +902,7 @@ let process_val_spec kid crcm ns id args ret vs =
           let p, vars = pattern dp in
           let choose_snd _ _ vs = Some vs in
           let env = Mstr.union choose_snd env vars in
-          let t = fmla kid crcm ns env t in
+          let t = fmla Raises kid crcm ns env t in
           Mxs.update xs (merge_xpost (Some (p, t))) mxs
     in
     List.fold_left process Mxs.empty exn |> Mxs.bindings
@@ -901,7 +919,7 @@ let process_val_spec kid crcm ns id args ret vs =
         process_args header.sp_hd_ret tyl env []
     | _, _ -> process_args header.sp_hd_ret [ (ret, Asttypes.Nolabel) ] env []
   in
-  let post = List.map (fmla kid crcm ns env) vs.sp_post in
+  let post = List.map (fmla Ensures kid crcm ns env) vs.sp_post in
 
   if vs.sp_pure then (
     if vs.sp_diverge then
@@ -1027,17 +1045,22 @@ let process_function kid crcm ns f =
 
   let def =
     match f_ty with
-    | None -> Option.map (fmla kid crcm ns env) f.fun_def
-    | Some ty -> Option.map (term_with_unify kid crcm ty ns env) f.fun_def
+    | None -> Option.map (fmla Function_or_predicate kid crcm ns env) f.fun_def
+    | Some ty ->
+        Option.map
+          (term_with_unify Function_or_predicate kid crcm ty ns env)
+          f.fun_def
   in
 
   let spec =
     Option.map
       (fun (spec : Uast.fun_spec) ->
-        let req = List.map (fmla kid crcm ns env) spec.fun_req in
-        let ens = List.map (fmla kid crcm ns env) spec.fun_ens in
+        let req = List.map (fmla Requires kid crcm ns env) spec.fun_req in
+        let ens = List.map (fmla Ensures kid crcm ns env) spec.fun_ens in
         let variant =
-          List.map (term_with_unify kid crcm ty_integer ns env) spec.fun_variant
+          List.map
+            (term_with_unify Variant kid crcm ty_integer ns env)
+            spec.fun_variant
         in
         mk_fun_spec req ens variant spec.fun_coer spec.fun_text spec.fun_loc)
       f.fun_spec
@@ -1049,7 +1072,7 @@ let process_function kid crcm ns f =
 
 let process_axiom loc kid crcm ns a =
   let id = Ident.of_preid a.Uast.ax_name in
-  let t = fmla kid crcm ns Mstr.empty a.Uast.ax_term in
+  let t = fmla Axiom kid crcm ns Mstr.empty a.Uast.ax_term in
   let ax = mk_axiom id t a.ax_loc a.ax_text in
   mk_sig_item (Sig_axiom ax) loc
 

--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -42,6 +42,7 @@ type kind =
   | Pattern_fully_guarded
   | Pattern_redundant of string
   | Ambiguous_pattern
+  | Old_in_precond of string
 
 type error = location * kind
 
@@ -153,6 +154,8 @@ let pp_kind ppf = function
         "The pattern-matching is redundant.@\n\
          Here is a case that is unused:@\n\
         \  %s" p
+  | Old_in_precond precond ->
+      pf ppf "`old' operator is not allowed in `%s' clauses" precond
 
 let styled_list l pp = List.fold_left (fun acc x -> styled x acc) pp l
 

--- a/test/issues/model_is_not_record.mli
+++ b/test/issues/model_is_not_record.mli
@@ -9,6 +9,6 @@ val f : 'a t -> unit
 
 (* {gospel_expected|
    [125] gospel: internal error, uncaught exception:
-                 File "src/typing.ml", line 112, characters 13-19: Assertion failed
+                 File "src/typing.ml", line 124, characters 13-19: Assertion failed
                  
    |gospel_expected} *)

--- a/test/semantic/dune.inc
+++ b/test/semantic/dune.inc
@@ -78,3 +78,23 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:no_modifies_while_returning_unit.mli}))))
 
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
+ (action
+  (with-outputs-to old_in_precond.mli.output
+   (run %{checker} %{dep:old_in_precond.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff old_in_precond.mli old_in_precond.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:old_in_precond.mli}))))
+

--- a/test/semantic/old_in_precond.mli
+++ b/test/semantic/old_in_precond.mli
@@ -1,0 +1,11 @@
+val first : 'a array -> 'a
+(*@ x = first a
+    requires Array.length (old a) >= 1
+*)
+
+(* {gospel_expected|
+   [125] File "old_in_precond.mli", line 3, characters 26-33:
+         3 |     requires Array.length (old a) >= 1
+                                       ^^^^^^^
+         Error: `old' operator is not allowed in `requires' clauses.
+   |gospel_expected} *)


### PR DESCRIPTION
- Route whereami information in type checker
- Reject `old` in `requires` and `checks` clauses
