### PR TITLE
Fix `ls_name` for unit logical symbol

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@
 
 - Fix premature parsing of specification keywords in the preprocessor.
   [\#394](https://github.com/ocaml-gospel/gospel/pull/394)
+- Fix `ls_name` of `unit` logical symbol to be `()`
+  [\#387](https://github.com/ocaml-gospel/gospel/pull/387)
 - Fix the `is_ts_tuple` function so that it doesn't take `unit` to be a tuple
   [\#386](https://github.com/ocaml-gospel/gospel/pull/386)
 - Use unique identifiers rather than physical equality for `Symbols.ls_equal`

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -79,7 +79,7 @@ let ps_equ =
 
 let fs_unit =
   fsymbol ~constr:true ~field:false
-    (Ident.create ~loc:Location.none "unit")
+    (Ident.create ~loc:Location.none "()")
     [] ty_unit
 
 let fs_bool_true =


### PR DESCRIPTION

This PR fixes #385

Along with #386, this also fixes [ortac#207](https://github.com/ocaml-gospel/ortac/issues/207)