### PR TITLE
Prepare the OPAM file for the second release

### DIFF
--- a/gospel.opam
+++ b/gospel.opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "A tool-agnostic formal specification language for OCaml"
 description: """\
-Gospel is a behavioural specification language for OCaml program. It provides
+Gospel is a behavioural specification language for OCaml programs. It provides
 developers with a non-invasive and easy-to-use syntax to annotate their module
 interfaces with formal contracts that describe type invariants, mutability,
 function pre-conditions and post-conditions, effects, exceptions, and much more!"""
@@ -18,24 +18,23 @@ license: "MIT"
 homepage: "https://github.com/ocaml-gospel/gospel"
 dev-repo: "git://github.com/ocaml-gospel/gospel"
 bug-reports: "https://github.com/ocaml-gospel/gospel/issues"
-
 build: [
   ["dune" "subst"] {dev}
   [
     "dune"
     "build"
     "-p"
-  name
+    name
     "-j"
     jobs
     "@install"
     "@runtest" {with-test}
-  "@doc" {with-doc}
+    "@doc" {with-doc}
   ]
 ]
-
 depends: [
   "ocaml" {>= "4.11"}
+  "ocamlfind"
   "dune" {>= "3.0.0"}
   "menhir" {>= "20181006"}
   "cmdliner" {>= "1.1.0"}
@@ -43,6 +42,5 @@ depends: [
   "ocaml-compiler-libs" {>= "v0.12.0"}
   "ppxlib" {>= "0.26.0"}
   "ppx_deriving" {>= "5.2.1"}
-  "ocamlfind"
   "pp_loc" {>= "2.1.0"}
 ]

--- a/gospel.opam
+++ b/gospel.opam
@@ -20,7 +20,7 @@ dev-repo: "git://github.com/ocaml-gospel/gospel"
 bug-reports: "https://github.com/ocaml-gospel/gospel/issues"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/gospel.opam
+++ b/gospel.opam
@@ -8,7 +8,9 @@ function pre-conditions and post-conditions, effects, exceptions, and much more!
 maintainer: "Jean-Christophe.Filliatre@lri.fr"
 authors: [
   "Jean-Christophe Filliâtre"
+  "Samuel Hym"
   "Cláudio Lourenço"
+  "Nicolas Obsorne"
   "Clément Pascutto"
   "Mário Pereira"
 ]


### PR DESCRIPTION
Complete authors list in the OPAM package description
Reformat the OPAM package file:
- Fix a typo and indentation
- Remove empty lines

`"-p" name` is probably useless, as this is a one-package repository, but since it doesn’t hurt...