### PR TITLE
Fix `is_ts_tuple`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 
 ## Internals
 
+- Fix the `is_ts_tuple` function so that it doesn't take `unit` to be a tuple
+  [\#386](https://github.com/ocaml-gospel/gospel/pull/386)
 - Use unique identifiers rather than physical equality for `Symbols.ls_equal`
   [\#380](https://github.com/ocaml-gospel/gospel/pull/380)
 - Remove the `gospel_expected` prologue at the end of successful tests

--- a/src/ttypes.ml
+++ b/src/ttypes.ml
@@ -243,7 +243,10 @@ let ts_arrow =
   ts id [ ta; tb ]
 
 let is_ts_tuple ts =
-  let ts_tuple = ts_tuple (ts_arity ts) in
+  let n = ts_arity ts in
+  n > 0
+  &&
+  let ts_tuple = ts_tuple n in
   Ident.equal ts_tuple.ts_ident ts.ts_ident
 
 let is_ts_arrow ts = Ident.equal ts_arrow.ts_ident ts.ts_ident

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -932,7 +932,7 @@ let process_val_spec kid crcm ns id args ret vs =
   let env, ret =
     match (header.sp_hd_ret, ret.ty_node) with
     | [], _ -> (env, [])
-    | _, Tyapp (ts, tyl) when (not (ts_equal ts ts_unit)) && is_ts_tuple ts ->
+    | _, Tyapp (ts, tyl) when is_ts_tuple ts ->
         let tyl = List.map (fun ty -> (ty, Asttypes.Nolabel)) tyl in
         process_args `Return header.sp_hd_ret tyl env []
     | _, _ ->


### PR DESCRIPTION

This PR proposes to change the implementation of the `Ttypes.is_ts_tuple` function so that it doesnt confuse `unit` for a tuple of length 0.

This has the immediate benefit of concentrating the logic in the function rather than having to check that a type symbol is not `ts_unit` before calling `is_ts_tuple` (hence the simplifcation of the condition in `Typing.process_val_spec`.

This also improves the state of [ortac#207](https://github.com/ocaml-gospel/ortac/issues/207)