### PR TITLE
Improve performance and clean up the preprocessor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,8 @@
 
 ## Fixed
 
+- Fix the performance issues in the preprocessor
+  [\353](https://github/ocaml-gospel/gospel/pull/353)
 - Gospel preprocessor support documentation for ghost declaration
   [\#331](https://github/ocaml-gospel/gospel/pull/331)
 - Consider comments as spaces while preprocessing (to ensure specification can

--- a/bin/pps.ml
+++ b/bin/pps.ml
@@ -16,7 +16,7 @@ let run_file file =
     let ic = open_in file in
     let lexbuf = Lexing.from_channel ic in
     Lexing.set_filename lexbuf file;
-    print_endline (Gospel.Pps.run lexbuf);
+    Fmt.pr "@[%a@]\n" Gospel.Pps.run lexbuf;
     close_in ic)
   else
     let ic = open_in file in

--- a/src/dune
+++ b/src/dune
@@ -18,3 +18,22 @@
  (deps stdlib/gospelstdlib.mli)
  (action
   (run stdlib/file_to_string.exe %{deps} %{targets})))
+
+(rule
+ (alias fmt)
+ (enabled_if %{bin-available:ex})
+ (action
+  (progn
+   (run
+    ex
+    -u
+    NONE
+    -n
+    %{dep:pps.mll}
+    -c
+    "g/^{/+,/^}$/-!ocamlformat --impl -m 78 - | sed 's/^./  &/'"
+    -c
+    "g/ {$/+,/^    }$/-!ocamlformat --impl -m 74 - | sed 's/^./      &/'"
+    -c
+    "wq! pps.formatted.mll")
+   (diff? pps.mll pps.formatted.mll))))

--- a/src/parser_frontend.ml
+++ b/src/parser_frontend.ml
@@ -33,7 +33,7 @@ let with_loadpath load_path file =
   else raise Not_found
 
 let parse_ocaml_lb lb =
-  let lb_pps = Pps.run lb |> Lexing.from_string in
+  let lb_pps = Fmt.str "%a" Pps.run lb |> Lexing.from_string in
   Location.init lb_pps lb.lex_start_p.pos_fname;
   try Parse.interface lb_pps
   with _ ->

--- a/src/pps.mli
+++ b/src/pps.mli
@@ -1,1 +1,1 @@
-val run : Lexing.lexbuf -> string
+val run : Format.formatter -> Lexing.lexbuf -> unit

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -36,7 +36,7 @@
       Queue.push (Other (Buffer.contents buf)) queue;
       Buffer.clear buf)
 
-  let directive pos =
+  let print_directive pos =
     let open Lexing in
     Fmt.str "\n# %d \"%s\"\n" pos.pos_lnum pos.pos_fname
 
@@ -53,9 +53,9 @@
   let print_gospel (lvl : [ `TwoAt | `ThreeAt ]) start_p end_p s =
     Fmt.str "[%sgospel%s%s {|%s|}%s%s]"
       (match lvl with `TwoAt -> "@@" | `ThreeAt -> "@@@")
-      (directive start_p)
+      (print_directive start_p)
       (String.make (start_p.pos_cnum - start_p.pos_bol) ' ')
-      s (directive end_p)
+      s (print_directive end_p)
       (String.make (end_p.pos_cnum - end_p.pos_bol - 1 (*]*)) ' ')
   (* ...(*@ foo *)
      (*@ bar *)...
@@ -73,23 +73,24 @@
 
   let print_nested_gospel start_p inner_start_p end_p outer_s inner_s =
     Fmt.str "[@@@@@@gospel%s%s {|%s|}[@@@@gospel%s%s {|%s|}]%s%s]"
-      (directive start_p)
+      (print_directive start_p)
       (String.make (start_p.pos_cnum - start_p.pos_bol) ' ')
-      outer_s (directive inner_start_p)
+      outer_s
+      (print_directive inner_start_p)
       (String.make (inner_start_p.pos_cnum - inner_start_p.pos_bol) ' ')
-      inner_s (directive end_p)
+      inner_s (print_directive end_p)
       (String.make (end_p.pos_cnum - end_p.pos_bol - 1 (*]*)) ' ')
 
   let print_documentation_attribute lvl start_p end_p s =
     Fmt.str "[%s%s%s {|%s|}%s%s]"
       (match lvl with `TwoAt -> "@@ocaml.doc" | `ThreeAt -> "@@@ocaml.text")
-      (directive start_p)
+      (print_directive start_p)
       (String.make (start_p.pos_cnum - start_p.pos_bol) ' ')
-      s (directive end_p)
+      s (print_directive end_p)
       (String.make (end_p.pos_cnum - end_p.pos_bol - 1 (*]*)) ' ')
 
   let print_empty_documentation end_p =
-    Fmt.str "[@@@ocaml.doc%s%s]" (directive end_p)
+    Fmt.str "[@@@ocaml.doc%s%s]" (print_directive end_p)
       (String.make (end_p.pos_cnum - end_p.pos_bol - 1 (*]*)) ' ')
 
   let print_triplet o sp doc sp' start_p end_p s =

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -313,9 +313,9 @@ and comment = parse
       }
    | "\""
       {
-        Buffer.add_char buf '\"';
+        Buffer.add_char buf '"';
         string lexbuf;
-        Buffer.add_char buf '\"';
+        Buffer.add_char buf '"';
         comment lexbuf
       }
    | newline as nl { Buffer.add_string buf nl; Lexing.new_line lexbuf; comment lexbuf }
@@ -343,7 +343,7 @@ and directive = parse
   | "" { scan lexbuf }
 
 and string = parse
-    '\"'
+    '"'
       { }
   | newline as nl
       {

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -36,9 +36,11 @@
       Queue.push (Other (Buffer.contents buf)) queue;
       Buffer.clear buf)
 
-  let print_directive pos =
+  let print_directive ?(first = false) pos =
     let open Lexing in
-    Fmt.str "\n# %d \"%s\"\n" pos.pos_lnum pos.pos_fname
+    Fmt.str "%s# %d \"%s\"\n"
+      (if first then "" else "\n")
+      pos.pos_lnum pos.pos_fname
 
   (* ...(*@ foo *)...
 
@@ -416,5 +418,6 @@ and quoted_string delim = parse
 {
   let run lb =
     clear ();
-    scan lb
+    let init_pos = lb.Lexing.lex_curr_p in
+    print_directive ~first:true init_pos ^ scan lb
 }

--- a/src/pps.mll
+++ b/src/pps.mll
@@ -218,22 +218,24 @@
         | Nl, Blk -> Nl
         | Nl, Comment -> Comment
     in
-    let rec loop = function
+    let rec loop acc = function
       | Spaces (k, s) :: l' ->
           Buffer.add_string b s;
           update_curk k;
-          loop l'
+          loop acc l'
       | elt :: l' ->
           let sp = Buffer.contents b in
           Buffer.clear b;
           let k = !curk in
           curk := Blk;
-          Spaces (k, sp) :: elt :: loop l'
+          loop (elt :: Spaces (k, sp) :: acc) l'
       | [] ->
-          if Buffer.length b > 0 then [ Spaces (!curk, Buffer.contents b) ]
-          else []
+          List.rev
+            (if Buffer.length b > 0 then
+               Spaces (!curk, Buffer.contents b) :: acc
+             else acc)
     in
-    loop l
+    loop [] l
 
   let flush ppf =
     push ();

--- a/test/documentation/test_preprocess_documentation.t
+++ b/test/documentation/test_preprocess_documentation.t
@@ -223,6 +223,7 @@ specifications after an multi-line informal documentation block:
 Gospel preprocessing should indicate the correct location with the `#` syntax:
 
   $ gospel pps foo.mli
+  # 1 "foo.mli"
   val f : int -> int
   [@@ocaml.doc
   # 2 "foo.mli"
@@ -273,6 +274,7 @@ Another corner case is the empty documentation attribute:
   > (*@ y = f x z *)
   > EOF
   $ gospel pps foo.mli
+  # 1 "foo.mli"
   val f : int -> int
   [@@ocaml.doc
   # 2 "foo.mli"
@@ -292,6 +294,7 @@ And some other corner cases with different spacing:
   > val f : int -> int(*@ y = f x z *)
   > EOF
   $ gospel pps foo.mli
+  # 1 "foo.mli"
   val f : int -> int[@@gospel
   # 1 "foo.mli"
                      {| y = f x z |}
@@ -306,6 +309,7 @@ And some other corner cases with different spacing:
   > (*@ y = f x *)
   > EOF
   $ gospel pps foo.mli
+  # 1 "foo.mli"
   val f : int -> int[@@ocaml.doc
   # 1 "foo.mli"
                      {| documentation |}
@@ -324,6 +328,7 @@ And some other corner cases with different spacing:
   > val f : int -> int(** documentation *)(*@ y = f x *)
   > EOF
   $ gospel pps foo.mli
+  # 1 "foo.mli"
   val f : int -> int[@@ocaml.doc
   # 1 "foo.mli"
                      {| documentation |}


### PR DESCRIPTION
This PR reworks the preprocessor by:

- cleaning up with a more complete and uniform reindentation,
- improving a lot its performance by generating the output into a formatter rather than generating lots of temporary strings.

In a bit more details, the performance gains are obtained by changing the interface of the preprocessor so that it outputs its result into a formatter rather than a string and propagating the change all the way down, so that:
- the whole output is generated in a single buffer when the target is a `string`, or directly on `stdout` in the case of `gospel pps`,
- `print` becomes tail recursive.

Using the example mentioned in #336 (test run in CI, so the performance may vary depending on load...), we go from:

```
16
allocated_words: 440218559
real	0m1.814s

32
allocated_words: 1749282355
real	0m10.295s

48
allocated_words: 3768016163
real	0m16.260s
```

to:

```
16
allocated_words: 2152756
real	0m0.019s

32
allocated_words: 4253492
real	0m0.031s

48
allocated_words: 6354228
real	0m0.044s
```