### PR TITLE
Remove the `gospel_expected` prologue at the end of successful tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@
   to experiment with Gospel syntax and future extensions of the language.
   [#361] (https://github.com/ocaml-gospel/gospel/pull/361)
 
+## Internals
+
+- Remove the `gospel_expected` prologue at the end of successful tests
+  [\#363](https://github.com/ocaml-gospel/gospel/pull/363)
+
 # 0.2
 
 ## Added

--- a/test/coercions/basic.mli
+++ b/test/coercions/basic.mli
@@ -3,7 +3,3 @@ type t2
 
 (*@ function c (x: t1) : t2 *)
 (*@ coercion *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/coercions/constr_literal.mli
+++ b/test/coercions/constr_literal.mli
@@ -3,7 +3,3 @@
 val f : int -> int
 (*@ y = f x
     requires A 42i = A 42i *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/literals/ints.mli
+++ b/test/literals/ints.mli
@@ -8,7 +8,3 @@ val f : int -> int
     requires 42 = 0x16
     requires A 42i = A 0x16i
     requires A 42i = A 43i *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/patterns/allsorts.mli
+++ b/test/patterns/allsorts.mli
@@ -202,7 +202,3 @@ val f16 : t16 -> int
            | C (y,z) when (match y with A -> true | _ -> false) -> true
            | _ -> true
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/patterns/allsorts2.mli
+++ b/test/patterns/allsorts2.mli
@@ -26,7 +26,3 @@ type t2 = B of int * int
 
 (*@ function f (x: t2) : unit =
     match x with B _ -> () *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/patterns/expressions_raises.mli
+++ b/test/patterns/expressions_raises.mli
@@ -23,7 +23,3 @@ val f : int -> t -> bool
     (* raises E _ -> false *)
     raises F _ -> true
     raises F (_, _) -> true *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/patterns/fun_option.mli
+++ b/test/patterns/fun_option.mli
@@ -2,7 +2,3 @@ val f : 'a option list -> bool
 (*@ b = f os
     ensures List._exists (fun (None | Some _) -> false) os
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/patterns/fun_pair.mli
+++ b/test/patterns/fun_pair.mli
@@ -2,7 +2,3 @@ val f : (int * 'a) list -> int list
 (*@ ys = f xs
     ensures ys = List.map (fun (x, _) -> x) xs
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/patterns/fun_triple.mli
+++ b/test/patterns/fun_triple.mli
@@ -2,7 +2,3 @@ val f : ('a * 'b * 'c) list -> 'a list
 (*@ xs = f ys
     ensures xs = List.map (fun (x, _, _) : 'a -> x) ys
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/patterns/inner_cast.mli
+++ b/test/patterns/inner_cast.mli
@@ -3,7 +3,3 @@ val f : int option -> int
     requires match x with
              | Some (y:int) -> y >= 0
              | None -> true *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/pure/pure_promoted.mli
+++ b/test/pure/pure_promoted.mli
@@ -6,7 +6,3 @@ val f : int -> int
 val g : int -> int
 (*@ y = g x
     requires f x > 0 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/abstract_functions.mli
+++ b/test/syntax/abstract_functions.mli
@@ -61,7 +61,3 @@
 (*@ function h14 (x: 'a): test *)
 
 (*@ function h15 (x: test): integer *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/allsorts_labels.mli
+++ b/test/syntax/allsorts_labels.mli
@@ -54,7 +54,3 @@ val f : int ref -> unit
 val f : int ref -> unit
 (*@ f x
     modifies x *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/basic_functions_axioms.mli
+++ b/test/syntax/basic_functions_axioms.mli
@@ -125,7 +125,3 @@ type 'a t6 = { xx : 'a; yy : int }
   | {y = B; x} -> {yy=int_of_integer 10; xx = b.y }
   | {x; y} -> {xx=y;yy=x}
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/bitvector.mli
+++ b/test/syntax/bitvector.mli
@@ -22,7 +22,3 @@ val mem : int -> t -> bool
 (*@ b = mem i bv
     checks 0 <= i < bv.size
     ensures b <-> mem i bv *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/constants.mli
+++ b/test/syntax/constants.mli
@@ -12,7 +12,3 @@ val y : t
 val modify_y : unit -> unit
 (*@ modify_y ()
     modifies y *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/constructor_arity5.mli
+++ b/test/syntax/constructor_arity5.mli
@@ -5,7 +5,3 @@ val f : (int * int) option -> unit
              | Some (_,_) -> true
              | _ -> false
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/exceptions.mli
+++ b/test/syntax/exceptions.mli
@@ -47,7 +47,3 @@ val f : 'a -> 'a
     raises E11 'a' -> true
     raises E11 ('a' | 'b') -> true
     raises E11 ('c'..'z') -> true *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/expressions.mli
+++ b/test/syntax/expressions.mli
@@ -30,7 +30,3 @@ val f : int -> int -> int
     ensures r = x + y
     ensures r > 2
     ensures r = 3 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/ghost_arg1.mli
+++ b/test/syntax/ghost_arg1.mli
@@ -19,7 +19,3 @@ val log2_existsb : int -> int
 (*@ r = log2_existsb x
     requires exists i. i >= 0 /\ x = pow 2 i
     ensures x = pow 2 r *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/ghost_arg2.mli
+++ b/test/syntax/ghost_arg2.mli
@@ -7,7 +7,3 @@ val fib : int -> int -> int -> int
     requires a = fibonacci i
     requires b = fibonacci (i+1)
     ensures r = fibonacci (i+n) *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/infix.mli
+++ b/test/syntax/infix.mli
@@ -5,7 +5,3 @@ val ( == ) : 'a -> 'a -> bool
 val ( == ) : 'a -> 'a -> bool
 (*@ r = x == y
       ensures r <-> x = y *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/invariants.mli
+++ b/test/syntax/invariants.mli
@@ -6,7 +6,3 @@ type t2 = private A | B
 
 type t3 = private int * int
 (*@ invariant 1 > 0 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/literals.mli
+++ b/test/syntax/literals.mli
@@ -9,7 +9,3 @@ val g : char -> string
 (*@ y = g x
     requires x = 'c'
     ensures y = "c" *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/module_with.mli
+++ b/test/syntax/module_with.mli
@@ -7,7 +7,3 @@ module type B = sig
 
   module C : A with type t = t
 end
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/modules1.mli
+++ b/test/syntax/modules1.mli
@@ -16,7 +16,3 @@ type int
  * module A : TA with type 'a t := 'a t1 *)
 
 (* @ function t1 (x:'a t1) : float = A.f x *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/modules2.mli
+++ b/test/syntax/modules2.mli
@@ -59,7 +59,3 @@ val default : MF.ft -> MF.ft
     requires MF.fp1 y
     ensures MF.fp2 x
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/no_specification.mli
+++ b/test/syntax/no_specification.mli
@@ -1,5 +1,1 @@
 val f : int -> unit
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/open2.mli
+++ b/test/syntax/open2.mli
@@ -1,7 +1,3 @@
 open Type
 
 type t2 = t
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/open3.mli
+++ b/test/syntax/open3.mli
@@ -3,7 +3,3 @@ open Types_functions
 type t3 = t1 * int t2
 
 (*@ function f4 (x: int t2) (y: t1) : t3 = (y,x) *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/open_gospelstdlib_module.mli
+++ b/test/syntax/open_gospelstdlib_module.mli
@@ -1,7 +1,3 @@
 type 'a t = 'a list
 
 (*@ open Set *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/open_qualified.mli
+++ b/test/syntax/open_qualified.mli
@@ -4,7 +4,3 @@ type t4 = t3
 type t5 = int Types_functions.t2
 
 (*@ function f5 (x: 'a Types_functions.t2) : Types_functions.t1 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/partial_application.mli
+++ b/test/syntax/partial_application.mli
@@ -2,7 +2,3 @@ val scalar_product : int list -> int -> int list
 
 (*@ r = scalar_product v s
     ensures List.map integer_of_int r = List.map ((fun x y -> x * integer_of_int y) (integer_of_int s)) v *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/predicates.mli
+++ b/test/syntax/predicates.mli
@@ -19,7 +19,3 @@ val merge : int array -> int array -> int array
 (*@ requires n >= 0
     variant n
     ensures result >= 0 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/pure.mli
+++ b/test/syntax/pure.mli
@@ -3,7 +3,3 @@ val f : int -> int * int
 
 val f : int -> int * int * int
 (*@ pure *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/qualified.mli
+++ b/test/syntax/qualified.mli
@@ -1,7 +1,3 @@
 (*@ type t3 = Open2.t2 *)
 
 (*@ type t4 = Type.t *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/recursive_invariants.mli
+++ b/test/syntax/recursive_invariants.mli
@@ -12,7 +12,3 @@ type u = private { tag : int; next : u }
 val f : u -> u
 (*@ y = f x
     requires x.tag = 0 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/stdlib_exceptions.mli
+++ b/test/syntax/stdlib_exceptions.mli
@@ -9,7 +9,3 @@ val find : ('a -> bool) -> 'a list -> 'a
 val invalid_arg : string -> 'a
 (*@ raises  Invalid_argument _ -> true
     ensures false *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/type.mli
+++ b/test/syntax/type.mli
@@ -1,5 +1,1 @@
 type t
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/type_decl.mli
+++ b/test/syntax/type_decl.mli
@@ -43,7 +43,3 @@ and 'b t22 = C of 'b
 type t23 = u
 and u = C of v
 and v = t23
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/types.mli
+++ b/test/syntax/types.mli
@@ -2,7 +2,3 @@ type t = int -> int
 type u = (int -> int) ref
 type v = private { x : int -> int }
 (*@ with self invariant self.x 0i = 0 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/types_functions.mli
+++ b/test/syntax/types_functions.mli
@@ -6,7 +6,3 @@ type 'a t2
 (*@ function f2 (x: int) : t1 *)
 
 (*@ function f3 (x: int) : int t2 = f1 (f2 x) *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/syntax/types_functions2.mli
+++ b/test/syntax/types_functions2.mli
@@ -30,7 +30,3 @@ type ('a, 'b) t7 = 'a t6
   match x with
   | {x;y} -> {x;y}
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/utils/testchecker.ml
+++ b/test/utils/testchecker.ml
@@ -21,13 +21,13 @@ let print_and_delete ppf file =
   s
 
 let test_file file =
-  let stdout = str "%s_stdout" file in
   let stderr = str "%s_stderr" file in
-  let command = str "gospel check %s > %s 2> %s" file stdout stderr in
+  let command = str "gospel check %s > %s 2> %s" file Filename.null stderr in
   let status = Sys.command command in
-  let output = if status = 0 then stdout else stderr in
-  pr "%a@\n(* @[{gospel_expected|@\n[%d] @[%a@]@\n|gospel_expected}@] *)@\n"
-    print file status print_and_delete output
+  pr "%a@\n" print file;
+  if status <> 0 then
+    pr "(* @[{gospel_expected|@\n[%d] @[%a@]@\n|gospel_expected}@] *)@\n" status
+      print_and_delete stderr
 
 let () =
   let file = Sys.argv.(1) in

--- a/test/utils/testchecker.ml
+++ b/test/utils/testchecker.ml
@@ -15,11 +15,6 @@ let print ppf file =
   aux ~first:true ();
   close_in ch
 
-let print_and_delete ppf file =
-  let s = print ppf file in
-  Sys.remove file;
-  s
-
 let test_file file =
   let stderr = str "%s_stderr" file in
   let command = str "gospel check %s > %s 2> %s" file Filename.null stderr in
@@ -27,7 +22,7 @@ let test_file file =
   pr "%a@\n" print file;
   if status <> 0 then
     pr "(* @[{gospel_expected|@\n[%d] @[%a@]@\n|gospel_expected}@] *)@\n" status
-      print_and_delete stderr
+      print stderr
 
 let () =
   let file = Sys.argv.(1) in

--- a/test/vocal/Arrays.mli
+++ b/test/vocal/Arrays.mli
@@ -73,7 +73,3 @@ val knuth_shuffle : 'a array -> unit
 (*@ knuth_shuffle a
       modifies a
       ensures  Array.permut (old a) a *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/CountingSort.mli
+++ b/test/vocal/CountingSort.mli
@@ -30,7 +30,3 @@ val in_place_counting_sort : int -> int array -> unit
       modifies a
       ensures  sorted a
       ensures  Array.permut (old a) a *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/FM19.mli
+++ b/test/vocal/FM19.mli
@@ -110,7 +110,3 @@ val f : tt -> tt -> tt -> tt -> int -> tt * tt * int
     requires true (* P in the paper *)
     modifies p1, p2.left  consumes p3
     ensures  true (* Q in the paper *) *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/HashTable.mli
+++ b/test/vocal/HashTable.mli
@@ -115,7 +115,3 @@ module Make (K : HashedType) : sig
   (*@ b = mem h k
     ensures b <-> h.view k <> [] *)
 end
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/Lists.mli
+++ b/test/vocal/Lists.mli
@@ -24,7 +24,3 @@ val map : ('a -> 'b) -> 'a list -> 'b list
       ensures forall i. 0 <= i < List.length l ->
                 List.nth r i = f (List.nth l i)
       equivalent "List.rev (List.map f (List.rev l))" *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/Mjrty.mli
+++ b/test/vocal/Mjrty.mli
@@ -26,7 +26,3 @@ val mjrty : string array -> string
       ensures  2 * num a r 0 (Array.length a) > Array.length a
       raises   Not_found ->
                forall c. 2 * num a c 0 (Array.length a) <= Array.length a *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/PairingHeap.mli
+++ b/test/vocal/PairingHeap.mli
@@ -63,7 +63,3 @@ end) : sig
         ensures  forall y. y <> minimum h -> Bag.occurrences y h'.bag = Bag.occurrences y h.bag
         ensures  Bag.cardinal h'.bag = Bag.cardinal h.bag - 1 *)
 end
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/PriorityQueue.mli
+++ b/test/vocal/PriorityQueue.mli
@@ -84,7 +84,3 @@ end) : sig
       modifies h
       ensures  h.bag = Bag.add x (old h).bag *)
 end
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/Queue.mli
+++ b/test/vocal/Queue.mli
@@ -41,7 +41,3 @@ val transfer : 'a t -> 'a t -> unit
       modifies q1.view, q2.view
       ensures  q1.view = Sequence.empty
       ensures  q2.view = old q2.view ++ old q1.view *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/RingBuffer.mli
+++ b/test/vocal/RingBuffer.mli
@@ -62,7 +62,3 @@ val copy : 'a buffer -> 'a buffer
       ensures b.capacity = r.capacity
       ensures forall i. 0 <= i < length r.sequence ->
         b.sequence[i] = r.sequence[i] *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/UnionFind.mli
+++ b/test/vocal/UnionFind.mli
@@ -121,7 +121,3 @@ val union : 'a elem -> 'a elem -> unit
       uf1.img x = if mem x (old uf1.dom) then old (uf1.img x)
                                          else old (uf2.img x)
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/Vector.mli
+++ b/test/vocal/Vector.mli
@@ -330,7 +330,3 @@ val unsafe_resize: 'a t -> int -> unit
 val unsafe_get : 'a t -> int -> 'a
 val unsafe_set : 'a t -> int -> 'a -> unit
 *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/test/vocal/ZipperList.mli
+++ b/test/vocal/ZipperList.mli
@@ -92,7 +92,3 @@ val focused : 'a t -> 'a option
     ensures match r with
             | None   -> z.idx = Sequence.length z.seq
             | Some x -> z.idx < Sequence.length z.seq /\ x = z.seq[z.idx] *)
-
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)


### PR DESCRIPTION
Wrapping up the `OK` of `gospel check` up in a `gospel_expected` comment is verbose and not really useful, so drop them altogether in the test suite
Address a comment made in #362