### PR TITLE
Add a test that shows the issue of misplaced Gospel comments

### DIFF
--- a/test/issues/attribute_syntax.mli
+++ b/test/issues/attribute_syntax.mli
@@ -1,0 +1,8 @@
+val f : int -> (*@ misplaced *) int
+
+(* {gospel_expected|
+   [125] File "attribute_syntax.mli", line 1, characters 15-18:
+         1 | val f : int -> (*@ misplaced *) int
+                            ^^^
+         Error: Syntax error.
+   |gospel_expected} *)

--- a/test/issues/dune.inc
+++ b/test/issues/dune.inc
@@ -3,6 +3,26 @@
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
  (action
+  (with-outputs-to attribute_syntax.mli.output
+   (run %{checker} %{dep:attribute_syntax.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff attribute_syntax.mli attribute_syntax.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:attribute_syntax.mli}))))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
+ (action
   (with-outputs-to include_module.mli.output
    (run %{checker} %{dep:include_module.mli}))))
 


### PR DESCRIPTION
As Gospel special comments are turned into attributes, if they are placed at positions at which the OCaml syntax does not accept attributes, they will be reported as syntax errors, which might be confusing to new users.

It might be useful to mention this fact also in the documentation page explaining the Gospel special comments.