### PR TITLE
Propagate non-optional name to typed ast

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@
 ## Improved
 
 - Make the `with` necessary when declaring type invariants
-  [\#372](https://github.com/ocaml-gospel/gospel/pull/372)
+  [\#372](https://github.com/ocaml-gospel/gospel/pull/372) and
+  [\#374](https://github.com/ocaml-gospel/gospel/pull/374)
 
 ## Internals
 

--- a/src/tast.ml
+++ b/src/tast.ml
@@ -57,7 +57,7 @@ type val_description = {
 type type_spec = {
   ty_ephemeral : bool;  (** Ephemeral *)
   ty_fields : (lsymbol * bool) list;  (** Models (field symbol * mutable) *)
-  ty_invariants : vsymbol option * term list;  (** Invariants *)
+  ty_invariants : (vsymbol * term list) option;  (** Invariants *)
   ty_text : string;
       (** String containing the original specificaion as written by the user *)
   ty_loc : Location.t; [@printer Utils.Fmt.pp_loc]  (** Specification location *)

--- a/src/tast_helper.mli
+++ b/src/tast_helper.mli
@@ -10,7 +10,7 @@ val vs_of_lb_arg : lb_arg -> vsymbol
 val type_spec :
   bool ->
   (lsymbol * bool) list ->
-  vsymbol option * term list ->
+  (vsymbol * term list) option ->
   string ->
   Location.t ->
   type_spec

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -565,21 +565,14 @@ let process_type_spec kid crcm ns ty spec =
   in
   let ns, fields = List.fold_left field (ns, []) spec.ty_field in
   let fields = List.rev fields in
-  let self_vs =
-    Option.map (fun (x, _) -> create_vsymbol x ty) spec.ty_invariant
+  let aux = function
+    | vs, xs ->
+        let self_vs = create_vsymbol vs ty in
+        let env = Mstr.singleton self_vs.vs_name.id_str self_vs in
+        (self_vs, List.map (fmla Invariant kid crcm ns env) xs)
   in
-  let env =
-    match self_vs with
-    | Some vs -> Mstr.singleton vs.vs_name.id_str vs
-    | None -> Mstr.empty
-  in
-  let invariants =
-    match spec.ty_invariant with
-    | None -> []
-    | Some (_, xs) -> List.map (fmla Invariant kid crcm ns env) xs
-  in
-  type_spec spec.ty_ephemeral fields (self_vs, invariants) spec.ty_text
-    spec.ty_loc
+  let invariants = Option.map aux spec.ty_invariant in
+  type_spec spec.ty_ephemeral fields invariants spec.ty_text spec.ty_loc
 
 (* TODO compare manifest with td_kind *)
 let type_type_declaration kid crcm ns r tdl =

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -114,7 +114,7 @@ First, create a test artifact:
                          ls_constr = false; ls_field = true },
                        false)
                       ];
-                    ty_invariants = (None, []);
+                    ty_invariants = None;
                     ty_text =
                     " mutable model contents : 'a list\n    model size : int ";
                     ty_loc = foo.mli:5:3 });


### PR DESCRIPTION
This PR completes #372.

It contains a breaking change in the typed AST.
