### PR TITLE
Hint that something is missing is a specification in the documentation

### DIFF
--- a/docs/docs/language/function-contracts.md
+++ b/docs/docs/language/function-contracts.md
@@ -332,7 +332,8 @@ or not.
 ```ocaml invalidSyntax
 val run : unit -> unit
 (*@ run ()
-    diverges *)
+    diverges
+    (* ... *) *)
 ```
 
 ## Data Mutability


### PR DESCRIPTION
Since #317 was not yet addressed, add an explicit `(* ... *)` to hint that the proposed specification cannot be used all by itself (yet)