### PR TITLE
Another series of patches to the documentation

### DIFF
--- a/docs/docs/getting-started/first-spec.md
+++ b/docs/docs/getting-started/first-spec.md
@@ -86,7 +86,7 @@ to specify three pieces of information:
 Let's write a Gospel formalisation of that contract. The contract starts with a
 header that names the arguments and the return value. We'll call the
 argument `c` and the return value `t`. Now we can mention them in the rest of the
-specification. The first property is a pre-condition of the function (we use the
+specification. The first property is a precondition of the function (we use the
 keyword `requires`), while the second and third ones are post-conditions (the
 keyword is `ensures`):
 
@@ -173,7 +173,7 @@ Since we have a `modifies` clause, the contents of `t` may be mutated even when
 
 Notice how we didn't need to repeat that `S.cardinal t.contents <= t.capacity`
 in every contract. As a type invariant, this property implicitly holds in every
-function's pre-state and post-state.
+function's prestate and poststate.
 
 ## Type-Checking Your Specification
 

--- a/docs/docs/getting-started/first-spec.md
+++ b/docs/docs/getting-started/first-spec.md
@@ -66,8 +66,8 @@ type 'a t
     invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
-The `Set` module is part of the [Gospel standard library](../stdlib). Although it
-tries to mimic familiar interfaces from the OCaml standard library, those two
+The `Set` module is part of the [Gospel standard library](../stdlib). Although
+it tries to mimic familiar interfaces from the OCaml standard library, those two
 should not be confused. Only logical declarations can appear in specifications!
 
 Now that we annotated our type with its models and invariants, we can attach
@@ -84,8 +84,8 @@ to specify three pieces of information:
 - The container is empty.
 
 Let's write a Gospel formalisation of that contract. The contract starts with a
-header that names the arguments and the return value. We'll call the
-argument `c` and the return value `t`. Now we can mention them in the rest of the
+header that names the arguments and the return value. We'll call the argument
+`c` and the return value `t`. Now we can mention them in the rest of the
 specification. The first property is a precondition of the function (we use the
 keyword `requires`), while the second and third ones are post-conditions (the
 keyword is `ensures`):
@@ -128,12 +128,12 @@ val mem: 'a t -> 'a -> bool
 Finally, let's specify `clear` and `add`, which are functions that mutate the
 container.
 
-The function `clear` removes all elements from its argument, meaning it's empty after the
-call. Obviously, it modifies the `contents` model of its argument. After its
-execution, the container should be empty. Note that we are only allowed to
-mention `is_empty` in the specification because it's a *pure* function.
-Attempting to use a non-pure OCaml function in a specification will result in a
-Gospel error.
+The function `clear` removes all elements from its argument, meaning it's empty
+after the call. Obviously, it modifies the `contents` model of its argument.
+After its execution, the container should be empty. Note that we are only
+allowed to mention `is_empty` in the specification because it's a *pure*
+function. Attempting to use a non-pure OCaml function in a specification will
+result in a Gospel error.
 
 ```ocaml
 val clear: 'a t -> unit
@@ -153,9 +153,9 @@ val add: 'a t -> 'a -> unit
     ensures t.contents = Set.add x (old t.contents) *)
 ```
 
-However, notice that this specification is incomplete. One specificity
-of this function is that it can raise `Full`, so let's complete that contract with
-this piece of information. If `add` raises `Full`, we can deduce that `t.contents`
+However, notice that this specification is incomplete. One specificity of this
+function is that it can raise `Full`, so let's complete that contract with this
+piece of information. If `add` raises `Full`, we can deduce that `t.contents`
 already contains `t.capacity` elements.
 
 ```ocaml

--- a/docs/docs/getting-started/first-spec.md
+++ b/docs/docs/getting-started/first-spec.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# Your first specification
+# Your First Specification
 
 Let us get started with a simple specification example, and specify a generic
 interface for polymorphic, limited capacity containers.
@@ -35,12 +35,12 @@ Gospel specifications live in special comments, starting with the `@` character.
 These comments may be attached to type declarations or value declarations. They
 provide a specification for the signature item they are attached to.
 
-## Models and invariants for `'a t`
+## Models and Invariants for `'a t`
 
 Let's start by specifying the abstract type `'a t`. As a container with fixed
 capacity, we can model it with two pieces of information: a fixed integer
-capacity, and a set of `'a` values, representing its contents. Note that the
-capacity is not mutable, while the contents are. This logical model of
+capacity and a set of `'a` values, representing its contents. Note that the
+capacity is not mutable even though the contents are. This logical model of
 the container directly translates into Gospel:
 
 ```ocaml
@@ -68,24 +68,24 @@ type 'a t
 
 The `Set` module is part of the [Gospel standard library](../stdlib). Although it
 tries to mimic familiar interfaces from the OCaml standard library, those two
-should not be confused: only logical declarations can appear in specifications!
+should not be confused. Only logical declarations can appear in specifications!
 
 Now that we annotated our type with its models and invariants, we can attach
 specifications to the functions to show how they interact with the container.
 
-## Your first function contract: `create`
+## Your First Function Contract: `create`
 
 The function `create` returns a container when provided a capacity. We may want
 to specify three pieces of information:
 
 - The provided capacity is positive.
-- The capacity of the returned container is indeed the one received as an
+- The returned container's capacity is indeed the one received as an
   argument.
 - The container is empty.
 
 Let's write a Gospel formalisation of that contract. The contract starts with a
-header that lets us name the arguments and return value (we will call the
-argument `c` and the return value `t`) to mention them in the rest of the
+header that names the arguments and the return value. We'll call the
+argument `c` and the return value `t`. Now we can mention them in the rest of the
 specification. The first property is a pre-condition of the function (we use the
 keyword `requires`), while the second and third ones are post-conditions (the
 keyword is `ensures`):
@@ -98,13 +98,13 @@ val create: int -> 'a t
     ensures t.contents = Set.empty *)
 ```
 
-## Simple accessors: `is_empty` and `mem`
+## Simple Accessors: `is_empty` and `mem`
 
 Now on to `is_empty` and `mem`.
 
 `is_empty t` is true if and only if `t` is empty; this is a post-condition. This
-function also (hopefully) has no side-effect: it does not modify `t`, does not
-depend on any internal state, and does not raise exceptions. In Gospel's
+function also (hopefully) has no side-effect: it doesn't modify `t`, 
+depend on any internal state, or raise exceptions. In Gospel's
 language, this function is *pure*.
 
 ```ocaml
@@ -123,16 +123,16 @@ val mem: 'a t -> 'a -> bool
     ensures b <-> Set.mem x t.contents *)
 ```
 
-## Mutating arguments and raising exceptions
+## Mutating Arguments and Raising Exceptions
 
-Finally, let us specify `clear` and `add`, which are functions that mutate the
+Finally, let's specify `clear` and `add`, which are functions that mutate the
 container.
 
-The function `clear` removes all elements from its argument: it is empty after the
+The function `clear` removes all elements from its argument, meaning it's empty after the
 call. Obviously, it modifies the `contents` model of its argument. After its
 execution, the container should be empty. Note that we are only allowed to
-mention `is_empty` in the specification because it is a pure function;
-attempting to use a non-pure OCaml function in a specification will result in a
+mention `is_empty` in the specification because it's a *pure* function. 
+Attempting to use a non-pure OCaml function in a specification will result in a
 Gospel error.
 
 ```ocaml
@@ -143,7 +143,7 @@ val clear: 'a t -> unit
 ```
 
 A first attempt at specifying `add` is similar to the previous examples. We use
-Gospel's `old` primitive to refer to the state of the container prior to the
+Gospel's `old` primitive to refer to the container's state prior to the
 function execution:
 
 ```ocaml
@@ -153,8 +153,8 @@ val add: 'a t -> 'a -> unit
     ensures t.contents = Set.add x (old t.contents) *)
 ```
 
-Notice, however, that this specification is incomplete. Indeed, one specificity
-of this function is that it can raise `Full`. Let us complete that contract with
+However, notice that this specification is incomplete. One specificity
+of this function is that it can raise `Full`, so let's complete that contract with
 this piece of information. If `add` raises `Full`, we can deduce that `t.contents`
 already contains `t.capacity` elements.
 
@@ -171,16 +171,16 @@ val add: 'a t -> 'a -> unit
 Since we have a `modifies` clause, the contents of `t` may be mutated even when
 `Full` is raised. The last line of specification forbids such a behavior.
 
-Notice how we did not need to repeat that `S.cardinal t.contents <= t.capacity`
-in every contract; as a type invariant, this property implicitly holds in every
+Notice how we didn't need to repeat that `S.cardinal t.contents <= t.capacity`
+in every contract. As a type invariant, this property implicitly holds in every
 function's pre-state and post-state.
 
-## Type-checking your specification
+## Type-Checking Your Specification
 
-We're done! Our module interface is fully specified, independently of any
+We're done! Our module interface is fully specified and independent of any
 implementation. The full example is available in
 [container.mli](./container.mli) in case you want to play with it.
-Let's finish by verifying that these are well-typed, and call Gospel's
+Let's finish by verifying that these are well-typed and call Gospel's
 type-checker:
 
 ```shell

--- a/docs/docs/getting-started/first-spec.md
+++ b/docs/docs/getting-started/first-spec.md
@@ -103,7 +103,7 @@ val create: int -> 'a t
 Now on to `is_empty` and `mem`.
 
 `is_empty t` is true if and only if `t` is empty; this is a post-condition. This
-function also (hopefully) has no side-effect: it doesn't modify `t`, 
+function also (hopefully) has no side-effect: it doesn't modify `t`,
 depend on any internal state, or raise exceptions. In Gospel's
 language, this function is *pure*.
 
@@ -131,7 +131,7 @@ container.
 The function `clear` removes all elements from its argument, meaning it's empty after the
 call. Obviously, it modifies the `contents` model of its argument. After its
 execution, the container should be empty. Note that we are only allowed to
-mention `is_empty` in the specification because it's a *pure* function. 
+mention `is_empty` in the specification because it's a *pure* function.
 Attempting to use a non-pure OCaml function in a specification will result in a
 Gospel error.
 

--- a/docs/docs/getting-started/going-further.md
+++ b/docs/docs/getting-started/going-further.md
@@ -7,9 +7,10 @@ sidebar_position: 4
 This tutorial only covered very few features of Gospel. Please feel free to
 visit our other resources before getting started:
 
-- If you like to learn by example, the [walk-through](../walkthroughs/introduction.md) section
-  contains a gallery of more advanced use cases extracted from real-world
-  interfaces. Those should help you familiarize yourself with the formal specification process.
+- If you like to learn by example, the
+  [walk-through](../walkthroughs/introduction.md) section contains a gallery of
+  more advanced use cases extracted from real-world interfaces. Those should
+  help you familiarize yourself with the formal specification process.
 
 - If you prefer to read the manual for more in-depth information on specific
   features of the language, you may also visit the [language

--- a/docs/docs/getting-started/going-further.md
+++ b/docs/docs/getting-started/going-further.md
@@ -2,21 +2,20 @@
 sidebar_position: 4
 ---
 
-# Going further
+# Going Further
 
 This tutorial only covered very few features of Gospel. Please feel free to
 visit our other resources before getting started:
 
 - If you like to learn by example, the [walk-through](../walkthroughs/introduction.md) section
-  contains a gallery of more advanced use-cases extracted from real-world
-  interfaces. Those should help you familiarize yourself with the process of
-  formal specification.
+  contains a gallery of more advanced use cases extracted from real-world
+  interfaces. Those should help you familiarize yourself with the formal specification process.
 
 - If you prefer to read the manual for more in-depth information on specific
   features of the language, you may also visit the [language
   reference](../language/syntax) section.
 
-Finally, we are always thrilled to hear your thoughts or questions regarding
+Finally, we're always thrilled to hear your thoughts or questions regarding
 Gospel and this tutorial. Please feel free to [open a
 discussion](https://github.com/ocaml-gospel/gospel/discussions/new) and share
 your issues and ideas!

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -4,8 +4,8 @@ sidebar_position: 1
 
 # Installing Gospel
 
-Please make sure that you already have a decently recent version of `ocaml` and
-`opam` installed. Gospel requires the following versions:
+Please make sure that you already have a decently recent version of OCaml and
+Opam installed. Gospel requires the following versions:
 
 - OCaml 4.09.0 or newer
 - Opam 2.0 or newer

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 Please make sure that you already have a decently recent version of OCaml and
 Opam installed. Gospel requires the following versions:
 
-- OCaml 4.09.0 or newer
+- OCaml 4.11 or newer
 - Opam 2.0 or newer
 
 Please visit [ocaml.org](https://ocaml.org/learn/tutorials/up_and_running.html)

--- a/docs/docs/getting-started/tools.md
+++ b/docs/docs/getting-started/tools.md
@@ -48,7 +48,7 @@ Why3gospel is a [Why3](https://why3.lri.fr) plugin that lets you verify that a
 program proof refines the Gospel specifications before extracting it to OCaml.
 
 It interfaces the Why3 framework with the Gospel specifications to ensure that
-the former refines the latter and guarantees that OCaml programs extracted from
+the former refines the latter and to guarantee that OCaml programs extracted from
 proved WhyML comply with their Gospel specification.
 
 For more information, please visit the project page [on

--- a/docs/docs/getting-started/tools.md
+++ b/docs/docs/getting-started/tools.md
@@ -10,9 +10,9 @@ Your specification alone is already helpful, as it completes the
 docstring, which may be incomplete or ambiguous. That could lead to incorrect
 interpretations of your semantics, or wrong usage of your library.
 
-Besides the `gospel` binary, we also provide a developer API which lets
-other tools leverage these specifications to provide different features. Such
-tools already exist and let you benefit from the specification, which brings more
+Besides the `gospel` binary, we also provide a developer API which lets other
+tools leverage these specifications to provide different features. Such tools
+already exist and let you benefit from the specification, which brings more
 guarantees to your programs.
 
 ## Cameleer
@@ -47,8 +47,8 @@ Why3gospel is a [Why3](https://why3.lri.fr) plugin that lets you verify that a
 program proof refines the Gospel specifications before extracting it to OCaml.
 
 It interfaces the Why3 framework with the Gospel specifications to ensure that
-the former refines the latter and to guarantee that OCaml programs extracted from
-proved WhyML comply with their Gospel specification.
+the former refines the latter and to guarantee that OCaml programs extracted
+from proved WhyML comply with their Gospel specification.
 
 For more information, please visit the project page [on
 Github](https://github.com/ocaml-gospel/why3gospel).

--- a/docs/docs/getting-started/tools.md
+++ b/docs/docs/getting-started/tools.md
@@ -31,13 +31,12 @@ Github](https://github.com/ocaml-gospel/cameleer).
 
 ## Ortac
 
-Ortac is a runtime verification tool for OCaml programs.
+Ortac is a testing tool for OCaml programs.
 
-It reads the Gospel annotations in the interfaces and generates code that
-automatically checks them at runtime. It is implementation-agnostic and quite
-flexible. You may use it to trigger exceptions when violations occur, monitor
-your program execution by logging unexpected events, or generate testing suites
-and fuzzers.
+It reads the Gospel specifications in the interfaces and generates code to test
+that they hold at runtime. It comes with a couple of plugins that provide
+different ways to run those tests. You may use it to generate testing suites and
+fuzzers or monitor your program execution.
 
 For more information, please visit the project page [on
 Github](https://github.com/ocaml-gospel/ortac).

--- a/docs/docs/getting-started/tools.md
+++ b/docs/docs/getting-started/tools.md
@@ -2,17 +2,17 @@
 sidebar_position: 3
 ---
 
-# Now what?
+# Now What?
 
 You've written your first specification. Now what can you do with it?
 
-Well, your specification alone is already helpful, as it completes the
-docstring, which may be incomplete or ambiguous, leading to wrong
+Your specification alone is already helpful, as it completes the
+docstring, which may be incomplete or ambiguous. That could lead to incorrect
 interpretations of your semantics, or wrong usage of your library.
 
-But besides the `gospel` binary, we also provide a developer API which lets
+Besides the `gospel` binary, we also provide a developer API which lets
 other tools leverage these specifications to provide different features. Such
-tools already exist, and let you benefit from the specification to bring more
+tools already exist and let you benefit from the specification, which brings more
 guarantees to your programs.
 
 ## Cameleer
@@ -21,7 +21,7 @@ Cameleer is a tool for deductive verification of OCaml code.
 
 It extends Gospel to implementation files, where you may add logical annotations
 like logical assertions, loop invariants, or termination arguments. The
-verification relies on the [Why3](https://why3.lri.fr) framework: `cameleer`
+verification relies on the [Why3](https://why3.lri.fr) framework. Cameleer
 translates the OCaml code into an equivalent WhyML program. It then lets you
 analyse this program within the framework (and its IDE!) to prove the
 assertions via semi-automated techniques based on SMT provers.
@@ -35,7 +35,7 @@ Ortac is a runtime verification tool for OCaml programs.
 
 It reads the Gospel annotations in the interfaces and generates code that
 automatically checks them at runtime. It is implementation-agnostic and quite
-flexible: you may use it to trigger exceptions when violations occur, monitor
+flexible. You may use it to trigger exceptions when violations occur, monitor
 your program execution by logging unexpected events, or generate testing suites
 and fuzzers.
 
@@ -48,8 +48,8 @@ Why3gospel is a [Why3](https://why3.lri.fr) plugin that lets you verify that a
 program proof refines the Gospel specifications before extracting it to OCaml.
 
 It interfaces the Why3 framework with the Gospel specifications to ensure that
-the former refines the latter, guaranteeing that OCaml programs extracted from
-proved WhyML indeed comply with their Gospel specification.
+the former refines the latter and guarantees that OCaml programs extracted from
+proved WhyML comply with their Gospel specification.
 
 For more information, please visit the project page [on
 Github](https://github.com/ocaml-gospel/why3gospel).

--- a/docs/docs/language/attributes.md
+++ b/docs/docs/language/attributes.md
@@ -2,7 +2,7 @@
 sidebar_position: 10
 ---
 
-# Appendix: Gospel in OCaml attributes
+# Appendix: Gospel in OCaml Attributes
 
 Gospel processes a file in various stages:
 
@@ -14,10 +14,10 @@ Gospel processes a file in various stages:
 [OCaml attributes]: https://caml.inria.fr/pub/docs/manual-ocaml/attributes.html
 
 Gospel uses OCaml attributes with the identifier `gospel` to bear the Gospel
-specifications in their payload, as strings: `[@@gospel "<spec>"]` and
+specifications in their payload as strings: `[@@gospel "<spec>"]` and
 `[@@@gospel "<spec>"]`.
 
-## Floating attributes
+## Floating Attributes
 
 [Ghost and logical declarations](logical.md) must lie in floating attributes,
 inside module signatures:
@@ -27,7 +27,7 @@ inside module signatures:
 [@@@gospel "predicate is_zero (x: integer) = x = 0"]
 ```
 
-## Attached attributes
+## Attached Attributes
 
 Specification bits which are semantically attached to OCaml declarations (e.g.
 [function contracts](function-contracts.md) or [type
@@ -39,7 +39,7 @@ val f: int -> int
 [@@gospel "y = f x ensures x > 0"]
 ```
 
-## Specification of ghost and logical declarations
+## Specification of Ghost and Logical Declarations
 
 When ghost and logical declarations need to be specified with a contract, the
 contract should reside in an attribute attached to the string containing the
@@ -50,7 +50,7 @@ declaration:
   [@@gospel "y = f x ensures x > 0"]]
 ```
 
-## Gospel preprocessor
+## Gospel Preprocessor
 
 The preprocessor is available via the `gospel pps` command. It is also applied
 automatically on type-checking, so you should not have to worry about manually

--- a/docs/docs/language/constant-specifications.md
+++ b/docs/docs/language/constant-specifications.md
@@ -18,4 +18,4 @@ val argv : string array
 (*@ ensures Array.length argv >= 1 *)
 ```
 
-These clauses hold at the end the surrounding module evaluation.
+These clauses hold at the end of the surrounding module evaluation.

--- a/docs/docs/language/constant-specifications.md
+++ b/docs/docs/language/constant-specifications.md
@@ -2,7 +2,7 @@
 sidebar_position: 5
 ---
 
-# Constant specifications
+# Constant Specifications
 
 OCaml constant specifications are simple. They consist of a list of clauses
 starting with the `ensures` keyword followed by a formula.
@@ -18,4 +18,4 @@ val argv : string array
 (*@ ensures Array.length argv >= 1 *)
 ```
 
-These clauses hold at the end of evaluating the surrounding module.
+These clauses hold at the end the surrounding module evaluation.

--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -223,7 +223,7 @@ part of its expected behaviour, this exception must be listed along with the
 associated postconditions.
 :::info
 
-Some exceptions are implicitly allowed and do not have to be listed because 
+Some exceptions are implicitly allowed and do not have to be listed because
 they could be unexpectedly triggered, depending on the specifics of the machine
 the code is executed on.
 

--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Function contracts
+# Function Contracts
 
 A function contract is a formal Gospel specification attached to the declaration
 of an OCaml function in an interface. Here is an example:
@@ -17,10 +17,10 @@ val euclidean_division: int -> int -> int * int
 
 A function contract is composed of two parts:
  - The first line is the **header** of the contract; it names the function
-   arguments and result. It must appear at the beginning of the contract.
+   arguments and result and must appear at the beginning of the contract.
  - The next lines contain as many specification `clauses` as needed. The
-   previous example features three clauses: one pre-condition introduced by
-   `requires`, and two post-conditions introduced by `ensures`.
+   previous example features three clauses: one precondition introduced by
+   `requires` and two postconditions introduced by `ensures`.
 
 ```ebnf title="Function contract syntax"
 contract = header? clause*
@@ -54,7 +54,7 @@ the following systematic order for uniformity:
 
 :::
 
-##  Default behaviour
+##  Default Behaviour
 
 To avoid boilerplate for usual properties, Gospel applies a default contract
 whenever a function has a specification attached. Of course, any
@@ -73,11 +73,11 @@ following properties:
 
    In the absence of a contract attached to a function declaration, you cannot
    make any assumptions about its behaviour: the function may diverge, raise
-   unlisted exceptions, modify mutable states, etc. However, **it still cannot
+   unlisted exceptions, or modify mutable states. However, **it still cannot
    break any type invariant.**
 
    You can still enable the default implicit properties about exceptions, mutability,
-   non-termination, etc. by creating an empty contract:
+   non-termination, etc., by creating an empty contract:
 
    ```ocaml
    val euclidean_division: int -> int -> int * int
@@ -86,13 +86,13 @@ following properties:
 
 :::
 
-## Pre-conditions
+## Preconditions
 
-Pre-conditions are **properties that must hold at the function entry**. You can use
-them to describe requirements on the function's inputs, but also possibly on a
+Preconditions are **properties that must hold at the function entry**. You can use
+them to describe requirements on the function's inputs, but you can also possibly use them on a
 global state that exists outside of the function arguments.
 
-You can express pre-conditions using the keyword `requires` or `checks`, followed by a
+You can express preconditions using the keyword `requires` or `checks` followed by a
 formula.
 
 ### `requires`
@@ -100,10 +100,10 @@ formula.
 A `requires` clause states under which conditions a specified function has a
 well-specified behaviour.
 
-Whenever a `requires` pre-condition is violated, its behaviour becomes
+Whenever a `requires` precondition is violated, its behaviour becomes
 unspecified, and the call should be considered faulty. Even if the function
 execution terminates, any other information provided by the contract
-(post-conditions, exceptions, effects, ...) cannot be assumed.
+(postconditions, exceptions, effects, ...) cannot be assumed.
 
 For example, the following function requires `y` to be positive to behave correctly.
 
@@ -117,10 +117,10 @@ val eucl_division: int -> int -> int * int
 
 ### `checks`
 
-Pre-conditions introduced with `checks` hold at function entry. However, unlike
-`requires` clauses, the behaviour of the function is well specified in case the
-pre-state does not meet such a pre-condition: the function fails by raising an
-OCaml `Invalid_argument` exception, and does not modify any existing state. The
+Preconditions introduced with `checks` hold at function entry. However, unlike
+`requires` clauses, the behaviour of the function is well-specified in case the
+prestate doesn't meet such a precondition. The function fails by raising an
+OCaml `Invalid_argument` exception and doesn't modify any existing state. The
 call is not faulty, but the caller is now in charge of handling the exception.
 
 For example, if we change the function contract of `eucl_division`
@@ -130,7 +130,7 @@ function raises `Invalid_argument` whenever `y <= 0`.
 :::note Combining multiple pre-conditions
 
 
-Whenever multiple pre-conditions of the same kind coexist, they hold as a
+Whenever multiple preconditions of the same kind coexist, they hold as a
 conjunction, which means
 
 ```ocaml invalidSyntax
@@ -145,9 +145,9 @@ is equivalent to:
     requires P /\ Q *)
 ```
 
-When combining `checks` and `requires` pre-conditions, the declaration order
-does not matter. The `requires` clauses take precedence and must always be
-respected; otherwise the `checks` behaviour cannot be assumed. This means that
+When combining `checks` and `requires` preconditions, the declaration order
+doesn't matter. The `requires` clauses take precedence and must always be
+respected; otherwise, the `checks` behaviour cannot be assumed. This means that
 ultimately,
 
 ```ocaml invalidSyntax
@@ -173,29 +173,29 @@ maintainability and is therefore encouraged.
 :::
 
 
-## Post-conditions
+## Postconditions
 
-Post-Conditions are **properties that hold at the function exit**. They are used
+Postconditions are **properties that hold at the function exit**. They are used
 to specify how the function's outputs relate to its inputs and how the call
 mutated the memory.
 
 :::caution
 
-  **When a function raises an exception, its post-conditions are not expected to
-  hold.** You must use exceptional post-conditions instead.
+  **When a function raises an exception, its postconditions are not expected to
+  hold.** You must use exceptional postconditions instead.
 
 :::
 
-Gospel introduces post-conditions using the keyword `ensures`, followed by a
+Gospel introduces postconditions using the keyword `ensures` followed by a
 formula.
 
 As discussed in the previous section, the property expressed by the formula is
-verified after the function call only if the pre-conditions were satisfied.
+verified after the function call only if the preconditions were satisfied.
 
-:::note Combining multiple post-conditions
+:::note Combining multiple postconditions
 
-The handling of multiple post-conditions is identical to pre-conditions of the
-same kind: multiple post-conditions are merged as a conjunction:
+The handling of multiple postconditions is identical to preconditions of the
+same kind. Multiple postconditions are merged as a conjunction:
 
 ```ocaml invalidSyntax
 (*@ ...
@@ -212,20 +212,19 @@ is equivalent to:
 
 :::
 
-## Exceptional post-conditions
+## Exceptional Postconditions
 
-Exceptional post-conditions are used to specify the exceptions that can be
-raised by the function, and what post-conditions hold in those cases.
+Exceptional postconditions are used to specify the exceptions that can be
+raised by the function and what postconditions hold in those cases.
 
 By default, functions should not raise any exceptions, and doing so is a
 violation of the specification. Whenever a function can raise an exception as
-part of its expected behaviour, this exception must be listed, along with the
-associated post-conditions.
-
+part of its expected behaviour, this exception must be listed along with the
+associated postconditions.
 :::info
 
-Some exceptions are implicitly allowed and do not have to be listed, because
-they could be unexpectedly triggered depending on the specifics of the machine
+Some exceptions are implicitly allowed and do not have to be listed because 
+they could be unexpectedly triggered, depending on the specifics of the machine
 the code is executed on.
 
 **The implicitly allowed exceptions are `Stack_overflow` and `Out_of_memory`.**
@@ -243,13 +242,13 @@ other exception:
 :::
 
 Exceptional clauses are expressed using a `raises` keyword, followed by a list
-of cases associating each exception with its formula, with a syntax similar to
+of cases associating each exception with its formula and a syntax similar to
 pattern-matching.
 
-Gospel expects each `raises` clause to perform an exhaustive pattern matching
-for each exception constructor listed in this clause. Similarly to OCaml's
-pattern-matching, when an exception is raised, the post-condition that is
-satisfied is the first match in the list of the cases.
+Gospel expects each `raises` clause to perform an exhaustive pattern-matching
+for each exception constructor listed in this clause. Similar to OCaml's
+pattern-matching, when an exception is raised, the postcondition that's
+satisfied is the first match in the cases' lists.
 
 ```ocaml invalidSyntax
 (*@ ...
@@ -257,15 +256,15 @@ satisfied is the first match in the list of the cases.
          | Unix_error _                    -> Q *)
 ```
 
-In the previous contract (notice that it is an exhaustive pattern-matching on
+The previous contract (notice that it's an exhaustive pattern-matching on
 the `Unix_error` exception) only states that `P` holds whenever `Unix_error` is
-raised with argument `ENAMETOOLONG`, and that `Q` holds whenever the function
-raises `Unix_error` with a different argument (`P` does not necessarily hold in
-this case).
+raised with argument `ENAMETOOLONG`, and `Q` holds whenever the function
+raises `Unix_error` with a different argument. (`P` doesn't necessarily hold in
+this case.)
 
 :::note Combining multiple exceptional post-conditions
 
-When multiple exceptional post-conditions exist, they hold independently of
+When multiple exceptional postconditions exist, they hold independently of
 each other, meaning that the raised exception is matched against each `raises`'s
 case list, and each matching post-condition must hold in conjunction. For
 instance, the contract:
@@ -284,11 +283,11 @@ implies that
 :::
 
 
-## Code equivalence
+## Code Equivalence
 
 Complementary to other specification clauses, Gospel allows you to talk about
-*code equivalence* in the function contract. It consists in a string containing
-the OCaml code the function behaves like, preceded by the `equivalent` keyword.
+*code equivalence* in the function contract. Put it in a string containing
+the OCaml code that behaves like the function, preceded by the `equivalent` keyword.
 
 This is useful when specifying functions whose behaviour can hardly be expressed
 in pure logic:
@@ -304,8 +303,8 @@ val iter : ('a -> unit) -> 'a t -> unit
 ```
 
 With such a specification, no logical assertion is provided, but applying `iter`
-to `f` and `t` is equivalent to applying `List.iter` to `f`, and the conversion
-of `t` to a list. This does not leak implementation details, as `iter` might in
+to `f` and `t` is equivalent to applying `List.iter` to `f` and the conversion
+of `t` to a list. This doesn't leak implementation details, as `iter` might in
 fact be implemented in a different, more efficient way. It does however make the
 specification concise and elegant.
 
@@ -313,20 +312,20 @@ specification concise and elegant.
 :::danger
 
 At the moment, the Gospel type-checker does **not** type-check the code provided
-inside the `equivalent` clauses, and will take it as-is.
+inside the `equivalent` clauses and will take it as-is.
 
 :::
 
-## Non termination
+## Non-Termination
 
 By default, OCaml functions with an attached contract implicitly terminate.
 
-If a function is allowed to not terminate (e.g. a server main loop, a function
+If a function is allowed to not terminate (e.g., a server main loop, a function
 waiting for a signal or event, etc.), one can add this information to the
 contract using the `diverges` keyword.
 
 The following example states that the execution of the function `run` may not
-terminate. It does not specify whether this function is always non-terminating
+terminate. It doesn't specify whether this function is always non-terminating
 or not.
 
 <!-- invalidSyntax: see #317 -->
@@ -336,9 +335,9 @@ val run : unit -> unit
     diverges *)
 ```
 
-## Data mutability
+## Data Mutability
 
-In the default specification, functions do not mutate any observable data. If
+In the default specification, functions don't mutate any observable data. If
 your function mutates an argument or some global state, you may specify it using
 the keyword `modifies`, followed by an identifier. In the following, the
 `contents` model of `a` can be modified by `inplace_map`.
@@ -355,7 +354,6 @@ val inplace_map : ('a -> 'a) -> 'a t -> unit
 If the function only modifies a few models of a value, these may be explicitly
 added to the clause.
 
-
 If a specific model is not mentioned, the whole data structure and its mutable
 models are potentially mutated.
 
@@ -369,11 +367,11 @@ In this example, all the mutable models of `a` can be mutated by `inplace_map`.
 
 :::note
 
-When a `modifies` clause is present, it affects all the declared post-conditions
-and exceptional post-conditions, meaning that the function may mutate data even
-in the case of exceptional post-conditions.
+When a `modifies` clause is present, it affects all the declared postconditions
+and exceptional postconditions, meaning that the function may mutate data even
+in the case of exceptional postconditions.
 
-If your data was not mutated in an exceptional post-state, for instance if the
+If your data was not mutated in an exceptional poststate, for instance if the
 function raised an exception **instead** of mutating the data, you have to
 manually specify it:
 
@@ -387,12 +385,12 @@ val inplace_map : ('a -> 'a) -> 'a t -> unit
 
 :::
 
-## Pure functions
+## Pure Functions
 
-An OCaml function can be declared as `pure`, which means
-- it has no side effect;
-- it raises no exception;
-- it terminates.
+An OCaml function can be declared as `pure`, which means it
+- has no side effect;
+- raises no exception;
+- terminates.
 
 ```ocaml {2}
 val length : 'a t -> int
@@ -403,10 +401,10 @@ Pure functions can be used in further Gospel specifications.
 On the contrary, OCaml functions not declared as `pure` cannot be used
 in specifications.
 
-## Data consumption
+## Data Consumption
 
 Gospel provides a specific syntax to specify that some data has been consumed by
-the function, and should be considered dirty — that is, not be used anymore — in
+the function, and should be considered dirty (that is, not used anymore) in
 the rest of the program. This is expressed with the `consumes`
 keyword:
 
@@ -418,7 +416,7 @@ val destructive_transfer: 'a t -> 'a t -> unit
 ```
 
 
-## Ghost parameters
+## Ghost Parameters
 
 Functions can take or return ghost values to ease the writing of function
 contracts. Such values appear within brackets in the contract header.
@@ -433,8 +431,8 @@ val log2: int -> int
     ensures r = i *)
 ```
 
-In this contract, the ghost parameter `i` is used in both the pre- and
-post-conditions. By introducing it as a ghost value, we avoid using quantifiers to
+In this contract, the ghost parameter `i` is used in both the preconditions and
+postconditions. By introducing it as a ghost value, we avoid using quantifiers to
 state the existence of `i`.
 
 :::note

--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -17,8 +17,8 @@ val euclidean_division: int -> int -> int * int
 
 A function contract is composed of two parts:
  - The first line is the **header** of the contract; it names the function
-   arguments and result and must appear at the beginning of the contract.
- - The next lines contain as many specification `clauses` as needed. The
+   arguments and results and must appear at the beginning of the contract.
+ - The next lines contain as many specification clauses as needed. The
    previous example features three clauses: one precondition introduced by
    `requires` and two postconditions introduced by `ensures`.
 
@@ -242,13 +242,13 @@ other exception:
 :::
 
 Exceptional clauses are expressed using a `raises` keyword, followed by a list
-of cases associating each exception with its formula and a syntax similar to
+of cases associating each exception with its formula. Those clauses use a syntax similar to
 pattern-matching.
 
 Gospel expects each `raises` clause to perform an exhaustive pattern-matching
 for each exception constructor listed in this clause. Similar to OCaml's
 pattern-matching, when an exception is raised, the postcondition that's
-satisfied is the first match in the cases' lists.
+satisfied is the first match in the list of cases.
 
 ```ocaml invalidSyntax
 (*@ ...

--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -432,8 +432,8 @@ val log2: int -> int
 ```
 
 In this contract, the ghost parameter `i` is used in both the preconditions and
-postconditions. By introducing it as a ghost value, we avoid using quantifiers to
-state the existence of `i`.
+postconditions. By introducing it as a ghost value, we avoid using quantifiers
+to state the existence of `i`.
 
 :::note
 

--- a/docs/docs/language/lexical-conventions.md
+++ b/docs/docs/language/lexical-conventions.md
@@ -2,12 +2,12 @@
 sidebar_position: 2
 ---
 
-# Lexical conventions
+# Lexical Conventions
 
 Gospel borrows most of [OCaml's lexical
 conventions](https://caml.inria.fr/pub/docs/manual-ocaml/lex.html).
-This means that the whitespace rules are the same, that the same kind
-of variable names are allowed, that integers are written the same way,
+This means that the whitespace rules are the same. The same kind
+of variable names are allowed, integers are written the same way,
 etc. There are however a number of exceptions:
 
 - There are extra reserved keywords:

--- a/docs/docs/language/lexical-conventions.md
+++ b/docs/docs/language/lexical-conventions.md
@@ -22,6 +22,6 @@ etc. There are however a number of exceptions:
   <->    /\    \/
   ```
 
-- There is an extra literal modifier for literals of type `int`. Unmodified 
+- There is an extra literal modifier for literals of type `int`. Unmodified
   literals (e.g. `42`) are of type `integer`, but Gospel adds a `i` modifier to
   write literals of type `int` (e.g. `42i`).

--- a/docs/docs/language/logical.md
+++ b/docs/docs/language/logical.md
@@ -95,8 +95,8 @@ that Fibonacci numbers are non-negative:
 
 :::info
 
-Note that as opposed to OCaml function contracts, logical function contracts don't 
-have a header. Consequently, Gospel automatically introduces a variable called `result` 
+Note that as opposed to OCaml function contracts, logical function contracts don't
+have a header. Consequently, Gospel automatically introduces a variable called `result`
 in the context to refer to the value returned by the
 function in a postcondition.
 

--- a/docs/docs/language/logical.md
+++ b/docs/docs/language/logical.md
@@ -4,7 +4,7 @@ sidebar_position: 7
 
 # Logical Declarations
 
-## Functions, predicates and axioms
+## Functions, Predicates and Axioms
 
 It's often convenient to introduce shortcuts for terms and formulas to avoid
 repetitions. *Predicates* let you write named formulae definitions in Gospel

--- a/docs/docs/language/logical.md
+++ b/docs/docs/language/logical.md
@@ -2,11 +2,11 @@
 sidebar_position: 7
 ---
 
-# Logical declarations
+# Logical Declarations
 
 ## Functions, predicates and axioms
 
-It is often convenient to introduce shortcuts for terms and formulas to avoid
+It's often convenient to introduce shortcuts for terms and formulas to avoid
 repetitions. *Predicates* let you write named formulae definitions in Gospel
 comments. Here is a typical example:
 
@@ -56,7 +56,7 @@ Finally, it is also possible to define *axioms*, for instance:
 (*@ axiom unbounded_integers : forall i. exists j. j > i *)
 ```
 
-## Logical function contracts
+## Logical Function Contracts
 
 Similarly to OCaml functions, contracts can be added to logical declarations.
 
@@ -66,7 +66,7 @@ Similarly to OCaml functions, contracts can be added to logical declarations.
 (*@ requires n >= 0 *)
 ```
 
-Such a contract does not prevent you from calling `fibonacci` on negative
+Such a contract doesn't prevent you from calling `fibonacci` on negative
 integers. For instance, `fibonacci (-1)` is a valid Gospel term. However, we
 know nothing about its value: the definition of `fibonacci` holds only when its
 precondition is true.
@@ -83,7 +83,7 @@ follows:
         else fibonacci (n-2) + fibonacci (n-1) *)
 ```
 
-Logical symbols can also come with post-conditions. For instance, we can assert
+Logical symbols can also come with postconditions. For instance, we can assert
 that Fibonacci numbers are non-negative:
 
 ```ocaml {4}
@@ -95,31 +95,31 @@ that Fibonacci numbers are non-negative:
 
 :::info
 
-Note that as opposed to OCaml function contracts, logical function contracts do
-not have a header. Consequently, a variable called `result` is automatically
-introduced in the context by Gospel to refer to the value returned by the
-function in a post-condition.
+Note that as opposed to OCaml function contracts, logical function contracts don't 
+have a header. Consequently, Gospel automatically introduces a variable called `result` 
+in the context to refer to the value returned by the
+function in a postcondition.
 
 :::
 
-The post-condition of `fibonacci` is equivalent to adding an axiom along with an
+The postcondition of `fibonacci` is equivalent to adding an axiom along with an
 uninterpreted counterpart.
 
 ```ocaml
 (*@ axiom fibonacci_post : forall n. n >= 0 -> fibonacci n >= 0 *)
 ```
 
-Note that the post-condition holds only when the pre-condition holds.
+Note that the postcondition holds only when the precondition holds.
 
 :::danger
 
-Gospel does not perform any verification beyond type-checking. If you wish to
-verify that the definition indeed complies with its contract, you need to use an
+Gospel doesn't perform any verification beyond type-checking. If you wish to
+verify that the definition indeed complies with its contract, you must use an
 external tool such as [Why3Gospel](https://github.com/ocaml-gospel/why3gospel).
 
 :::
 
-## Termination arguments
+## Termination Arguments
 
 Using recursive definitions in the logical domain can introduce inconsistencies.
 For instance, consider the following recursive function:
@@ -128,11 +128,11 @@ For instance, consider the following recursive function:
 (*@ function rec f (n: integer): integer = f n + 1 *)
 ```
 
-As explained above, it is perfectly fine to mention `f 0` in a formula. Although
-we do not know its value, we know that `f 0 = f 0 + 1`, thus `0 = 1`, which is
+As explained above, it's perfectly fine to mention `f 0` in a formula. Although
+we don't know its value, we know that `f 0 = f 0 + 1`, thus `0 = 1`, which is
 obviously inconsistent.
 
-In order to prevent this, it is a good practice to provide a termination
+In order to prevent this, it's a good practice to provide a termination
 argument for each recursive definition. Gospel provides one way of doing this
 via *variants*.
 
@@ -145,9 +145,9 @@ via *variants*.
 
 :::danger
 
-Similarly to contracts, Gospel does not perform any verification that the
-variant indeed ensures the termination, it will only checks that it is of type
-integer. It is up to an external tool to exploit the expression given as
+Similarly to contracts, Gospel doesn't perform any verification that the
+variant indeed ensures the termination, it will only checks that it's of type
+integer. It's up to an external tool to exploit the expression given as
 `variant` to check termination.
 
 :::

--- a/docs/docs/language/scope.md
+++ b/docs/docs/language/scope.md
@@ -2,7 +2,7 @@
 sidebar_position: 8
 ---
 
-# Symbols in scope
+# Symbols in Scope
 
 Gospel checks that only symbols that are meaningful are in scope.
 

--- a/docs/docs/language/syntax.md
+++ b/docs/docs/language/syntax.md
@@ -2,13 +2,13 @@
 sidebar_position: 1
 ---
 
-# Gospel special comment syntax
+# Gospel Special Comment Syntax
 
 Gospel specifications are written in interface files (`.mli`). They are written
 in special comments, starting with the `@` character[^1]:
 
 [^1]: Existing specification languages for other host languages introduced this
-    notation, *e.g.* [JML](https://www.cs.ucf.edu/~leavens/JML/index.shtml) for
+    notation, *e.g.,* [JML](https://www.cs.ucf.edu/~leavens/JML/index.shtml) for
     Java and [ACSL](https://frama-c.com/html/acsl.html) for C. Hence Gospel
     also uses this convention.
 
@@ -51,10 +51,10 @@ Error: Syntax error.
 :::
 
 
-## Specifications and documentation comments
+## Specifications and Documentation Comments
 
 Note that Gospel annotations can be combined with traditional documentation
-comments, *e.g.* as follows:
+comments. For example:
 
 ```ocaml invalidSyntax
 val eucl_division: int -> int -> int * int

--- a/docs/docs/language/syntax.md
+++ b/docs/docs/language/syntax.md
@@ -25,6 +25,32 @@ val f: int -> int           (* An OCaml value declaration *)
 Those comments must be located _after_ the item they specify.
 
 
+:::tip
+
+Gospel is using a preprocessor to turn those special comments into OCaml
+attributes behind the scene before feeding the result to the standard OCaml
+parser (see the [appendix page](attributes) for more information).
+
+This has the following consequence: Gospel special comments can only appear at a
+positions where OCaml accepts attributes. So given the following interface
+`misplaced.mli`:
+
+```ocaml invalidSyntax
+val f : int -> (*@ misplaced *) int
+```
+
+`gospel check misplaced.mli` will complain with the following somewhat
+surprising message:
+
+```
+1 | val f : int -> (*@ misplaced *) int
+                   ^^^
+Error: Syntax error.
+```
+
+:::
+
+
 ## Specifications and documentation comments
 
 Note that Gospel annotations can be combined with traditional documentation

--- a/docs/docs/language/syntax.md
+++ b/docs/docs/language/syntax.md
@@ -12,8 +12,7 @@ in special comments, starting with the `@` character[^1]:
     Java and [ACSL](https://frama-c.com/html/acsl.html) for C. Hence Gospel
     also uses this convention.
 
-<!-- invalidSyntax: see #320 -->
-```ocaml invalidSyntax
+```ocaml
 val f: int -> int           (* An OCaml value declaration *)
 (*@ y = f x
     ensures x > 0 *)        (* Its Gospel specification   *)

--- a/docs/docs/language/type-specifications.md
+++ b/docs/docs/language/type-specifications.md
@@ -73,8 +73,8 @@ Only use `ephemeral` when there is mutability that cannot be guessed otherwise.
 
 ## Invariants
 
-Type annotations may also contain invariants that hold at every function's entry and exit
-point that manipulates their values. Formulae expressing these
+Type annotations may also contain invariants that hold at every function's entry
+and exit point that manipulates their values. Formulae expressing these
 properties may be added after the `invariant` keyword:
 
 ```ocaml {4}
@@ -84,5 +84,5 @@ type 'a t
     with t invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
-Note that functions may break these invariants internally, but they must restore them
-so that they still hold at the function exit.
+Note that functions may break these invariants internally, but they must restore
+them so that they still hold at the function exit.

--- a/docs/docs/language/type-specifications.md
+++ b/docs/docs/language/type-specifications.md
@@ -2,7 +2,7 @@
 sidebar_position: 4
 ---
 
-# Type specifications
+# Type Specifications
 
 OCaml types can be annotated with Gospel specifications in order to model their
 contents and express invariants. Consider the following example of a container
@@ -16,13 +16,13 @@ type 'a t
 ```
 
 The specification of this type contains three elements:
- - the first two lines are models. They represent the type `t` in the logical
+ - The first two lines are models. They represent the type `t` in the logical
    domain. `capacity` is an immutable model of type `int` representing the
    maximum length of the data-structure, and `contents` is a mutable set
    representing its contents. Note that `Set.t` references a logical set
-   provided by Gospel's [standard library](../stdlib). Models do not
+   provided by Gospel's [standard library](../stdlib). Models don't
    give any information on the actual implementation of `t`.
- - the last line is a clause denoting a type invariant. At all times, values of
+ - The last line is a clause denoting a type invariant. At all times, values of
    type `t` should contain less elements that their maximum capacity.
 
 Type specifications can contain models, invariants, and mutability information.
@@ -41,8 +41,8 @@ exposing them and leaking implementation details.
 
 The keyword `model` is used to introduce a new model. It may be preceded by the
 keyword `mutable` to denote that the model may be mutated during the execution
-of the program, e.g. by a function call. It is then followed by a type annotated
-name for that model, in a fashion similar to OCaml's record fields.
+of the program, e.g., by a function call. It's followed by a type-annotated
+name for that model in a fashion similar to OCaml's record fields.
 
 ```ocaml {2,3}
 type 'a t
@@ -51,7 +51,7 @@ type 'a t
     with t invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
-## Mutable types
+## Mutable Types
 
 Gospel lets you specify when a type may contain some mutable state by using the
 keyword `ephemeral` in its annotation:
@@ -73,8 +73,8 @@ Only use `ephemeral` when there is mutability that cannot be guessed otherwise.
 
 ## Invariants
 
-Type annotations may also contain invariants that hold at every entry and exit
-point of every function that manipulates their values. Formulae expressing these
+Type annotations may also contain invariants that hold at every function's entry and exit
+point that manipulates their values. Formulae expressing these
 properties may be added after the `invariant` keyword:
 
 ```ocaml {4}
@@ -84,5 +84,5 @@ type 'a t
     with t invariant Set.cardinal t.contents <= t.capacity *)
 ```
 
-Note that functions may break these invariants internally, but must restore them
+Note that functions may break these invariants internally, but they must restore them
 so that they still hold at the function exit.

--- a/docs/docs/walkthroughs/fibonacci.md
+++ b/docs/docs/walkthroughs/fibonacci.md
@@ -72,7 +72,8 @@ The contract is pretty straightforward:
   - The first precondition states that `n` must be non-negative. If `n`
     is negative, the function raises an exception, so this is a strong
     requirement.
-  - The second precondition states that `a` and `b` are consecutive Fibonacci numbers.
+  - The second precondition states that `a` and `b` are consecutive Fibonacci
+    numbers.
   - The postcondition specifies that if `a` is the `i`th Fibonacci number, and
     `b` is the `i+1`th Fibonacci number, then `r` (the result of the
     computation) is the `i+n`th Fibonacci number.
@@ -103,8 +104,8 @@ second clause). We don't need to repeat the previous condition on `i` either.
 If it holds in the prestate, then it also holds in the poststate because nothing
 here is mutable.
 
-This contract is much easier to write, and more importantly, it's much easier to read
-and to reason about. We cheated a bit though: `fib` does not take this `i`
+This contract is much easier to write, and more importantly, it's much easier to
+read and to reason about. We cheated a bit though: `fib` does not take this `i`
 argument, so modifying it for the sole purpose of specification seems quite
 intrusive.
 

--- a/docs/docs/walkthroughs/fibonacci.md
+++ b/docs/docs/walkthroughs/fibonacci.md
@@ -103,8 +103,8 @@ second clause). We don't need to repeat the previous condition on `i` either.
 If it holds in the prestate, then it also holds in the poststate because nothing
 here is mutable.
 
-This contract is much easier to write, and more importantly, it's much more rational
-and easier to read. We cheated a bit though: `fib` does not take this `i`
+This contract is much easier to write, and more importantly, it's much easier to read
+and to reason about. We cheated a bit though: `fib` does not take this `i`
 argument, so modifying it for the sole purpose of specification seems quite
 intrusive.
 

--- a/docs/docs/walkthroughs/fibonacci.md
+++ b/docs/docs/walkthroughs/fibonacci.md
@@ -33,7 +33,7 @@ uninterpreted logical function along with an axiom defining it.
 (*@ axiom a:
          fibonacci 0 = 0
       /\ fibonacci 1 = 1
-      /\ forall n. n >= 2 -> fibonacci n = fibonacci (n-1) + fibonacci (n-2) *) 
+      /\ forall n. n >= 2 -> fibonacci n = fibonacci (n-1) + fibonacci (n-2) *)
 ```
 
 Below is an implementation of such a function. When `a` and `b` are two
@@ -76,7 +76,7 @@ The contract is pretty straightforward:
   - The postcondition specifies that if `a` is the `i`th Fibonacci number, and
     `b` is the `i+1`th Fibonacci number, then `r` (the result of the
     computation) is the `i+n`th Fibonacci number.
-    
+
 Although this specification isn't complicated, it's
 quite verbose and repetitive. The term `i >= 0 /\ a = fibonacci i /\ b =
 fibonacci (i+1)` is repeated, and it actually refers to the same value of `i`
@@ -99,7 +99,7 @@ val fib : i:int -> int -> int -> int -> int
 
 We don't need to quantify over `i` anymore, since it's provided to the
 function, but we still need to state the preconditions that apply to it (see the
-second clause). We don't need to repeat the previous condition on `i` either. 
+second clause). We don't need to repeat the previous condition on `i` either.
 If it holds in the prestate, then it also holds in the poststate because nothing
 here is mutable.
 
@@ -111,7 +111,7 @@ intrusive.
 To overcome this issue, Gospel provides *ghost parameters*. It lets you
 introduce logical arguments (or return values) that don't exist initially, so
 you can use them in the specifications and hopefully make them easier to
-understand. 
+understand.
 
 Thus, we can rewrite our last attempt by using this feature and benefit from
 `i` being an argument without actually modifying the OCaml interface or

--- a/docs/docs/walkthroughs/fibonacci.md
+++ b/docs/docs/walkthroughs/fibonacci.md
@@ -2,9 +2,9 @@
 sidebar_position: 2
 ---
 
-# Fibonacci numbers
+# Fibonacci Numbers
 
-In this example, we will look into specifying an efficient implementation of a
+In this example, we'll look into specifying an efficient implementation of a
 function computing Fibonacci numbers. This example is adapted from the article
 _The Spirit of Ghost Code_[^1].
 
@@ -14,7 +14,7 @@ _The Spirit of Ghost Code_[^1].
     ⟨[10.1007/s10703-016-0243-x](https://dx.doi.org/10.1007/s10703-016-0243-x)⟩.
     ⟨[hal-01396864](https://hal.archives-ouvertes.fr/hal-01396864v1)⟩
 
-## The problem
+## The Problem
 
 Recall that [Fibonacci numbers](https://en.wikipedia.org/wiki/Fibonacci_number)
 are defined as follows:
@@ -25,7 +25,7 @@ F_1 = 1\\
 F_i = F_{i-1} + F_{i-2}
 $$
 
-To begin with, let us introduce this definition into the Gospel world, using an
+To begin, let's introduce this definition into the Gospel world by using an
 uninterpreted logical function along with an axiom defining it.
 
 ```ocaml
@@ -36,7 +36,7 @@ uninterpreted logical function along with an axiom defining it.
       /\ forall n. n >= 2 -> fibonacci n = fibonacci (n-1) + fibonacci (n-2) *) 
 ```
 
-Here is an implementation of such a function. When `a` and `b` are two
+Below is an implementation of such a function. When `a` and `b` are two
 consecutive Fibonacci numbers, the following function computes the `n`th number
 ahead of `a`. Hence, `fib n 0 1` is the `n`th Fibonacci number.
 
@@ -53,9 +53,9 @@ Its signature is simple:
 val fib : int -> int -> int -> int
 ```
 
-## A simple contract
+## A Simple Contract
 
-Let us write a first contract for this interface.
+Let's write a first contract for this interface.
 
 ```ocaml
 val fib : int -> int -> int -> int
@@ -69,7 +69,7 @@ val fib : int -> int -> int -> int
 ```
 
 The contract is pretty straightforward:
-  - The first precondition states that `n` must be non-negative. Indeed, if `n`
+  - The first precondition states that `n` must be non-negative. If `n`
     is negative, the function raises an exception, so this is a strong
     requirement.
   - The second precondition states that `a` and `b` are consecutive Fibonacci numbers.
@@ -77,14 +77,14 @@ The contract is pretty straightforward:
     `b` is the `i+1`th Fibonacci number, then `r` (the result of the
     computation) is the `i+n`th Fibonacci number.
     
-Although nothing complicated is really involved in this specification, it is
+Although this specification isn't complicated, it's
 quite verbose and repetitive. The term `i >= 0 /\ a = fibonacci i /\ b =
-fibonacci (i+1)` is repeated, and actually refers to the same value of `i`
+fibonacci (i+1)` is repeated, and it actually refers to the same value of `i`
 in both occurrences. We can certainly do better.
 
-## Simplifying using a ghost argument
+## Simplify by Using a Ghost Argument
 
-Let us imagine for a moment that our `fib` function takes an additional
+Let's imagine for a moment that our `fib` function takes an additional
 argument, `i`, representing the index of `a` in the Fibonacci sequence (the same
 `i` that we've been using in the specification so far). Its contract could look
 like:
@@ -97,23 +97,23 @@ val fib : i:int -> int -> int -> int -> int
     ensures r = fibonacci (i+n) *)
 ```
 
-We do not need to quantify over `i` anymore, since it is provided to the
+We don't need to quantify over `i` anymore, since it's provided to the
 function, but we still need to state the preconditions that apply to it (see the
-second clause). We do not need to repeat the previous condition on `i` either:
-if it holds in the prestate, then it also holds in the poststate, since nothing
+second clause). We don't need to repeat the previous condition on `i` either. 
+If it holds in the prestate, then it also holds in the poststate because nothing
 here is mutable.
 
-This contract is much easier to write, and more importantly, much easier to read
-and reason about. We cheated a bit though: `fib` does not take this `i`
-argument, and modifying it for the sole purpose of specification seems quite
+This contract is much easier to write, and more importantly, it's much more rational
+and easier to read. We cheated a bit though: `fib` does not take this `i`
+argument, so modifying it for the sole purpose of specification seems quite
 intrusive.
 
 To overcome this issue, Gospel provides *ghost parameters*. It lets you
-introduce logical arguments (or return values) that do not exist initially, so
+introduce logical arguments (or return values) that don't exist initially, so
 you can use them in the specifications and hopefully make them easier to
 understand. 
 
-Thus, we can rewrite our last attempt by using this feature, and benefit from
+Thus, we can rewrite our last attempt by using this feature and benefit from
 `i` being an argument without actually modifying the OCaml interface or
 implementation.
 

--- a/docs/docs/walkthroughs/introduction.md
+++ b/docs/docs/walkthroughs/introduction.md
@@ -10,6 +10,7 @@ highlights particular features of the language in a concrete setting.
 - [Fibonacci numbers](fibonacci)  
   **Highlights:** Ghost parameters
 - [Mutable queues](mutable-queue)  
-  **Highlights:** Type models, Exceptional postconditions, `requires`/`checks`, `consumes`
+  **Highlights:** Type models, Exceptional postconditions, `requires`/`checks`,
+  `consumes`
 - [Union-find](union-find).  
   **Highlights:** Ghost declarations

--- a/docs/docs/walkthroughs/introduction.md
+++ b/docs/docs/walkthroughs/introduction.md
@@ -4,12 +4,12 @@ sidebar_position: 1
 
 # Introduction
 
-This section features some real-world specifications using Gospel, and
+This section features some real-world specifications using Gospel and
 highlights particular features of the language in a concrete setting.
 
-- [Fibonacci numbers](fibonacci). <br />
-  **Highlights:** Ghost parameters.
-- [Mutable queues](mutable-queue). <br />
-  **Highlights:** Type models, Exceptional postconditions, `requires`/`checks`, `consumes`.
+- [Fibonacci numbers](fibonacci) <br />
+  **Highlights:** Ghost parameters
+- [Mutable queues](mutable-queue) <br />
+  **Highlights:** Type models, Exceptional postconditions, `requires`/`checks`, `consumes`
 - [Union-find](union-find). <br />
-  **Highlights:** Ghost declarations.
+  **Highlights:** Ghost declarations

--- a/docs/docs/walkthroughs/introduction.md
+++ b/docs/docs/walkthroughs/introduction.md
@@ -7,9 +7,9 @@ sidebar_position: 1
 This section features some real-world specifications using Gospel and
 highlights particular features of the language in a concrete setting.
 
-- [Fibonacci numbers](fibonacci) <br />
+- [Fibonacci numbers](fibonacci)  
   **Highlights:** Ghost parameters
-- [Mutable queues](mutable-queue) <br />
+- [Mutable queues](mutable-queue)  
   **Highlights:** Type models, Exceptional postconditions, `requires`/`checks`, `consumes`
-- [Union-find](union-find). <br />
+- [Union-find](union-find).  
   **Highlights:** Ghost declarations

--- a/docs/docs/walkthroughs/mutable-queue.md
+++ b/docs/docs/walkthroughs/mutable-queue.md
@@ -191,7 +191,7 @@ val transfer: 'a t -> 'a t -> unit
 
 Here the contract states that both queues are modified. The queue `src` is
 emptied after the call and its elements are appended to the queue `dst`. Notice
-the use of `old` in the second postcondition. This helps us refer to the queues' state 
+the use of `old` in the second postcondition. This helps us refer to the queues' state
 before they're passed to the function.
 
 ### Destructive Operations

--- a/docs/docs/walkthroughs/mutable-queue.md
+++ b/docs/docs/walkthroughs/mutable-queue.md
@@ -2,7 +2,7 @@
 sidebar_position: 3
 ---
 
-# Mutable queues
+# Mutable Queues
 
 This example aims to provide a formal specification for a mutable queue data
 structure, similar to OCaml's standard library `Queue`.
@@ -17,10 +17,10 @@ verified using Why3gospel.
     2019 - 23rd International Symposium on Formal Methods, Oct 2019, Porto,
     Portugal. ⟨[hal-02157484](https://hal.inria.fr/hal-02157484)⟩
 
-## Modeling the queue datastructure
+## Modeling the Queue Datastructure
 
-Let's start by defining the type of queues: the `'a t` type represents a
-polymorphic queue, storing elements of type `'a`. To enable reasoning about the
+Let's start by defining the type of queues. The `'a t` type represents a
+polymorphic queue, storing elements of type `'a`. To enable reasoning for the
 elements of a queue, we attach one model to its type declaration:
 
 ```ocaml
@@ -36,14 +36,14 @@ keyword states that the `view` field can change over time.
 :::tip
 
 This shows how Gospel annotations provide extra insight and are also relevant
-for documentation: the `mutable` keyword states that the type `'a t` is mutable,
+for documentation. The `mutable` keyword states that the type `'a t` is mutable,
 which cannot be deduced from its OCaml declaration alone.
 
 :::
 
-## Pushing into the queue
+## Pushing Into the Queue
 
-Let us now declare and specify a `push` operation for these queues:
+Now let's declare and specify a `push` operation for these queues:
 
 ```ocaml
 val push: 'a -> 'a t -> unit
@@ -56,21 +56,21 @@ val push: 'a -> 'a t -> unit
   of `push`: `v` and `q`.
 - The `modifies` clause states that the function `push` may mutate the contents
   of `q`.
-- Finally, the `ensures` clause introduces a post-condition that describes the
-  model `view` of `q` after a call to `push`: the new `view` extends the old
+- Finally, the `ensures` clause introduces a postcondition that describes the
+  model `view` of `q` after a call to `push`. The new `view` extends the old
   value of `view` with the element `v` at the front. We use the keyword `old` to
-  refer to the value of an expression (here, `q.view`) in the pre-state, *i.e.*,
+  refer to the value of an expression (here, `q.view`) in the prestate, *i.e.*,
   before the function call.
 
 Note that the module `Sequence` is part of the Gospel standard library and should not
 be confused with module `Seq` from the OCaml standard library.
 
-## Various flavors of `pop`
+## Various Flavors of `pop`
 
-Let us now move to another function, `pop`, and illustrate three ways of
+Now let's move to another function, `pop`, and illustrate three ways of
 handling assumptions from the client in Gospel specifications.
 
-### Exceptional version
+### Exceptional Version
 
 In this version, similar to the one provided by the OCaml standard library,
 `pop` raises an `Empty` exception if its argument is an empty queue. We specify
@@ -86,23 +86,23 @@ val pop: 'a t -> 'a
     raises   Empty -> q.view = old q.view = Sequence.empty *)
 ```
 
-We have two post-conditions:
+We have two postconditions:
 
-- The first one, introduced with `ensures`, states the post-condition that holds
+- The first one, introduced with `ensures`, states the postcondition that holds
   whenever the function `pop` returns a value `v`.
-- The second one, introduced by `raises`, states the exceptional post-condition
+- The second one, introduced by `raises`, states the exceptional postcondition
   that holds whenever the call raises the exception `Empty`.
 
 Similarly to the `push` case, the clause `modifies` indicates that this function
 call may mutate `q`. Note that this applies to the exceptional case as well, and
 that's why we state that `q` is both empty and not modified.
 
-### Unsafe version
+### Unsafe Version
 
 Now, let us consider an unsafe variant of `pop` that should only be called on a
 non-empty queue, leaving the responsibility of that property to the client code.
 The function does not raise `Empty` anymore but instead expects a non-empty
-argument. We can thus add the following pre-condition to the contract using the
+argument. We can thus add the following precondition to the contract using the
 keyword `requires`:
 
 ```ocaml {3}
@@ -113,7 +113,7 @@ val unsafe_pop: 'a t -> 'a
     ensures  old q.view = q.view ++ (Sequence.cons v Sequence.empty) *)
 ```
 
-### Defensive version
+### Defensive Version
 
 Instead of assuming that the precondition is guaranteed by the caller, we can
 also adopt a more defensive approach where `pop` raises `Invalid_argument`
@@ -134,7 +134,7 @@ that `q.view` is just a logical model and may not exist at all in the
 implementation. However, the function checks a property that, from a logical
 point of view, results in `q.view` not being empty.
 
-## A small break: `is_empty`
+## A Small Break: `is_empty`
 
 Our next function needs a simpler specification. Consider the following
 declaration for an emptiness test, together with its contract:
@@ -145,14 +145,14 @@ val is_empty: 'a t -> bool
       ensures b <-> q.view = Sequence.empty *)
 ```
 
-The post-conditions captures that the function returns `true` if and only if the
+The postconditions capture that the function returns `true` if and only if the
 queue is empty.
 
-Although very simple, note that the above specification implies an important
-property: since no `modifies` clause is present, the argument `q` is read-only:
-we know that a call to `is_empty` does not modify `q.view`.
+Although very simple, the above specification implies an important
+property. Since no `modifies` clause is present, the argument `q` is read-only.
+We know that a call to `is_empty` does not modify `q.view`.
 
-## Creating queues
+## Creating Queues
 
 The next function features the creation of a queue. Its declaration and
 specification are as follows:
@@ -163,23 +163,23 @@ val create: unit -> 'a t
       ensures q.view = Sequence.empty *)
 ```
 
-The newly created queue has no elements: its `view` model equals the `empty`
-sequence, as stated by the post-condition.
+The newly created queue has no elements. Its `view` model equals the `empty`
+sequence, as stated by the postcondition.
 
-It is worth mentioning that the specification implicitly assumes `q` to be
-disjoint from every previously allocated queue. This is an important design
-choice of Gospel that follows a rule of thumbs: writing functions that return
-non-fresh, mutable values is considered bad practice in OCaml.
+It's worth mentioning that the specification implicitly assumes `q` to be
+disjointed from every previously allocated queue. This is an important design
+choice of Gospel that follows this general principle: writing functions that return
+non-fresh, mutable values is considered a bad practice in OCaml.
 
-## Merging queues
+## Merging Queues
 
-Let us conclude this specification with a function to merge two queues. Several
-approaches are possible; we will showcase three of them.
+Let's conclude this specification with a function to merge two queues. Several
+approaches are possible, so we'll showcase three of them.
 
-### In-place transfer
+### In-Place Transfer
 
-Let us start with a concatenation that transfers all elements from one queue to
-another, with the following specification:
+Start with a concatenation that transfers all elements from one queue to
+another using the following specification:
 
 ```ocaml
 val transfer: 'a t -> 'a t -> unit
@@ -189,18 +189,18 @@ val transfer: 'a t -> 'a t -> unit
     ensures  dst.view = old dst.view ++ old src.view *)
 ```
 
-Here, the contract states that both queues are modified. The queue `src` is
+Here the contract states that both queues are modified. The queue `src` is
 emptied after the call and its elements are appended to the queue `dst`. Notice
-the use of `old` in the second post-condition, which helps us refer to the state
-of the queues before they are passed to the function.
+the use of `old` in the second postcondition. This helps us refer to the queues' state 
+before they're passed to the function.
 
-### Destructive operations
+### Destructive Operations
 
-One could think of a slightly different version of `transfer`,
-`destructive_transfer`, that invalidates `src` when called. In other words, the
-value of `src` should be considered dirty and must not be used anymore in the
-rest of the program. Such use-cases are frequent in system programming, for
-instance when dealing with file descriptors after closing them. Gospel
+One could think of a slightly different version of `transfer`:
+`destructive_transfer`, which invalidates `src` when called. In other words, the
+value of `src` should be considered taboo, so it must not be used in the
+rest of the program. Such use cases are frequent in system programming, like
+when dealing with file descriptors after closing them. Gospel
 provides `consumes` clauses to capture this semantic:
 
 ```ocaml {3}
@@ -211,12 +211,12 @@ val destructive_transfer: 'a t -> 'a t -> unit
     ensures  dst.view = old dst.view ++ old src.view *)
 ```
 
-Note that we do not need to give any information on `src` in the post-state,
-since its value must not be used anymore.
+Note that we don't need to give information on `src` in the poststate, since
+its value must not be used anymore.
 
-### A constructive version
+### A Constructive Version
 
-Finally, a perhaps simpler version may consist in a `concat` function creating a
+Finally, perhaps a simpler version may consist in a `concat` function to create a
 fresh queue with the elements of the queues passed as arguments:
 
 ```ocaml
@@ -225,6 +225,6 @@ val concat: 'a t -> 'a t -> 'a t
     ensures new.view = q1.view ++ q2.view *)
 ```
 
-In this version, no `modifies` appears, meaning that none of the arguments are
-modified by the function, thus specifying their models in the post-state is not
+In this version, no `modifies` appears. This means that none of the arguments are
+modified by the function, so specifying their models in the poststate isn't
 necessary.

--- a/docs/docs/walkthroughs/mutable-queue.md
+++ b/docs/docs/walkthroughs/mutable-queue.md
@@ -62,8 +62,8 @@ val push: 'a -> 'a t -> unit
   refer to the value of an expression (here, `q.view`) in the prestate, *i.e.*,
   before the function call.
 
-Note that the module `Sequence` is part of the Gospel standard library and should not
-be confused with module `Seq` from the OCaml standard library.
+Note that the module `Sequence` is part of the Gospel standard library and
+should not be confused with module `Seq` from the OCaml standard library.
 
 ## Various Flavors of `pop`
 
@@ -168,8 +168,8 @@ sequence, as stated by the postcondition.
 
 It's worth mentioning that the specification implicitly assumes `q` to be
 disjoint from every previously allocated queue. This is an important design
-choice of Gospel that follows this general principle: writing functions that return
-non-fresh, mutable values is considered a bad practice in OCaml.
+choice of Gospel that follows this general principle: writing functions that
+return non-fresh, mutable values is considered a bad practice in OCaml.
 
 ## Merging Queues
 
@@ -191,8 +191,8 @@ val transfer: 'a t -> 'a t -> unit
 
 Here the contract states that both queues are modified. The queue `src` is
 emptied after the call and its elements are appended to the queue `dst`. Notice
-the use of `old` in the second postcondition. This helps us refer to the queues' state
-before they're passed to the function.
+the use of `old` in the second postcondition. This helps us refer to the queues'
+state before they're passed to the function.
 
 ### Destructive Operations
 
@@ -216,8 +216,8 @@ its value must not be used anymore.
 
 ### A Constructive Version
 
-Finally, perhaps a simpler version may consist in a `concat` function that creates a
-fresh queue with the elements of the queues passed as arguments:
+Finally, perhaps a simpler version may consist in a `concat` function that
+creates a fresh queue with the elements of the queues passed as arguments:
 
 ```ocaml
 val concat: 'a t -> 'a t -> 'a t
@@ -225,6 +225,6 @@ val concat: 'a t -> 'a t -> 'a t
     ensures new.view = q1.view ++ q2.view *)
 ```
 
-In this version, no `modifies` appears. This means that none of the arguments are
-modified by the function, so specifying their models in the poststate isn't
+In this version, no `modifies` appears. This means that none of the arguments
+are modified by the function, so specifying their models in the poststate isn't
 necessary.

--- a/docs/docs/walkthroughs/mutable-queue.md
+++ b/docs/docs/walkthroughs/mutable-queue.md
@@ -20,7 +20,7 @@ verified using Why3gospel.
 ## Modeling the Queue Datastructure
 
 Let's start by defining the type of queues. The `'a t` type represents a
-polymorphic queue, storing elements of type `'a`. To enable reasoning for the
+polymorphic queue, storing elements of type `'a`. To enable reasoning about the
 elements of a queue, we attach one model to its type declaration:
 
 ```ocaml
@@ -167,7 +167,7 @@ The newly created queue has no elements. Its `view` model equals the `empty`
 sequence, as stated by the postcondition.
 
 It's worth mentioning that the specification implicitly assumes `q` to be
-disjointed from every previously allocated queue. This is an important design
+disjoint from every previously allocated queue. This is an important design
 choice of Gospel that follows this general principle: writing functions that return
 non-fresh, mutable values is considered a bad practice in OCaml.
 
@@ -179,7 +179,7 @@ approaches are possible, so we'll showcase three of them.
 ### In-Place Transfer
 
 Start with a concatenation that transfers all elements from one queue to
-another using the following specification:
+another:
 
 ```ocaml
 val transfer: 'a t -> 'a t -> unit
@@ -198,7 +198,7 @@ before they're passed to the function.
 
 One could think of a slightly different version of `transfer`:
 `destructive_transfer`, which invalidates `src` when called. In other words, the
-value of `src` should be considered taboo, so it must not be used in the
+value of `src` should be considered *dirty*, so it must not be used in the
 rest of the program. Such use cases are frequent in system programming, like
 when dealing with file descriptors after closing them. Gospel
 provides `consumes` clauses to capture this semantic:
@@ -216,7 +216,7 @@ its value must not be used anymore.
 
 ### A Constructive Version
 
-Finally, perhaps a simpler version may consist in a `concat` function to create a
+Finally, perhaps a simpler version may consist in a `concat` function that creates a
 fresh queue with the elements of the queues passed as arguments:
 
 ```ocaml

--- a/docs/docs/walkthroughs/union-find.md
+++ b/docs/docs/walkthroughs/union-find.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Union-find
 
-In this example, we will highlight an advanced use-case of ghost declarations in
+In this example, we will highlight an advanced use case of ghost declarations in
 Gospel through the specification of a union-find datastructure.
 
 [Union-find](https://en.wikipedia.org/wiki/Disjoint-set_data_structure) is a
@@ -29,27 +29,26 @@ val union : 'a element -> 'a element -> unit
 ## Why is this hard to specify?
 
 Union-find structures store a partition of a set. Notice that a typical
-interface for union-find does not materialise this greater set (let us call it
+interface for union-find doesn't materialise this greater set (let's call it
 our *universe*). Instead, the programmer has access to individual elements of
-the set, and may merge them or access a representative of the partition it is
-in.
+the set, so they may merge them or access a representative of its partition.
 
 However, for the sake of specification, not having this global set is a problem.
-How can we state that the subsets are disjoint? How do we refer to the set of
+How can we state that the subsets are disjointed? How do we refer to the set of
 elements that exist in the union-find universe? Can we even tell that the
 representative of an element (returned by `find`) is indeed part of a subset
-that was `union`ed with it at some point? It seems that we cannot do any of this
+that was `union`ed with it at some point? It seems that we cannot do any of these 
 by attaching contracts to our functions and type only.
 
 This example shows how Gospel's *ghost declarations* help describe such complex
 behaviours.
 
-## Introducing the ghost universe
+ ## Introducing the Ghost Universe
 
 Seemingly, the root of our problems is that union-find relies on the implicit
-universe of elements. It does not exist in the OCaml's interface, so let us
-introduce it as a ghost type declaration. We can also add that this universe is
-mutable: so long as elements are added, for instance, it will be modified.
+universe of elements. It doesn't exist in the OCaml's interface, so let's
+introduce it as a ghost-type declaration. We can also add that this universe is
+mutable. As long as elements are added, for instance, it will be modified.
 
 ```ocaml
 (*@ type 'a universe *)
@@ -57,12 +56,12 @@ mutable: so long as elements are added, for instance, it will be modified.
 ```
 
 Now, our three functions still apply to set elements, but they also apply _in the
-context of a universe_: you create a new singleton subset in the context of the
-greater set, or find the representative of an element in the rest of universe
-for instance. This translates into our three functions taking a value of type `'a
-universe` as argument. Of course, `'a universe` is ghost, and you do not want to
-modify the signature of the functions anyway, so this argument is ghost too[^1].
-We can also already get a sense that `make` and `union` will modify the
+context of an universe_ since you create a new singleton subset in the context of the
+greater set, or find the representative of an element in the rest of the universe.
+This translates into our three functions taking a value of type `'a
+universe` as its argument. Of course, `'a universe` is a ghost type and you don't want to
+modify the functions' signatures anyway, so this argument is ghost, too[^1].
+We already get a sense that `make` and `union` will modify the
 universe.
 
 [^1]: If you're not comfortable with ghost arguments, you may want to [read our
@@ -82,26 +81,26 @@ val union : 'a element -> 'a element -> unit
 ```
 
 Since we now have a type for universes, and functions that take values of such
-type, we probably need a constructor for this type. Let us introduce that as a
+a type, we probably need a constructor for this type. Let's introduce that as a
 ghost value:
 
 ```ocaml
 (*@ val make_universe: unit -> 'a universe *)
 ```
 
-Having this abstract type on is not very useful so far. We are able to state
-that the functions apply in the context of a universe, and that they may mutate
-it, but that's pretty much it. Let us be more precise than that.
+Having this abstract type on is not very useful so far. We're able to state
+that the functions apply in the context of a universe and they may mutate
+it, but that's pretty much it. Let's be more precise than that.
 
-## Elements: gotta catch 'em all
+## Elements: Gotta Catch 'em All
 
-A first interesting property that we would like to capture is that the subsets
-are indeed disjoint. For instance, `make` should not create an element that is
-already in the universe, otherwise you would have two different subsets
+The first interesting property to capture is that the subsets
+are indeed disjointed. For instance, `make` shouldn't create an element that's
+already in the universe, otherwise you'd have two different subsets
 containing the same element.
 
-In order to specify this, we need to be able to talk about the set of existing
-elements in the universe. Let us introduce this as a logical model attached to
+In order to specify this, we need to talk about the set of existing
+elements in the universe. Let's introduce this as a logical model attached to
 our `universe` type:
 
 ```ocaml
@@ -111,14 +110,14 @@ our `universe` type:
 
 :::tip
 
-Since at least one model is mutable, we may now omit the `ephemeral` keyword,
-although it is valid to keep it if you prefer. For instance, you may keep it if
+Since at least one model is mutable, we may now omit the `ephemeral` keyword 
+(although it's also valid to keep it if you prefer). For instance, you may keep it if
 you want to indicate that the type is also mutable in a way that is not visible
 in the models.
 
 :::
 
-Now let us add more information on how the functions interact with it. The
+Now let's add more information on how the functions interact with it. The
 constructor should ensure two things:
 - The returned element is a fresh element.
 - The universe's domain is augmented with the singleton containing the
@@ -132,8 +131,8 @@ val make : 'a -> 'a element
     ensures u.dom = Set.add e (old u.dom) *)
 ```
 
-The `find` function obviously needs an element of the universe, and also returns
-an element that is part of the universe:
+The `find` function obviously needs an element of the universe, and it also returns
+an element that's part of the universe:
 
 ```ocaml {3,4}
 val find : 'a element -> 'a element
@@ -143,8 +142,8 @@ val find : 'a element -> 'a element
 ```
 
 Finally, `union` requires that the provided elements are part of the universe
-too. Note that it does not modify the universe domain (no element is added nor
-removed), but since we added the `modify u` clause, we need to state that
+too. Please note: it doesn't modify the universe domain (no element is added nor
+removed); however, since we added the `modify u` clause, we need to state that
 explicitly, or the contract may imply that `u.dom` was modified (in an
 unspecified way).
 
@@ -157,16 +156,16 @@ val union : 'a element -> 'a element -> unit
     ensures u.dom = old u.dom *)
 ```
 
-## Find your representative
+## Find Your Representative
 
 We can now talk about all the elements in our partition, but we still haven't
-mentioned elements representatives at all. Each element in the universe has a
-representative in the set, so we may represent this using a `'a element -> 'a
+mentioned the elements' representatives. Each element in the universe has a
+representative in the set, so we can represent this using a `'a element -> 'a
 element` function. We can also add two invariants:
 
-- the representative of an element must live in the same universe as the
-  element itself,
-- the `rep` function is idempotent: the representative of an element is its own
+- The representative of an element must live in the same universe as the
+  element itself.
+- The `rep` function is idempotent: the representative of an element is its own
   representative.
 
 ```ocaml {3-5}
@@ -180,14 +179,14 @@ element` function. We can also add two invariants:
 
 :::caution
 
-Notice how in both cases, speaking of the representative of an element only
-makes sense for elements that are in the universe. However, Gospel's logic is
-total, so `rep` is also defined outside of the universe, but it is unspecified
+Notice how in both cases, speaking of the element's representative only
+makes sense for elements that live in the universe. However, Gospel's logic is
+total, so `rep` is also defined outside of the universe; however, it's unspecified
 there.
 
 :::
 
-Let us now add clauses to our functions to indicate how they interact with
+Now let's add clauses to our functions that indicate how they interact with
 `rep`. After a call to our constructor, the created element is obviously its own
 representative, and all other representatives are left unchanged:
 
@@ -208,8 +207,8 @@ notation `f[x -> y]` is a shorthand notation for the function defined as `fun i
 
 :::
 
-The `find` function does not modify the representatives, but return the
-representative of the input element:
+The `find` function doesn't modify the representatives, but they return the
+input element's representative:
 
 ```ocaml {5}
 val find : 'a element -> 'a element
@@ -222,10 +221,10 @@ val find : 'a element -> 'a element
 Finally, the postcondition for `union` is a bit more involved. We need to
 capture that the new representative of an element may change.
 
-First, it is left unchanged if the element is not in `x` nor `y` subset.
+First, it's left unchanged if the element is not in `x` nor `y` subset.
 
 Let's start by introducing a predicate that will help us decide if two elements
-are in the same subset (or equivalence class). This is the case iff they have
+are in the same subset (or equivalence class). This is the case if they have
 the same subset representative:
 
 ```ocaml
@@ -233,7 +232,7 @@ the same subset representative:
       u.rep x = u.rep y *)
 ```
 
-We can now use that to state that elements that are not equivalent to `x` or `y`
+We can now use this to state that elements that aren't equivalent to `x` or `y`
 have the same representative:
 
 ```ocaml {7-9}
@@ -266,9 +265,8 @@ val union : 'a element -> 'a element -> unit
                    -> u.rep e = r *)
 ```
 
-We could go further and add more functions, for instance an equality function
-over `element`s, or a `get` function to extract the value contained in an
-element, but we'll keep it there for this tutorial. Hopefully, you now have a
+We could go further and add more functions, like an equality function
+over `element`s or a `get` function to extract an element's value, 
+but we'll keep it there for this tutorial. Hopefully, this gives you a
 better overview of the purpose of ghost types in Gospel specifications and how
-they can help you refer to meta-elements that are not present in the code, or
-not exposed.
+they can help you refer to meta-elements not present or not exposed in the code.

--- a/docs/docs/walkthroughs/union-find.md
+++ b/docs/docs/walkthroughs/union-find.md
@@ -37,8 +37,8 @@ However, for the sake of specification, not having this global set is a problem.
 How can we state that the subsets are disjoint? How do we refer to the set of
 elements that exist in the union-find universe? Can we even tell that the
 representative of an element (returned by `find`) is indeed part of a subset
-that was `union`ed with it at some point? It seems that we cannot do any of these
-by attaching contracts to our functions and type only.
+that was `union`ed with it at some point? It seems that we cannot do any of
+these by attaching contracts to our functions and type only.
 
 This example shows how Gospel's *ghost declarations* help describe such complex
 behaviours.
@@ -55,13 +55,13 @@ mutable. As long as elements are added, for instance, it will be modified.
 (*@ ephemeral *)
 ```
 
-Now, our three functions still apply to set elements, but they also apply _in the
-context of a universe_ since you create a new singleton subset in the context of the
-greater set, or find the representative of an element in the rest of the universe.
-This translates into our three functions taking a value of type `'a
-universe` as its argument. Of course, `'a universe` is a ghost type and you don't want to
-modify the functions' signatures anyway, so this argument is ghost, too[^1].
-We already get a sense that `make` and `union` will modify the
+Now, our three functions still apply to set elements, but they also apply _in
+the context of a universe_ since you create a new singleton subset in the
+context of the greater set, or find the representative of an element in the rest
+of the universe. This translates into our three functions taking a value of type
+`'a universe` as its argument. Of course, `'a universe` is a ghost type and you
+don't want to modify the functions' signatures anyway, so this argument is
+ghost, too[^1]. We already get a sense that `make` and `union` will modify the
 universe.
 
 [^1]: If you're not comfortable with ghost arguments, you may want to [read our
@@ -111,9 +111,9 @@ our `universe` type:
 :::tip
 
 Since at least one model is mutable, we may now omit the `ephemeral` keyword
-(although it's also valid to keep it if you prefer). For instance, you may keep it if
-you want to indicate that the type is also mutable in a way that is not visible
-in the models.
+(although it's also valid to keep it if you prefer). For instance, you may keep
+it if you want to indicate that the type is also mutable in a way that is not
+visible in the models.
 
 :::
 
@@ -131,8 +131,8 @@ val make : 'a -> 'a element
     ensures u.dom = Set.add e (old u.dom) *)
 ```
 
-The `find` function obviously needs an element of the universe, and it also returns
-an element that's part of the universe:
+The `find` function obviously needs an element of the universe, and it also
+returns an element that's part of the universe:
 
 ```ocaml {3,4}
 val find : 'a element -> 'a element
@@ -179,9 +179,9 @@ element` function. We can also add two invariants:
 
 :::caution
 
-Notice how in both cases, speaking of the element's representative only
-makes sense for elements that live in the universe. However, Gospel's logic is
-total, so `rep` is also defined outside of the universe; however, it's unspecified
+Notice how in both cases, speaking of the element's representative only makes
+sense for elements that live in the universe. However, Gospel's logic is total,
+so `rep` is also defined outside of the universe; however, it's unspecified
 there.
 
 :::
@@ -224,8 +224,8 @@ capture that the new representative of an element may change.
 First, it's left unchanged if the element is not in `x` nor `y` subset.
 
 Let's start by introducing a predicate that will help us decide if two elements
-are in the same subset (or equivalence class). This is the case if and only if they have
-the same subset representative:
+are in the same subset (or equivalence class). This is the case if and only if
+they have the same subset representative:
 
 ```ocaml
 (*@ predicate equiv (u: 'a universe) (x y: 'a element) =

--- a/docs/docs/walkthroughs/union-find.md
+++ b/docs/docs/walkthroughs/union-find.md
@@ -37,7 +37,7 @@ However, for the sake of specification, not having this global set is a problem.
 How can we state that the subsets are disjointed? How do we refer to the set of
 elements that exist in the union-find universe? Can we even tell that the
 representative of an element (returned by `find`) is indeed part of a subset
-that was `union`ed with it at some point? It seems that we cannot do any of these 
+that was `union`ed with it at some point? It seems that we cannot do any of these
 by attaching contracts to our functions and type only.
 
 This example shows how Gospel's *ghost declarations* help describe such complex
@@ -110,7 +110,7 @@ our `universe` type:
 
 :::tip
 
-Since at least one model is mutable, we may now omit the `ephemeral` keyword 
+Since at least one model is mutable, we may now omit the `ephemeral` keyword
 (although it's also valid to keep it if you prefer). For instance, you may keep it if
 you want to indicate that the type is also mutable in a way that is not visible
 in the models.
@@ -266,7 +266,7 @@ val union : 'a element -> 'a element -> unit
 ```
 
 We could go further and add more functions, like an equality function
-over `element`s or a `get` function to extract an element's value, 
+over elements or a `get` function to extract an element's value,
 but we'll keep it there for this tutorial. Hopefully, this gives you a
 better overview of the purpose of ghost types in Gospel specifications and how
 they can help you refer to meta-elements not present or not exposed in the code.

--- a/docs/docs/walkthroughs/union-find.md
+++ b/docs/docs/walkthroughs/union-find.md
@@ -34,7 +34,7 @@ our *universe*). Instead, the programmer has access to individual elements of
 the set, so they may merge them or access a representative of its partition.
 
 However, for the sake of specification, not having this global set is a problem.
-How can we state that the subsets are disjointed? How do we refer to the set of
+How can we state that the subsets are disjoint? How do we refer to the set of
 elements that exist in the union-find universe? Can we even tell that the
 representative of an element (returned by `find`) is indeed part of a subset
 that was `union`ed with it at some point? It seems that we cannot do any of these
@@ -56,7 +56,7 @@ mutable. As long as elements are added, for instance, it will be modified.
 ```
 
 Now, our three functions still apply to set elements, but they also apply _in the
-context of an universe_ since you create a new singleton subset in the context of the
+context of a universe_ since you create a new singleton subset in the context of the
 greater set, or find the representative of an element in the rest of the universe.
 This translates into our three functions taking a value of type `'a
 universe` as its argument. Of course, `'a universe` is a ghost type and you don't want to
@@ -95,7 +95,7 @@ it, but that's pretty much it. Let's be more precise than that.
 ## Elements: Gotta Catch 'em All
 
 The first interesting property to capture is that the subsets
-are indeed disjointed. For instance, `make` shouldn't create an element that's
+are indeed disjoint. For instance, `make` shouldn't create an element that's
 already in the universe, otherwise you'd have two different subsets
 containing the same element.
 
@@ -224,7 +224,7 @@ capture that the new representative of an element may change.
 First, it's left unchanged if the element is not in `x` nor `y` subset.
 
 Let's start by introducing a predicate that will help us decide if two elements
-are in the same subset (or equivalence class). This is the case if they have
+are in the same subset (or equivalence class). This is the case if and only if they have
 the same subset representative:
 
 ```ocaml

--- a/docs/docs/welcome.md
+++ b/docs/docs/welcome.md
@@ -12,9 +12,9 @@ to get you started with formal specifications for your OCaml programs.
 - If you are entirely new to Gospel, please head out to the [Getting
   Started](getting-started/installation) section. You'll learn how to install
   Gospel and then use it to write your first specification.
-- The [Walk-through](walkthroughs/introduction) section showcases real-world OCaml
-  interfaces, including a comprehensive explanation of the specification process and
-  language features.
+- The [Walk-through](walkthroughs/introduction) section showcases real-world
+  OCaml interfaces, including a comprehensive explanation of the specification
+  process and language features.
 - More detailed explanations of the language features are available in the
   [Language Reference](language/syntax) section.
 - Some information about the Gospel Standard library are available in the


### PR DESCRIPTION
This PR brings:
- rebased #111, #112 and #118 by Christine Rose, integrated with the current state of the documentation,
- a new tip to help new users when `(*@ ... *)` are misplaced,
- a new presentation of Ortac.

Closes #111, closes #112, closes #118