### PR TITLE
Change `ls_equal` implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Internals
 
+- Use unique identifiers rather than physical equality for `Symbols.ls_equal`
+  [\#380](https://github.com/ocaml-gospel/gospel/pull/380)
 - Remove the `gospel_expected` prologue at the end of successful tests
   [\#363](https://github.com/ocaml-gospel/gospel/pull/363)
 

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -39,7 +39,7 @@ type lsymbol = {
 [@@deriving show]
 
 (* CHECK *)
-let ls_equal : lsymbol -> lsymbol -> bool = ( == )
+let ls_equal l r = Ident.equal l.ls_name r.ls_name
 
 module LS = struct
   type t = lsymbol


### PR DESCRIPTION

This PR proposes to move from physical equality to equality of the identifiers.

This will be needed as we plan to make gospel type checker modular (see #377): different files will be typed by different runs of the gospel program and physical equality won't hold between these runs.