### PR TITLE
Bool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   [#406] (https://github.com/ocaml-gospel/gospel/pull/406)
 - Display an error message when encoutering a Functor application
   [#404] (https://github.com/ocaml-gospel/gospel/pull/404)
+- Changed the gospel typechecker to use bool as the type of logical formulae
+  [\#391](https://github.com/ocaml-gospel/gospel/pull/391)
 
 # 0.3
 

--- a/src/coercion.ml
+++ b/src/coercion.ml
@@ -27,7 +27,7 @@ type coercion = {
 
 let ty_of ls =
   match (ls.ls_args, ls.ls_value) with
-  | [ { ty_node = Tyapp (ty1, _) } ], Some { ty_node = Tyapp (ty2, _) } ->
+  | [ { ty_node = Tyapp (ty1, _) } ], { ty_node = Tyapp (ty2, _) } ->
       (ty1.ts_ident.id_str, ty2.ts_ident.id_str)
   | _ -> assert false
 
@@ -47,7 +47,7 @@ let empty = Mts.empty
 
 let create_crc ls =
   match (ls.ls_args, ls.ls_value) with
-  | [ { ty_node = Tyapp (ts1, tl1) } ], Some { ty_node = Tyapp (ts2, tl2) }
+  | [ { ty_node = Tyapp (ts1, tl1) } ], { ty_node = Tyapp (ts2, tl2) }
     when not (ts_equal ts1 ts2) ->
       {
         crc_kind = CRCleaf ls;

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -410,4 +410,3 @@ and term_node ~loc env dty dterm_node =
       t_case t pl loc
 
 let term env dt = term env dt
-let fmla env dt = term env dt

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -186,19 +186,17 @@ let dty_unify ~loc dty1 dty2 =
 let dterm_unify dt dty =
   match dt.dt_dty with
   | Some dt_dty -> dty_unify ~loc:dt.dt_loc dt_dty dty
-  | None -> (
-      try unify dty_bool dty
-      with Exit -> W.error ~loc:dt.dt_loc W.Term_expected)
+  | None -> assert false
 
 let dfmla_unify dt =
   match dt.dt_dty with
-  | None -> ()
+  | None -> assert false
   | Some dt_dty -> (
       try unify dt_dty dty_bool
       with Exit -> W.error ~loc:dt.dt_loc W.Formula_expected)
 
 let unify dt dty =
-  match dty with None -> dfmla_unify dt | Some dt_dty -> dterm_unify dt dt_dty
+  match dty with None -> assert false | Some dt_dty -> dterm_unify dt dt_dty
 
 (* environment *)
 
@@ -293,7 +291,7 @@ let dterm_expected_op crcmap dt dty =
   unify dt dty;
   dt
 
-let dfmla_expected crcmap dt = dterm_expected_op crcmap dt None
+let dfmla_expected crcmap dt = dterm_expected_op crcmap dt (Some dty_bool)
 let dterm_expected crcmap dt dty = dterm_expected_op crcmap dt (Some dty)
 
 (** dterm to tterm *)
@@ -329,20 +327,6 @@ let pattern dp =
 let rec term env dt =
   let loc = dt.dt_loc in
   term_node ~loc env dt.dt_dty dt.dt_node
-(*
-let rec term env prop dt =
-  let loc = dt.dt_loc in
-  let t = term_node ~loc env prop dt.dt_dty dt.dt_node in
-  match t.t_ty with
-  | Some _ when prop -> (
-      try t_equ t (t_bool_true loc) loc
-      with TypeMismatch (ty1, ty2) ->
-        let t1 = Fmt.str "%a" print_ty ty1 in
-        let t2 = Fmt.str "%a" print_ty ty2 in
-        W.error ~loc (W.Bad_type (t1, t2)))
-  | None when not prop -> t_if t (t_bool_true loc) (t_bool_false loc) loc
-  | _ -> t
- *)
 
 and term_node ~loc env dty dterm_node =
   match dterm_node with

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -337,10 +337,6 @@ and term_node ~loc env dty dterm_node =
   | DTconst c -> t_const c (ty_of_dty (Option.get dty)) loc
   | DTapp (ls, []) when ls_equal ls fs_bool_true -> t_true loc
   | DTapp (ls, []) when ls_equal ls fs_bool_false -> t_false loc
-  | DTapp (ls, [ dt1; dt2 ]) when ls_equal ls ps_equ ->
-      if dt1.dt_dty = None || dt2.dt_dty = None then
-        f_iff (term env dt1) (term env dt2) loc
-      else t_equ (term env dt1) (term env dt2) loc
   | DTapp (ls, [ dt1 ]) when ls.ls_field ->
       t_field (term env dt1) ls
         (Option.fold ~some:ty_of_dty ~none:ty_bool dty)

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -354,7 +354,7 @@ and term_node ~loc env dty dterm_node =
       t_if (term env dt1) (term env dt2) (term env dt3) loc
   | DTlet (pid, dt1, dt2) ->
       let t1 = term env dt1 in
-      let vs = create_vsymbol pid (t_type t1) in
+      let vs = create_vsymbol pid t1.t_ty in
       let env = Mstr.add pid.pid_str vs env in
       let t2 = term env dt2 in
       t_let vs t1 t2 loc

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -142,8 +142,8 @@ let rec unify_dty_ty dty ty =
   match (head dty, ty.ty_node) with
   | Tvar tvar, _ -> tvar.dtv_def <- Some (Tty ty)
   | Tty ty1, _ when ty_equal ty1 ty -> ()
-  | Tapp (ts1, dl), Tyapp (ts2, tl) when ts_equal ts1 ts2 -> (
-      try List.iter2 unify_dty_ty dl tl with Invalid_argument _ -> raise Exit)
+  | Tapp (ts1, dl), Tyapp (ts2, tl) when ts_equal ts1 ts2 ->
+      List.iter2 unify_dty_ty dl tl
   | _ -> raise Exit
 
 let rec unify dty1 dty2 =
@@ -151,8 +151,8 @@ let rec unify dty1 dty2 =
   | Tvar { dtv_id = id1; _ }, Tvar { dtv_id = id2; _ } when id1 = id2 -> ()
   | Tvar tvar, dty | dty, Tvar tvar ->
       if occur tvar dty then raise Exit else tvar.dtv_def <- Some dty
-  | Tapp (ts1, dtyl1), Tapp (ts2, dtyl2) when ts_equal ts1 ts2 -> (
-      try List.iter2 unify dtyl1 dtyl2 with Invalid_argument _ -> raise Exit)
+  | Tapp (ts1, dtyl1), Tapp (ts2, dtyl2) when ts_equal ts1 ts2 ->
+      List.iter2 unify dtyl1 dtyl2
   | Tty ty, dty | dty, Tty ty -> unify_dty_ty dty ty
   | _ -> raise Exit
 

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -278,15 +278,6 @@ let max_dty crcmap dtl =
   in
   if l = [] then (List.hd dtl).dt_dty else aux l
 
-let max_dty crcmap dtl =
-  match max_dty crcmap dtl with
-  | Some (Tty ty)
-    when ty_equal ty ty_bool
-         && List.exists (fun { dt_dty; _ } -> dt_dty = None) dtl ->
-      (* favor prop over bool *)
-      None
-  | dty -> dty
-
 let dterm_expected crcmap dt dty =
   try
     let ts1, ts2 = (ts_of_dty dt.dt_dty, ts_of_dty dty) in
@@ -335,6 +326,10 @@ let pattern dp =
   let p = pattern_node dp in
   (p, !vars)
 
+let rec term env dt =
+  let loc = dt.dt_loc in
+  term_node ~loc env dt.dt_dty dt.dt_node
+(*
 let rec term env prop dt =
   let loc = dt.dt_loc in
   let t = term_node ~loc env prop dt.dt_dty dt.dt_node in
@@ -347,66 +342,63 @@ let rec term env prop dt =
         W.error ~loc (W.Bad_type (t1, t2)))
   | None when not prop -> t_if t (t_bool_true loc) (t_bool_false loc) loc
   | _ -> t
+ *)
 
-and term_node ~loc env prop dty dterm_node =
+and term_node ~loc env dty dterm_node =
   match dterm_node with
   | DTvar pid ->
       let vs = denv_find ~loc:pid.pid_loc pid.pid_str env in
       (* TODO should I match vs.vs_ty with dty? *)
       t_var vs loc
   | DTconst c -> t_const c (ty_of_dty (Option.get dty)) loc
-  | DTapp (ls, []) when ls_equal ls fs_bool_true ->
-      if prop then t_true loc else t_bool_true loc
-  | DTapp (ls, []) when ls_equal ls fs_bool_false ->
-      if prop then t_false loc else t_bool_false loc
+  | DTapp (ls, []) when ls_equal ls fs_bool_true -> t_true loc
+  | DTapp (ls, []) when ls_equal ls fs_bool_false -> t_false loc
   | DTapp (ls, [ dt1; dt2 ]) when ls_equal ls ps_equ ->
       if dt1.dt_dty = None || dt2.dt_dty = None then
-        f_iff (term env true dt1) (term env true dt2) loc
-      else t_equ (term env false dt1) (term env false dt2) loc
+        f_iff (term env dt1) (term env dt2) loc
+      else t_equ (term env dt1) (term env dt2) loc
   | DTapp (ls, [ dt1 ]) when ls.ls_field ->
-      t_field (term env false dt1) ls
+      t_field (term env dt1) ls
         (Option.fold ~some:ty_of_dty ~none:ty_bool dty)
         loc
   | DTapp (ls, dtl) ->
       t_app ls
-        (List.map (term env false) dtl)
+        (List.map (term env) dtl)
         (Option.fold ~some:ty_of_dty ~none:ty_bool dty)
         loc
   | DTif (dt1, dt2, dt3) ->
-      let prop = prop || dty = None in
-      t_if (term env true dt1) (term env prop dt2) (term env prop dt3) loc
+      t_if (term env dt1) (term env dt2) (term env dt3) loc
   | DTlet (pid, dt1, dt2) ->
-      let prop = prop || dty = None in
-      let t1 = term env false dt1 in
+      let t1 = term env dt1 in
       let vs = create_vsymbol pid (t_type t1) in
       let env = Mstr.add pid.pid_str vs env in
-      let t2 = term env prop dt2 in
+      let t2 = term env dt2 in
       t_let vs t1 t2 loc
   | DTbinop (b, dt1, dt2) ->
-      let t1, t2 = (term env true dt1, term env true dt2) in
+      let t1, t2 = (term env dt1, term env dt2) in
       t_binop b t1 t2 loc
-  | DTnot dt -> t_not (term env true dt) loc
-  | DTtrue -> if prop then t_true loc else t_bool_true loc
-  | DTfalse -> if prop then t_false loc else t_bool_false loc
+  | DTnot dt -> t_not (term env dt) loc
+  | DTtrue -> t_true loc
+  | DTfalse -> t_false loc
   | DTattr (dt, at) ->
-      let t = term env prop dt in
+      let t = term env dt in
       t_attr_set at t
-  | DTold dt -> t_old (term env prop dt) loc
+  | DTold dt -> t_old (term env dt) loc
   | DTquant (q, bl, dt) ->
       let add_var (env, vsl) (pid, dty) =
         let vs = create_vsymbol pid (ty_of_dty dty) in
         (Mstr.add pid.pid_str vs env, vs :: vsl)
       in
       let env, vsl = List.fold_left add_var (env, []) bl in
-      let t = term env prop dt in
-      t_quant q (List.rev vsl) t (Option.map ty_of_dty dty) loc
+      let t = term env dt in
+      t_quant q (List.rev vsl) t (ty_of_dty (Option.get dty)) loc
   | DTlambda (dpl, dt) ->
       let ty = ty_of_dty_raw dty and pl = List.map pattern dpl in
       let env =
         let join _ _ vs = Some vs in
         List.fold_left (fun env (_, vs) -> Mstr.union join env vs) env pl
       in
-      let t = term env false dt in
+      let t = term env dt in
       (* Are the patterns exhaustive? *)
       List.iter
         (fun (p, _) ->
@@ -415,16 +407,16 @@ and term_node ~loc env prop dty dterm_node =
             [ (p, None, t (* [t] is really just a place holder *)) ]
             ~loc)
         pl;
-      t_lambda (List.map fst pl) t (Some ty) loc
+      t_lambda (List.map fst pl) t ty loc
   | DTcase (dt, ptl) ->
-      let t = term env false dt in
+      let t = term env dt in
       let branch (dp, guard, dt) =
         let p, vars = pattern dp in
         let join _ _ vs = Some vs in
         let env = Mstr.union join env vars in
-        let dt = term env false dt in
+        let dt = term env dt in
         let guard =
-          match guard with None -> None | Some g -> Some (term env true g)
+          match guard with None -> None | Some g -> Some (term env g)
         in
         (p, guard, dt)
       in
@@ -433,5 +425,5 @@ and term_node ~loc env prop dty dterm_node =
       Patmat.checks ty pl ~loc;
       t_case t pl loc
 
-let fmla env dt = term env true dt
-let term env dt = term env false dt
+let term env dt = term env dt
+let fmla env dt = term env dt

--- a/src/dterm.mli
+++ b/src/dterm.mli
@@ -81,5 +81,4 @@ val is_in_denv : denv -> string -> bool
 val denv_add_var : denv -> string -> dty -> denv
 val denv_add_var_quant : denv -> (Identifier.Preid.t * dty) list -> denv
 val term : vsymbol Mstr.t -> dterm -> term
-val fmla : vsymbol Mstr.t -> dterm -> term
 val pattern : dpattern -> Tterm.pattern * vsymbol Mstr.t

--- a/src/dterm.mli
+++ b/src/dterm.mli
@@ -58,7 +58,7 @@ val dty_of_dterm : dterm -> dty
 val dty_of_ty : Ttypes.ty -> dty
 val dty_fresh : unit -> dty
 val max_dty : Coercion.t -> dterm list -> dty option
-val specialize_ls : lsymbol -> dty list * dty option
+val specialize_ls : lsymbol -> dty list * dty
 val specialize_cs : loc:Location.t -> lsymbol -> dty list * dty
 val dty_unify : loc:Location.t -> dty -> dty -> unit
 val dterm_unify : dterm -> dty -> unit

--- a/src/patmat.ml
+++ b/src/patmat.ml
@@ -173,9 +173,7 @@ end = struct
     match pmat.mat with
     | [ e ] ->
         let args, l = split [] 0 e in
-        let hd =
-          mk_pattern (Papp (ck, args)) (Option.get ck.ls_value) Location.none
-        in
+        let hd = mk_pattern (Papp (ck, args)) ck.ls_value Location.none in
         { rows = 1; cols = pmat.cols - ak + 1; mat = [ hd :: l ] }
     | _ -> assert false
 end

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -32,7 +32,7 @@ module Mvs = Map.Make (Vs)
 type lsymbol = {
   ls_name : Ident.t;
   ls_args : ty list;
-  ls_value : ty option;
+  ls_value : ty;
   ls_constr : bool;
   (* true if it is a construct, false otherwise*)
   ls_field : bool; (* true if it is a record/model field *)
@@ -57,19 +57,19 @@ let lsymbol ?(constr = false) ~field ls_name ls_args ls_value =
   { ls_name; ls_args; ls_value; ls_constr = constr; ls_field = field }
 
 let fsymbol ?(constr = false) ~field nm tyl ty =
-  lsymbol ~constr ~field nm tyl (Some ty)
+  lsymbol ~constr ~field nm tyl ty
 
-let psymbol nm ty = lsymbol ~field:false nm ty None
+let psymbol nm ty = lsymbol ~field:false nm ty ty_bool
 
 let ls_subst_ts old_ts new_ts ({ ls_name; ls_constr; ls_field; _ } as ls) =
   let ls_args = List.map (ty_subst_ts old_ts new_ts) ls.ls_args in
-  let ls_value = Option.map (ty_subst_ts old_ts new_ts) ls.ls_value in
+  let ls_value = ty_subst_ts old_ts new_ts ls.ls_value in
   lsymbol ls_name ls_args ls_value ~constr:ls_constr ~field:ls_field
 
 let ls_subst_ty old_ts new_ts new_ty ls =
   let subst ty = ty_subst_ty old_ts new_ts new_ty ty in
   let ls_args = List.map subst ls.ls_args in
-  let ls_value = Option.map subst ls.ls_value in
+  let ls_value = subst ls.ls_value in
   lsymbol ls.ls_name ls_args ls_value ~constr:ls.ls_constr ~field:ls.ls_field
 
 (** buil-in lsymbols *)

--- a/src/tast_helper.ml
+++ b/src/tast_helper.ml
@@ -48,9 +48,9 @@ let mk_val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc =
   in
   let (_ : Svs.t) = List.fold_left add Svs.empty args in
   let ty_check ty t = t_ty_check t ty in
-  List.iter (ty_check None) pre;
-  List.iter (ty_check None) checks;
-  List.iter (ty_check None) post;
+  List.iter (ty_check ty_bool) pre;
+  List.iter (ty_check ty_bool) checks;
+  List.iter (ty_check ty_bool) post;
   val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc
 
 let mk_val_description vd_name vd_type vd_prim vd_attrs vd_args vd_ret vd_spec
@@ -83,7 +83,7 @@ let type_declaration td_ts td_params td_cstrs td_kind td_private td_manifest
 let axiom ax_name ax_term ax_loc ax_text = { ax_name; ax_term; ax_text; ax_loc }
 
 let mk_axiom id t l =
-  t_ty_check t None;
+  t_ty_check t ty_bool;
   axiom id t l
 
 let fun_spec fun_req fun_ens fun_variant fun_coer fun_text fun_loc =
@@ -92,11 +92,11 @@ let fun_spec fun_req fun_ens fun_variant fun_coer fun_text fun_loc =
 let mk_fun_spec req ens var coer =
   let t_ty_check ty t = t_ty_check t ty in
   (* Check that preconditions are of type prop *)
-  List.iter (t_ty_check None) req;
+  List.iter (t_ty_check ty_bool) req;
   (* Check that postconditions are of type prop *)
-  List.iter (t_ty_check None) ens;
+  List.iter (t_ty_check ty_bool) ens;
   (* Check that variants are of type integer *)
-  List.iter (t_ty_check (Some ty_integer)) var;
+  List.iter (t_ty_check ty_integer) var;
   fun_spec req ens var coer
 
 let function_ fun_ls fun_rec fun_params fun_def fun_spec fun_loc fun_text =
@@ -120,7 +120,7 @@ let function_ fun_ls fun_rec fun_params fun_def fun_spec fun_loc fun_text =
    5 - elements of v are of type integer, and elements of treq and
    tens are of type None
 *)
-let mk_function ?result ls r params def spec loc =
+let mk_function result ls r params def spec loc =
   (* check 1 *)
   let add_v s vs ty =
     if Svs.mem vs s then W.error ~loc (W.Duplicated_argument vs.vs_name.id_str);
@@ -133,11 +133,10 @@ let mk_function ?result ls r params def spec loc =
   Option.iter (t_free_vs_in_set args) def;
   Option.iter (fun spec -> List.iter (t_free_vs_in_set args) spec.fun_req) spec;
   let args_r =
-    match (result, ls.ls_value) with
-    | Some vs, Some ty ->
-        ty_equal_check vs.vs_ty ty;
-        Svs.add vs args
-    | _ -> args
+    let vs = result in
+    let ty = ls.ls_value in
+    ty_equal_check vs.vs_ty ty;
+    Svs.add vs args
   in
   Option.iter
     (fun spec -> List.iter (t_free_vs_in_set args_r) spec.fun_ens)
@@ -148,8 +147,8 @@ let mk_function ?result ls r params def spec loc =
   Option.iter (check_ty ls.ls_value) def;
   Option.iter
     (fun spec ->
-      List.iter (check_ty (Some ty_integer)) spec.fun_variant;
-      List.iter (check_ty None) spec.fun_ens)
+      List.iter (check_ty ty_integer) spec.fun_variant;
+      List.iter (check_ty ty_bool) spec.fun_ens)
     spec;
 
   function_ ls r params def spec loc

--- a/src/tast_helper.ml
+++ b/src/tast_helper.ml
@@ -37,15 +37,6 @@ let val_spec sp_args sp_ret sp_pre sp_checks sp_post sp_xpost sp_wr sp_cs
    1 - check what to do with writes
    2 - sp_xpost sp_reads sp_alias *)
 let mk_val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc =
-  let add args = function
-    | Lunit -> args
-    | a ->
-        let vs = vs_of_lb_arg a in
-        if Svs.mem vs args then
-          W.error ~loc (W.Duplicated_argument vs.vs_name.id_str);
-        Svs.add vs args
-  in
-  let (_ : Svs.t) = List.fold_left add Svs.empty args in
   val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc
 
 let mk_val_description vd_name vd_type vd_prim vd_attrs vd_args vd_ret vd_spec
@@ -81,28 +72,8 @@ let mk_axiom id t l = axiom id t l
 let mk_fun_spec fun_req fun_ens fun_variant fun_coer fun_text fun_loc =
   { fun_req; fun_ens; fun_variant; fun_coer; fun_text; fun_loc }
 
-let function_ fun_ls fun_rec fun_params fun_def fun_spec fun_loc fun_text =
+let mk_function fun_ls fun_rec fun_params fun_def fun_spec fun_loc fun_text =
   { fun_ls; fun_rec; fun_params; fun_def; fun_spec; fun_loc; fun_text }
-
-(* For
-   (*@ function rec f (x:ty1) (y:ty2):ty3 = t
-       variant v
-       requires treq
-       ensures tens
-       coercion
-   *)
-   we check the following
-   1 - no duplicate arguments (Ident.tifiers may have the same
-   string but still be different)
-   2 - types or params match the type of lsymbol
-   3 - free variables of t, treq, v come from the arguments;
-   in case of tens, if it is a function, it can also be the
-   ~result vsylbol
-   4 - type of t is ty3 (None if it is a predicate)
-   5 - elements of v are of type integer, and elements of treq and
-   tens are of type None
-*)
-let mk_function ls r params def spec loc = function_ ls r params def spec loc
 
 let extension_constructor id xs kd loc attrs =
   {

--- a/src/tast_helper.ml
+++ b/src/tast_helper.ml
@@ -1,7 +1,6 @@
 open Tast
 open Ttypes
 open Symbols
-open Tterm_helper
 module W = Warnings
 
 let vs_of_lb_arg = function
@@ -47,10 +46,6 @@ let mk_val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc =
         Svs.add vs args
   in
   let (_ : Svs.t) = List.fold_left add Svs.empty args in
-  let ty_check ty t = t_ty_check t ty in
-  List.iter (ty_check ty_bool) pre;
-  List.iter (ty_check ty_bool) checks;
-  List.iter (ty_check ty_bool) post;
   val_spec args ret pre checks post xpost wr cs dv pure equiv txt loc
 
 let mk_val_description vd_name vd_type vd_prim vd_attrs vd_args vd_ret vd_spec
@@ -81,23 +76,10 @@ let type_declaration td_ts td_params td_cstrs td_kind td_private td_manifest
   }
 
 let axiom ax_name ax_term ax_loc ax_text = { ax_name; ax_term; ax_text; ax_loc }
+let mk_axiom id t l = axiom id t l
 
-let mk_axiom id t l =
-  t_ty_check t ty_bool;
-  axiom id t l
-
-let fun_spec fun_req fun_ens fun_variant fun_coer fun_text fun_loc =
+let mk_fun_spec fun_req fun_ens fun_variant fun_coer fun_text fun_loc =
   { fun_req; fun_ens; fun_variant; fun_coer; fun_text; fun_loc }
-
-let mk_fun_spec req ens var coer =
-  let t_ty_check ty t = t_ty_check t ty in
-  (* Check that preconditions are of type prop *)
-  List.iter (t_ty_check ty_bool) req;
-  (* Check that postconditions are of type prop *)
-  List.iter (t_ty_check ty_bool) ens;
-  (* Check that variants are of type integer *)
-  List.iter (t_ty_check ty_integer) var;
-  fun_spec req ens var coer
 
 let function_ fun_ls fun_rec fun_params fun_def fun_spec fun_loc fun_text =
   { fun_ls; fun_rec; fun_params; fun_def; fun_spec; fun_loc; fun_text }
@@ -120,38 +102,7 @@ let function_ fun_ls fun_rec fun_params fun_def fun_spec fun_loc fun_text =
    5 - elements of v are of type integer, and elements of treq and
    tens are of type None
 *)
-let mk_function result ls r params def spec loc =
-  (* check 1 *)
-  let add_v s vs ty =
-    if Svs.mem vs s then W.error ~loc (W.Duplicated_argument vs.vs_name.id_str);
-    ty_equal_check vs.vs_ty ty;
-    Svs.add vs s
-  in
-  let args = List.fold_left2 add_v Svs.empty params ls.ls_args in
-
-  (* check 3 *)
-  Option.iter (t_free_vs_in_set args) def;
-  Option.iter (fun spec -> List.iter (t_free_vs_in_set args) spec.fun_req) spec;
-  let args_r =
-    let vs = result in
-    let ty = ls.ls_value in
-    ty_equal_check vs.vs_ty ty;
-    Svs.add vs args
-  in
-  Option.iter
-    (fun spec -> List.iter (t_free_vs_in_set args_r) spec.fun_ens)
-    spec;
-
-  (* check 4 and 5 *)
-  let check_ty ty t = t_ty_check t ty in
-  Option.iter (check_ty ls.ls_value) def;
-  Option.iter
-    (fun spec ->
-      List.iter (check_ty ty_integer) spec.fun_variant;
-      List.iter (check_ty ty_bool) spec.fun_ens)
-    spec;
-
-  function_ ls r params def spec loc
+let mk_function ls r params def spec loc = function_ ls r params def spec loc
 
 let extension_constructor id xs kd loc attrs =
   {

--- a/src/tast_helper.mli
+++ b/src/tast_helper.mli
@@ -44,7 +44,6 @@ val mk_fun_spec :
   fun_spec
 
 val mk_function :
-  vsymbol ->
   lsymbol ->
   bool ->
   vsymbol list ->

--- a/src/tast_helper.mli
+++ b/src/tast_helper.mli
@@ -44,7 +44,7 @@ val mk_fun_spec :
   fun_spec
 
 val mk_function :
-  ?result:vsymbol ->
+  vsymbol ->
   lsymbol ->
   bool ->
   vsymbol list ->

--- a/src/tast_printer.ml
+++ b/src/tast_printer.ml
@@ -17,8 +17,7 @@ let print_variant_field fmt ld =
 let print_rec_field fmt ld =
   pp fmt "%s%a:%a"
     (if ld.ld_mut = Mutable then "mutable " else "")
-    Ident.pp_simpl ld.ld_field.ls_name print_ty
-    (Stdlib.Option.get ld.ld_field.ls_value)
+    Ident.pp_simpl ld.ld_field.ls_name print_ty ld.ld_field.ls_value
 
 let print_label_decl_list print_field fmt fields =
   pp fmt "{%a}" (list ~sep:semi print_field) fields
@@ -54,8 +53,7 @@ let print_type_spec fmt { ty_ephemeral; ty_fields; ty_invariants; _ } =
     let print_field f (ls, mut) =
       pp f "@[%s%a : %a@]"
         (if mut then "mutable model " else "model ")
-        print_ls_nm ls print_ty
-        (Stdlib.Option.get ls.ls_value)
+        print_ls_nm ls print_ty ls.ls_value
     in
     let print_invariants ppf i =
       pf ppf "with %a@;%a" print_vs (fst i)
@@ -166,7 +164,7 @@ let print_param f p = pp f "(%a:%a)" Ident.pp_simpl p.vs_name print_ty p.vs_ty
 
 let print_function f x =
   let func_pred =
-    if x.fun_ls.ls_value = None then "predicate" else "function"
+    if ty_equal x.fun_ls.ls_value ty_bool then "predicate" else "function"
   in
   let print_term f t = pp f "@[%a@]" print_term t in
   let print_term f t = pp f "@[%a@]" print_term t in
@@ -194,7 +192,7 @@ let print_function f x =
     pp f "@[%s %s%a %a%a%a%a@]" func_pred
       (if x.fun_rec then "rec " else "")
       Ident.pp_simpl x.fun_ls.ls_name (list ~sep:sp print_param) x.fun_params
-      (option (fun f -> pp f ": %a" print_ty))
+      (fun f -> pp f ": %a" print_ty)
       x.fun_ls.ls_value
       (option (fun f -> pp f " =@\n@[<hov2>@[%a@]@]" print_term))
       x.fun_def (option func_spec) x.fun_spec

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -481,7 +481,7 @@ let add_sig_contents muc sig_ =
   | Sig_val (({ vd_spec = Some { sp_pure = true; _ }; _ } as v), _) ->
       let tyl = List.map ty_of_lb_arg v.vd_args in
       let ty = ty_tuple (List.map ty_of_lb_arg v.vd_ret) in
-      let ls = lsymbol ~field:false v.vd_name tyl (Some ty) in
+      let ls = lsymbol ~field:false v.vd_name tyl ty in
       let muc = add_ls ~export:true muc ls.ls_name.id_str ls in
       add_kid muc ls.ls_name sig_
   | Sig_function f ->

--- a/src/tterm.ml
+++ b/src/tterm.ml
@@ -48,7 +48,7 @@ type quant = Tforall | Texists [@@deriving show]
 
 type term = {
   t_node : term_node;
-  t_ty : ty option;
+  t_ty : ty;
   t_attrs : string list;
   t_loc : Location.t; [@printer Utils.Fmt.pp_loc]
 }

--- a/src/tterm_helper.ml
+++ b/src/tterm_helper.ml
@@ -62,12 +62,7 @@ let t_free_vs_in_set svs t =
          (Svs.elements diff |> List.map (fun vs -> vs.vs_name.id_str)))
 
 (** type checking *)
-
-(*let t_prop t =
-  if ty_equal t.t_ty ty_bool then t else W.error ~loc:t.t_loc W.Formula_expected *)
-
 let t_type t = t.t_ty
-let t_ty_check t ty = match (ty, t.t_ty) with l, r -> ty_equal_check l r
 
 let ls_arg_inst ls tl =
   let rec short_fold_left2 f accu l1 l2 =

--- a/src/tterm_helper.ml
+++ b/src/tterm_helper.ml
@@ -63,8 +63,8 @@ let t_free_vs_in_set svs t =
 
 (** type checking *)
 
-let t_prop t =
-  if ty_equal t.t_ty ty_bool then t else W.error ~loc:t.t_loc W.Formula_expected
+(*let t_prop t =
+  if ty_equal t.t_ty ty_bool then t else W.error ~loc:t.t_loc W.Formula_expected *)
 
 let t_type t = t.t_ty
 let t_ty_check t ty = match (ty, t.t_ty) with l, r -> ty_equal_check l r
@@ -159,16 +159,8 @@ let t_bool_true = mk_term (Tapp (fs_bool_true, [])) ty_bool
 let t_bool_false = mk_term (Tapp (fs_bool_false, [])) ty_bool
 let t_equ t1 t2 = t_app ps_equ [ t1; t2 ] ty_bool
 let t_neq t1 t2 loc = t_not (t_equ t1 t2 loc)
-let f_binop op f1 f2 = t_binop op (t_prop f1) (t_prop f2)
-let f_not f = t_not (t_prop f)
-
-let t_quant q vsl t ty loc =
-  match vsl with
-  | [] -> t_prop t
-  | _ ->
-      if not (ty_equal ty ty_bool) then W.error ~loc W.Formula_expected;
-      t_quant q vsl (t_prop t) ty_bool loc
-
+let f_binop op f1 f2 = t_binop op f1 f2
+let f_not f = t_not f
 let f_and = f_binop Tand
 let f_and_asym = f_binop Tand_asym
 let f_or = f_binop Tor

--- a/src/tterm_helper.mli
+++ b/src/tterm_helper.mli
@@ -16,7 +16,6 @@ open Symbols
 
 val t_free_vars : Tterm.term -> Svs.t
 val t_free_vs_in_set : Svs.t -> Tterm.term -> unit
-val t_prop : Tterm.term -> Tterm.term
 val t_type : term -> ty
 val t_ty_check : term -> ty -> unit
 val ls_arg_inst : lsymbol -> term list -> ty Mtv.t
@@ -29,7 +28,7 @@ val p_or : pattern -> pattern -> Location.t -> pattern
 val p_as : pattern -> vsymbol -> Location.t -> pattern
 val p_interval : char -> char -> Location.t -> pattern
 val p_const : Parsetree.constant -> Location.t -> pattern
-val mk_term : term_node -> ty option -> Location.t -> term
+val mk_term : term_node -> ty -> Location.t -> term
 val t_var : vsymbol -> Location.t -> term
 val t_const : constant -> ty -> Location.t -> term
 val t_app : lsymbol -> term list -> ty -> Location.t -> term
@@ -37,7 +36,7 @@ val t_field : term -> lsymbol -> ty -> Location.t -> term
 val t_if : term -> term -> term -> Location.t -> term
 val t_let : vsymbol -> term -> term -> Location.t -> term
 val t_case : term -> (pattern * term option * term) list -> Location.t -> term
-val t_lambda : pattern list -> term -> ty option -> Location.t -> term
+val t_lambda : pattern list -> term -> ty -> Location.t -> term
 val t_binop : binop -> term -> term -> Location.t -> term
 val t_not : term -> Location.t -> term
 val t_old : term -> Location.t -> term
@@ -50,9 +49,7 @@ val t_equ : term -> term -> Location.t -> term
 val t_neq : term -> term -> Location.t -> Location.t -> term
 val f_binop : binop -> term -> term -> Location.t -> term
 val f_not : term -> Location.t -> term
-val t_quant : quant -> vsymbol list -> term -> ty option -> Location.t -> term
-val f_forall : vsymbol list -> term -> ty option -> Location.t -> term
-val f_exists : vsymbol list -> term -> ty option -> Location.t -> term
+val t_quant : quant -> vsymbol list -> term -> ty -> Location.t -> term
 val f_and : term -> term -> Location.t -> term
 val f_and_asym : term -> term -> Location.t -> term
 val f_or : term -> term -> Location.t -> term

--- a/src/tterm_helper.mli
+++ b/src/tterm_helper.mli
@@ -17,7 +17,6 @@ open Symbols
 val t_free_vars : Tterm.term -> Svs.t
 val t_free_vs_in_set : Svs.t -> Tterm.term -> unit
 val t_type : term -> ty
-val t_ty_check : term -> ty -> unit
 val ls_arg_inst : lsymbol -> term list -> ty Mtv.t
 val ls_app_inst : lsymbol -> term list -> ty -> ty Mtv.t
 val mk_pattern : pattern_node -> ty -> Location.t -> pattern

--- a/src/tterm_helper.mli
+++ b/src/tterm_helper.mli
@@ -15,8 +15,6 @@ open Ttypes
 open Symbols
 
 val t_free_vars : Tterm.term -> Svs.t
-val t_free_vs_in_set : Svs.t -> Tterm.term -> unit
-val t_type : term -> ty
 val ls_arg_inst : lsymbol -> term list -> ty Mtv.t
 val ls_app_inst : lsymbol -> term list -> ty -> ty Mtv.t
 val mk_pattern : pattern_node -> ty -> Location.t -> pattern

--- a/src/tterm_helper.mli
+++ b/src/tterm_helper.mli
@@ -18,9 +18,9 @@ val t_free_vars : Tterm.term -> Svs.t
 val t_free_vs_in_set : Svs.t -> Tterm.term -> unit
 val t_prop : Tterm.term -> Tterm.term
 val t_type : term -> ty
-val t_ty_check : term -> ty option -> unit
+val t_ty_check : term -> ty -> unit
 val ls_arg_inst : lsymbol -> term list -> ty Mtv.t
-val ls_app_inst : lsymbol -> term list -> ty option -> Location.t -> ty Mtv.t
+val ls_app_inst : lsymbol -> term list -> ty -> ty Mtv.t
 val mk_pattern : pattern_node -> ty -> Location.t -> pattern
 val p_wild : ty -> Location.t -> pattern
 val p_var : vsymbol -> Location.t -> pattern
@@ -32,8 +32,8 @@ val p_const : Parsetree.constant -> Location.t -> pattern
 val mk_term : term_node -> ty option -> Location.t -> term
 val t_var : vsymbol -> Location.t -> term
 val t_const : constant -> ty -> Location.t -> term
-val t_app : lsymbol -> term list -> ty option -> Location.t -> term
-val t_field : term -> lsymbol -> ty option -> Location.t -> term
+val t_app : lsymbol -> term list -> ty -> Location.t -> term
+val t_field : term -> lsymbol -> ty -> Location.t -> term
 val t_if : term -> term -> term -> Location.t -> term
 val t_let : vsymbol -> term -> term -> Location.t -> term
 val t_case : term -> (pattern * term option * term) list -> Location.t -> term

--- a/src/tterm_printer.ml
+++ b/src/tterm_printer.ml
@@ -18,7 +18,7 @@ let print_vs fmt { vs_name; vs_ty } =
   pp fmt "@[%a:%a@]" Ident.pp_simpl vs_name print_ty vs_ty
 
 let print_ls_decl fmt { ls_name; ls_args; ls_value; _ } =
-  let is_func = Option.is_some ls_value in
+  let is_func = ty_equal ls_value ty_bool in
   let print_unnamed_arg fmt ty = pp fmt "(_:%a)" print_ty ty in
   pp fmt "%s %a %a%s%a"
     (if is_func then "function" else "predicate")
@@ -26,7 +26,7 @@ let print_ls_decl fmt { ls_name; ls_args; ls_value; _ } =
     (list ~sep:sp print_unnamed_arg)
     ls_args
     (if is_func then " : " else "")
-    (option print_ty) ls_value
+    print_ty ls_value
 
 let print_ls_nm fmt { ls_name; _ } = pp fmt "%a" Ident.pp_simpl ls_name
 let protect_on x s = if x then "(" ^^ s ^^ ")" else s

--- a/src/tterm_printer.ml
+++ b/src/tterm_printer.ml
@@ -66,9 +66,7 @@ let print_quantifier fmt = function
 
 (* TODO use pretty printer from why3 *)
 let rec print_term fmt { t_node; t_ty; t_attrs; _ } =
-  let print_ty fmt ty =
-    match ty with None -> pp fmt ":prop" | Some ty -> pp fmt ":%a" print_ty ty
-  in
+  let print_ty fmt ty = pp fmt ":%a" print_ty ty in
   let print_t_node fmt t_node =
     match t_node with
     | Tconst c -> pp fmt "%a%a" Opprintast.constant c print_ty t_ty
@@ -76,7 +74,7 @@ let rec print_term fmt { t_node; t_ty; t_attrs; _ } =
     | Tfalse -> pp fmt "false%a" print_ty t_ty
     | Tvar vs ->
         pp fmt "%a" print_vs vs;
-        assert (vs.vs_ty = Option.get t_ty) (* TODO remove this *)
+        assert (vs.vs_ty = t_ty) (* TODO remove this *)
     | Tapp (ls, [ x1; x2 ]) when Identifier.is_infix ls.ls_name.id_str ->
         let op_nm =
           match String.split_on_char ' ' ls.ls_name.id_str with

--- a/src/tterm_printer.ml
+++ b/src/tterm_printer.ml
@@ -18,15 +18,13 @@ let print_vs fmt { vs_name; vs_ty } =
   pp fmt "@[%a:%a@]" Ident.pp_simpl vs_name print_ty vs_ty
 
 let print_ls_decl fmt { ls_name; ls_args; ls_value; _ } =
-  let is_func = ty_equal ls_value ty_bool in
+  let is_pred = ty_equal ls_value ty_bool in
   let print_unnamed_arg fmt ty = pp fmt "(_:%a)" print_ty ty in
-  pp fmt "%s %a %a%s%a"
-    (if is_func then "function" else "predicate")
+  pp fmt "%s %a %a:%a"
+    (if is_pred then "predicate" else "function")
     Ident.pp_simpl ls_name
     (list ~sep:sp print_unnamed_arg)
-    ls_args
-    (if is_func then " : " else "")
-    print_ty ls_value
+    ls_args print_ty ls_value
 
 let print_ls_nm fmt { ls_name; _ } = pp fmt "%a" Ident.pp_simpl ls_name
 let protect_on x s = if x then "(" ^^ s ^^ ")" else s

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -1069,9 +1069,9 @@ let process_function path kid crcm ns f =
         Mstr.update nm (add_var nm vs) env)
       Mstr.empty params
   in
-  let result, env =
+  let env =
     let result = create_vsymbol (Preid.create ~loc:f.fun_loc "result") f_ty in
-    (result, Mstr.add "result" result env)
+    Mstr.add "result" result env
   in
 
   let def =

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -1069,9 +1069,9 @@ let process_function path kid crcm ns f =
         Mstr.update nm (add_var nm vs) env)
       Mstr.empty params
   in
-  let env, result =
+  let env =
     let result = create_vsymbol (Preid.create ~loc:f.fun_loc "result") f_ty in
-    (Mstr.add "result" result env, result)
+    Mstr.add "result" result env
   in
 
   let def =
@@ -1093,9 +1093,7 @@ let process_function path kid crcm ns f =
         mk_fun_spec req ens variant spec.fun_coer spec.fun_text spec.fun_loc)
       f.fun_spec
   in
-  let f =
-    mk_function result ls f.fun_rec params def spec f.fun_loc f.fun_text
-  in
+  let f = mk_function ls f.fun_rec params def spec f.fun_loc f.fun_text in
   mk_sig_item (Sig_function f) f.fun_loc
 
 let process_axiom path loc kid crcm ns a =

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -1069,9 +1069,9 @@ let process_function path kid crcm ns f =
         Mstr.update nm (add_var nm vs) env)
       Mstr.empty params
   in
-  let env =
+  let result, env =
     let result = create_vsymbol (Preid.create ~loc:f.fun_loc "result") f_ty in
-    Mstr.add "result" result env
+    (result, Mstr.add "result" result env)
   in
 
   let def =
@@ -1093,6 +1093,7 @@ let process_function path kid crcm ns f =
         mk_fun_spec req ens variant spec.fun_coer spec.fun_text spec.fun_loc)
       f.fun_spec
   in
+
   let f = mk_function ls f.fun_rec params def spec f.fun_loc f.fun_text in
   mk_sig_item (Sig_function f) f.fun_loc
 

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -79,16 +79,16 @@ First, create a test artifact:
                            }
                           ];
                         ls_value =
-                        (Some { Ttypes.ty_node =
-                                (Ttypes.Tyapp (
-                                   { Ttypes.ts_ident = list;
-                                     ts_args = [{ Ttypes.tv_name = a_1 }];
-                                     ts_alias = None },
-                                   [{ Ttypes.ty_node =
-                                      (Ttypes.Tyvar { Ttypes.tv_name = a }) }
-                                     ]
-                                   ))
-                                });
+                        { Ttypes.ty_node =
+                          (Ttypes.Tyapp (
+                             { Ttypes.ts_ident = list;
+                               ts_args = [{ Ttypes.tv_name = a_1 }];
+                               ts_alias = None },
+                             [{ Ttypes.ty_node =
+                                (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                               ]
+                             ))
+                          };
                         ls_constr = false; ls_field = true },
                       true);
                       ({ Symbols.ls_name = size;
@@ -105,12 +105,12 @@ First, create a test artifact:
                             }
                            ];
                          ls_value =
-                         (Some { Ttypes.ty_node =
-                                 (Ttypes.Tyapp (
-                                    { Ttypes.ts_ident = int; ts_args = [];
-                                      ts_alias = None },
-                                    []))
-                                 });
+                         { Ttypes.ty_node =
+                           (Ttypes.Tyapp (
+                              { Ttypes.ts_ident = int; ts_args = [];
+                                ts_alias = None },
+                              []))
+                           };
                          ls_constr = false; ls_field = true },
                        false)
                       ];
@@ -200,8 +200,14 @@ First, create a test artifact:
                                   []))
                                }
                              ];
-                           ls_value = None; ls_constr = false; ls_field = false
-                           },
+                           ls_value =
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = bool; ts_args = [];
+                                  ts_alias = None },
+                                []))
+                             };
+                           ls_constr = false; ls_field = false },
                          [{ Tterm.t_node =
                             (Tterm.Tapp (
                                { Symbols.ls_name = Gospelstdlib.integer_of_int;
@@ -214,12 +220,12 @@ First, create a test artifact:
                                     }
                                    ];
                                  ls_value =
-                                 (Some { Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = integer;
-                                              ts_args = []; ts_alias = None },
-                                            []))
-                                         });
+                                 { Ttypes.ty_node =
+                                   (Ttypes.Tyapp (
+                                      { Ttypes.ts_ident = integer;
+                                        ts_args = []; ts_alias = None },
+                                      []))
+                                   };
                                  ls_constr = false; ls_field = false },
                                [{ Tterm.t_node =
                                   (Tterm.Tvar
@@ -233,35 +239,42 @@ First, create a test artifact:
                                          }
                                        });
                                   t_ty =
-                                  (Some { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = int;
-                                               ts_args = []; ts_alias = None },
-                                             []))
-                                          });
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = int; ts_args = [];
+                                         ts_alias = None },
+                                       []))
+                                    };
                                   t_attrs = []; t_loc = foo.mli:10:11 }
                                  ]
                                ));
                             t_ty =
-                            (Some { Ttypes.ty_node =
-                                    (Ttypes.Tyapp (
-                                       { Ttypes.ts_ident = integer;
-                                         ts_args = []; ts_alias = None },
-                                       []))
-                                    });
+                            { Ttypes.ty_node =
+                              (Ttypes.Tyapp (
+                                 { Ttypes.ts_ident = integer; ts_args = [];
+                                   ts_alias = None },
+                                 []))
+                              };
                             t_attrs = []; t_loc = foo.mli:10:11 };
                            { Tterm.t_node = <constant>;
                              t_ty =
-                             (Some { Ttypes.ty_node =
-                                     (Ttypes.Tyapp (
-                                        { Ttypes.ts_ident = integer;
-                                          ts_args = []; ts_alias = None },
-                                        []))
-                                     });
+                             { Ttypes.ty_node =
+                               (Ttypes.Tyapp (
+                                  { Ttypes.ts_ident = integer; ts_args = [];
+                                    ts_alias = None },
+                                  []))
+                               };
                              t_attrs = []; t_loc = foo.mli:10:16 }
                            ]
                          ));
-                      t_ty = None; t_attrs = []; t_loc = foo.mli:10:11 }
+                      t_ty =
+                      { Ttypes.ty_node =
+                        (Ttypes.Tyapp (
+                           { Ttypes.ts_ident = bool; ts_args = [];
+                             ts_alias = None },
+                           []))
+                        };
+                      t_attrs = []; t_loc = foo.mli:10:11 }
                      ];
                    sp_post =
                    [{ Tterm.t_node =
@@ -273,8 +286,14 @@ First, create a test artifact:
                              { Ttypes.ty_node =
                                (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) }
                              ];
-                           ls_value = None; ls_constr = false; ls_field = false
-                           },
+                           ls_value =
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = bool; ts_args = [];
+                                  ts_alias = None },
+                                []))
+                             };
+                           ls_constr = false; ls_field = false },
                          [{ Tterm.t_node =
                             (Tterm.Tfield (
                                { Tterm.t_node =
@@ -295,19 +314,17 @@ First, create a test artifact:
                                         }
                                       });
                                  t_ty =
-                                 (Some { Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = t;
-                                              ts_args =
-                                              [{ Ttypes.tv_name = a }];
-                                              ts_alias = None },
-                                            [{ Ttypes.ty_node =
-                                               (Ttypes.Tyvar
-                                                  { Ttypes.tv_name = a })
-                                               }
-                                              ]
-                                            ))
-                                         });
+                                 { Ttypes.ty_node =
+                                   (Ttypes.Tyapp (
+                                      { Ttypes.ts_ident = t;
+                                        ts_args = [{ Ttypes.tv_name = a }];
+                                        ts_alias = None },
+                                      [{ Ttypes.ty_node =
+                                         (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                         }
+                                        ]
+                                      ))
+                                   };
                                  t_attrs = []; t_loc = foo.mli:11:12 },
                                { Symbols.ls_name = contents;
                                  ls_args =
@@ -324,69 +341,71 @@ First, create a test artifact:
                                     }
                                    ];
                                  ls_value =
-                                 (Some { Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = list;
-                                              ts_args =
-                                              [{ Ttypes.tv_name = a_1 }];
-                                              ts_alias = None },
-                                            [{ Ttypes.ty_node =
-                                               (Ttypes.Tyvar
-                                                  { Ttypes.tv_name = a })
-                                               }
-                                              ]
-                                            ))
-                                         });
+                                 { Ttypes.ty_node =
+                                   (Ttypes.Tyapp (
+                                      { Ttypes.ts_ident = list;
+                                        ts_args = [{ Ttypes.tv_name = a_1 }];
+                                        ts_alias = None },
+                                      [{ Ttypes.ty_node =
+                                         (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                         }
+                                        ]
+                                      ))
+                                   };
                                  ls_constr = false; ls_field = true }
                                ));
                             t_ty =
-                            (Some { Ttypes.ty_node =
-                                    (Ttypes.Tyapp (
-                                       { Ttypes.ts_ident = list;
-                                         ts_args = [{ Ttypes.tv_name = a_1 }];
-                                         ts_alias = None },
-                                       [{ Ttypes.ty_node =
-                                          (Ttypes.Tyvar { Ttypes.tv_name = a })
-                                          }
-                                         ]
-                                       ))
-                                    });
+                            { Ttypes.ty_node =
+                              (Ttypes.Tyapp (
+                                 { Ttypes.ts_ident = list;
+                                   ts_args = [{ Ttypes.tv_name = a_1 }];
+                                   ts_alias = None },
+                                 [{ Ttypes.ty_node =
+                                    (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                   ]
+                                 ))
+                              };
                             t_attrs = []; t_loc = foo.mli:11:12 };
                            { Tterm.t_node =
                              (Tterm.Tapp (
                                 { Symbols.ls_name = []; ls_args = [];
                                   ls_value =
-                                  (Some { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = list;
-                                               ts_args =
-                                               [{ Ttypes.tv_name = a_1 }];
-                                               ts_alias = None },
-                                             [{ Ttypes.ty_node =
-                                                (Ttypes.Tyvar
-                                                   { Ttypes.tv_name = a_1 })
-                                                }
-                                               ]
-                                             ))
-                                          });
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = list;
+                                         ts_args = [{ Ttypes.tv_name = a_1 }];
+                                         ts_alias = None },
+                                       [{ Ttypes.ty_node =
+                                          (Ttypes.Tyvar
+                                             { Ttypes.tv_name = a_1 })
+                                          }
+                                         ]
+                                       ))
+                                    };
                                   ls_constr = true; ls_field = false },
                                 []));
                              t_ty =
-                             (Some { Ttypes.ty_node =
-                                     (Ttypes.Tyapp (
-                                        { Ttypes.ts_ident = list;
-                                          ts_args = [{ Ttypes.tv_name = a_1 }];
-                                          ts_alias = None },
-                                        [{ Ttypes.ty_node =
-                                           (Ttypes.Tyvar { Ttypes.tv_name = a })
-                                           }
-                                          ]
-                                        ))
-                                     });
+                             { Ttypes.ty_node =
+                               (Ttypes.Tyapp (
+                                  { Ttypes.ts_ident = list;
+                                    ts_args = [{ Ttypes.tv_name = a_1 }];
+                                    ts_alias = None },
+                                  [{ Ttypes.ty_node =
+                                     (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                    ]
+                                  ))
+                               };
                              t_attrs = []; t_loc = foo.mli:11:25 }
                            ]
                          ));
-                      t_ty = None; t_attrs = []; t_loc = foo.mli:11:12 };
+                      t_ty =
+                      { Ttypes.ty_node =
+                        (Ttypes.Tyapp (
+                           { Ttypes.ts_ident = bool; ts_args = [];
+                             ts_alias = None },
+                           []))
+                        };
+                      t_attrs = []; t_loc = foo.mli:11:12 };
                      { Tterm.t_node =
                        (Tterm.Tapp (
                           { Symbols.ls_name = infix =;
@@ -396,8 +415,14 @@ First, create a test artifact:
                               { Ttypes.ty_node =
                                 (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) }
                               ];
-                            ls_value = None; ls_constr = false;
-                            ls_field = false },
+                            ls_value =
+                            { Ttypes.ty_node =
+                              (Ttypes.Tyapp (
+                                 { Ttypes.ts_ident = bool; ts_args = [];
+                                   ts_alias = None },
+                                 []))
+                              };
+                            ls_constr = false; ls_field = false },
                           [{ Tterm.t_node =
                              (Tterm.Tfield (
                                 { Tterm.t_node =
@@ -419,19 +444,17 @@ First, create a test artifact:
                                          }
                                        });
                                   t_ty =
-                                  (Some { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = t;
-                                               ts_args =
-                                               [{ Ttypes.tv_name = a }];
-                                               ts_alias = None },
-                                             [{ Ttypes.ty_node =
-                                                (Ttypes.Tyvar
-                                                   { Ttypes.tv_name = a })
-                                                }
-                                               ]
-                                             ))
-                                          });
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = t;
+                                         ts_args = [{ Ttypes.tv_name = a }];
+                                         ts_alias = None },
+                                       [{ Ttypes.ty_node =
+                                          (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                          }
+                                         ]
+                                       ))
+                                    };
                                   t_attrs = []; t_loc = foo.mli:12:12 },
                                 { Symbols.ls_name = size;
                                   ls_args =
@@ -448,21 +471,21 @@ First, create a test artifact:
                                      }
                                     ];
                                   ls_value =
-                                  (Some { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = int;
-                                               ts_args = []; ts_alias = None },
-                                             []))
-                                          });
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = int; ts_args = [];
+                                         ts_alias = None },
+                                       []))
+                                    };
                                   ls_constr = false; ls_field = true }
                                 ));
                              t_ty =
-                             (Some { Ttypes.ty_node =
-                                     (Ttypes.Tyapp (
-                                        { Ttypes.ts_ident = int; ts_args = [];
-                                          ts_alias = None },
-                                        []))
-                                     });
+                             { Ttypes.ty_node =
+                               (Ttypes.Tyapp (
+                                  { Ttypes.ts_ident = int; ts_args = [];
+                                    ts_alias = None },
+                                  []))
+                               };
                              t_attrs = []; t_loc = foo.mli:12:12 };
                             { Tterm.t_node =
                               (Tterm.Tvar
@@ -476,16 +499,23 @@ First, create a test artifact:
                                      }
                                    });
                               t_ty =
-                              (Some { Ttypes.ty_node =
-                                      (Ttypes.Tyapp (
-                                         { Ttypes.ts_ident = int; ts_args = [];
-                                           ts_alias = None },
-                                         []))
-                                      });
+                              { Ttypes.ty_node =
+                                (Ttypes.Tyapp (
+                                   { Ttypes.ts_ident = int; ts_args = [];
+                                     ts_alias = None },
+                                   []))
+                                };
                               t_attrs = []; t_loc = foo.mli:12:21 }
                             ]
                           ));
-                       t_ty = None; t_attrs = []; t_loc = foo.mli:12:12 }
+                       t_ty =
+                       { Ttypes.ty_node =
+                         (Ttypes.Tyapp (
+                            { Ttypes.ts_ident = bool; ts_args = [];
+                              ts_alias = None },
+                            []))
+                         };
+                       t_attrs = []; t_loc = foo.mli:12:12 }
                      ];
                    sp_xpost = []; sp_wr = []; sp_cs = []; sp_diverge = false;
                    sp_pure = false; sp_equiv = [];
@@ -499,8 +529,14 @@ First, create a test artifact:
       (Tast.Sig_axiom
          { Tast.ax_name = Foo.a_3;
            ax_term =
-           { Tterm.t_node = Tterm.Ttrue; t_ty = None; t_attrs = [];
-             t_loc = foo.mli:16:14 };
+           { Tterm.t_node = Tterm.Ttrue;
+             t_ty =
+             { Ttypes.ty_node =
+               (Ttypes.Tyapp (
+                  { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None }, 
+                  []))
+               };
+             t_attrs = []; t_loc = foo.mli:16:14 };
            ax_loc = foo.mli:16:3; ax_text = " axiom a : true " });
       sig_loc = foo.mli:16:0 };
     { Tast.sig_desc =
@@ -523,12 +559,11 @@ First, create a test artifact:
                  }
                ];
              ls_value =
-             (Some { Ttypes.ty_node =
-                     (Ttypes.Tyapp (
-                        { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None
-                          },
-                        []))
-                     });
+             { Ttypes.ty_node =
+               (Ttypes.Tyapp (
+                  { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None }, 
+                  []))
+               };
              ls_constr = false; ls_field = false };
            fun_rec = false;
            fun_params =
@@ -554,23 +589,50 @@ First, create a test artifact:
              ];
            fun_def =
            (Some { Tterm.t_node =
-                   (Tterm.Tif (
-                      { Tterm.t_node =
-                        (Tterm.Tapp (
-                           { Symbols.ls_name = infix =;
-                             ls_args =
-                             [{ Ttypes.ty_node =
-                                (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) };
-                               { Ttypes.ty_node =
-                                 (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) }
-                               ];
-                             ls_value = None; ls_constr = false;
-                             ls_field = false },
-                           [{ Tterm.t_node =
-                              (Tterm.Tapp (
-                                 { Symbols.ls_name = Gospelstdlib.List.length;
-                                   ls_args =
-                                   [{ Ttypes.ty_node =
+                   (Tterm.Tapp (
+                      { Symbols.ls_name = infix =;
+                        ls_args =
+                        [{ Ttypes.ty_node =
+                           (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) };
+                          { Ttypes.ty_node =
+                            (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) }
+                          ];
+                        ls_value =
+                        { Ttypes.ty_node =
+                          (Ttypes.Tyapp (
+                             { Ttypes.ts_ident = bool; ts_args = [];
+                               ts_alias = None },
+                             []))
+                          };
+                        ls_constr = false; ls_field = false },
+                      [{ Tterm.t_node =
+                         (Tterm.Tapp (
+                            { Symbols.ls_name = Gospelstdlib.List.length;
+                              ls_args =
+                              [{ Ttypes.ty_node =
+                                 (Ttypes.Tyapp (
+                                    { Ttypes.ts_ident = list;
+                                      ts_args = [{ Ttypes.tv_name = a_1 }];
+                                      ts_alias = None },
+                                    [{ Ttypes.ty_node =
+                                       (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                      ]
+                                    ))
+                                 }
+                                ];
+                              ls_value =
+                              { Ttypes.ty_node =
+                                (Ttypes.Tyapp (
+                                   { Ttypes.ts_ident = integer; ts_args = [];
+                                     ts_alias = None },
+                                   []))
+                                };
+                              ls_constr = false; ls_field = false },
+                            [{ Tterm.t_node =
+                               (Tterm.Tvar
+                                  { Symbols.vs_name = xs;
+                                    vs_ty =
+                                    { Ttypes.ty_node =
                                       (Ttypes.Tyapp (
                                          { Ttypes.ts_ident = list;
                                            ts_args = [{ Ttypes.tv_name = a_1 }];
@@ -582,128 +644,57 @@ First, create a test artifact:
                                            ]
                                          ))
                                       }
-                                     ];
-                                   ls_value =
-                                   (Some { Ttypes.ty_node =
-                                           (Ttypes.Tyapp (
-                                              { Ttypes.ts_ident = integer;
-                                                ts_args = []; ts_alias = None },
-                                              []))
-                                           });
-                                   ls_constr = false; ls_field = false },
-                                 [{ Tterm.t_node =
-                                    (Tterm.Tvar
-                                       { Symbols.vs_name = xs;
-                                         vs_ty =
-                                         { Ttypes.ty_node =
-                                           (Ttypes.Tyapp (
-                                              { Ttypes.ts_ident = list;
-                                                ts_args =
-                                                [{ Ttypes.tv_name = a_1 }];
-                                                ts_alias = None },
-                                              [{ Ttypes.ty_node =
-                                                 (Ttypes.Tyvar
-                                                    { Ttypes.tv_name = a })
-                                                 }
-                                                ]
-                                              ))
-                                           }
-                                         });
-                                    t_ty =
-                                    (Some { Ttypes.ty_node =
-                                            (Ttypes.Tyapp (
-                                               { Ttypes.ts_ident = list;
-                                                 ts_args =
-                                                 [{ Ttypes.tv_name = a_1 }];
-                                                 ts_alias = None },
-                                               [{ Ttypes.ty_node =
-                                                  (Ttypes.Tyvar
-                                                     { Ttypes.tv_name = a })
-                                                  }
-                                                 ]
-                                               ))
-                                            });
-                                    t_attrs = []; t_loc = foo.mli:18:71 }
-                                   ]
-                                 ));
-                              t_ty =
-                              (Some { Ttypes.ty_node =
-                                      (Ttypes.Tyapp (
-                                         { Ttypes.ts_ident = integer;
-                                           ts_args = []; ts_alias = None },
-                                         []))
-                                      });
-                              t_attrs = []; t_loc = foo.mli:18:59 };
-                             { Tterm.t_node =
-                               (Tterm.Tvar
-                                  { Symbols.vs_name = x;
-                                    vs_ty =
-                                    { Ttypes.ty_node =
-                                      (Ttypes.Tyapp (
-                                         { Ttypes.ts_ident = integer;
-                                           ts_args = []; ts_alias = None },
-                                         []))
-                                      }
                                     });
                                t_ty =
-                               (Some { Ttypes.ty_node =
-                                       (Ttypes.Tyapp (
-                                          { Ttypes.ts_ident = integer;
-                                            ts_args = []; ts_alias = None },
-                                          []))
-                                       });
-                               t_attrs = []; t_loc = foo.mli:18:76 }
-                             ]
-                           ));
-                        t_ty = None; t_attrs = []; t_loc = foo.mli:18:59 },
-                      { Tterm.t_node =
-                        (Tterm.Tapp (
-                           { Symbols.ls_name = true; ls_args = [];
-                             ls_value =
-                             (Some { Ttypes.ty_node =
-                                     (Ttypes.Tyapp (
-                                        { Ttypes.ts_ident = bool; ts_args = [];
-                                          ts_alias = None },
-                                        []))
-                                     });
-                             ls_constr = true; ls_field = false },
-                           []));
-                        t_ty =
-                        (Some { Ttypes.ty_node =
-                                (Ttypes.Tyapp (
-                                   { Ttypes.ts_ident = bool; ts_args = [];
-                                     ts_alias = None },
-                                   []))
-                                });
-                        t_attrs = []; t_loc = foo.mli:18:59 },
-                      { Tterm.t_node =
-                        (Tterm.Tapp (
-                           { Symbols.ls_name = false; ls_args = [];
-                             ls_value =
-                             (Some { Ttypes.ty_node =
-                                     (Ttypes.Tyapp (
-                                        { Ttypes.ts_ident = bool; ts_args = [];
-                                          ts_alias = None },
-                                        []))
-                                     });
-                             ls_constr = true; ls_field = false },
-                           []));
-                        t_ty =
-                        (Some { Ttypes.ty_node =
-                                (Ttypes.Tyapp (
-                                   { Ttypes.ts_ident = bool; ts_args = [];
-                                     ts_alias = None },
-                                   []))
-                                });
-                        t_attrs = []; t_loc = foo.mli:18:59 }
-                      ));
-                   t_ty =
-                   (Some { Ttypes.ty_node =
+                               { Ttypes.ty_node =
+                                 (Ttypes.Tyapp (
+                                    { Ttypes.ts_ident = list;
+                                      ts_args = [{ Ttypes.tv_name = a_1 }];
+                                      ts_alias = None },
+                                    [{ Ttypes.ty_node =
+                                       (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                      ]
+                                    ))
+                                 };
+                               t_attrs = []; t_loc = foo.mli:18:71 }
+                              ]
+                            ));
+                         t_ty =
+                         { Ttypes.ty_node =
                            (Ttypes.Tyapp (
-                              { Ttypes.ts_ident = bool; ts_args = [];
+                              { Ttypes.ts_ident = integer; ts_args = [];
                                 ts_alias = None },
                               []))
-                           });
+                           };
+                         t_attrs = []; t_loc = foo.mli:18:59 };
+                        { Tterm.t_node =
+                          (Tterm.Tvar
+                             { Symbols.vs_name = x;
+                               vs_ty =
+                               { Ttypes.ty_node =
+                                 (Ttypes.Tyapp (
+                                    { Ttypes.ts_ident = integer; ts_args = [];
+                                      ts_alias = None },
+                                    []))
+                                 }
+                               });
+                          t_ty =
+                          { Ttypes.ty_node =
+                            (Ttypes.Tyapp (
+                               { Ttypes.ts_ident = integer; ts_args = [];
+                                 ts_alias = None },
+                               []))
+                            };
+                          t_attrs = []; t_loc = foo.mli:18:76 }
+                        ]
+                      ));
+                   t_ty =
+                   { Ttypes.ty_node =
+                     (Ttypes.Tyapp (
+                        { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None
+                          },
+                        []))
+                     };
                    t_attrs = []; t_loc = foo.mli:18:59 });
            fun_spec = None;
            fun_text =
@@ -735,20 +726,19 @@ First, create a test artifact:
                  }
                ];
              ls_value =
-             (Some { Ttypes.ty_node =
+             { Ttypes.ty_node =
+               (Ttypes.Tyapp (
+                  { Ttypes.ts_ident = list;
+                    ts_args = [{ Ttypes.tv_name = a_1 }]; ts_alias = None },
+                  [{ Ttypes.ty_node =
                      (Ttypes.Tyapp (
-                        { Ttypes.ts_ident = list;
-                          ts_args = [{ Ttypes.tv_name = a_1 }]; ts_alias = None
-                          },
-                        [{ Ttypes.ty_node =
-                           (Ttypes.Tyapp (
-                              { Ttypes.ts_ident = integer; ts_args = [];
-                                ts_alias = None },
-                              []))
-                           }
-                          ]
-                        ))
-                     });
+                        { Ttypes.ts_ident = integer; ts_args = [];
+                          ts_alias = None },
+                        []))
+                     }
+                    ]
+                  ))
+               };
              ls_constr = false; ls_field = false };
            fun_rec = false;
            fun_params =
@@ -800,8 +790,14 @@ First, create a test artifact:
                                        ))
                                     }
                                   ];
-                                ls_value = None; ls_constr = false;
-                                ls_field = false },
+                                ls_value =
+                                { Ttypes.ty_node =
+                                  (Ttypes.Tyapp (
+                                     { Ttypes.ts_ident = bool; ts_args = [];
+                                       ts_alias = None },
+                                     []))
+                                  };
+                                ls_constr = false; ls_field = false },
                               [{ Tterm.t_node =
                                  (Tterm.Tvar
                                     { Symbols.vs_name = x_1;
@@ -814,12 +810,12 @@ First, create a test artifact:
                                         }
                                       });
                                  t_ty =
-                                 (Some { Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = integer;
-                                              ts_args = []; ts_alias = None },
-                                            []))
-                                         });
+                                 { Ttypes.ty_node =
+                                   (Ttypes.Tyapp (
+                                      { Ttypes.ts_ident = integer;
+                                        ts_args = []; ts_alias = None },
+                                      []))
+                                   };
                                  t_attrs = []; t_loc = foo.mli:21:27 };
                                 { Tterm.t_node =
                                   (Tterm.Tvar
@@ -843,31 +839,50 @@ First, create a test artifact:
                                          }
                                        });
                                   t_ty =
-                                  (Some { Ttypes.ty_node =
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = list;
+                                         ts_args = [{ Ttypes.tv_name = a_1 }];
+                                         ts_alias = None },
+                                       [{ Ttypes.ty_node =
                                           (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = list;
-                                               ts_args =
-                                               [{ Ttypes.tv_name = a_1 }];
-                                               ts_alias = None },
-                                             [{ Ttypes.ty_node =
-                                                (Ttypes.Tyapp (
-                                                   { Ttypes.ts_ident = integer;
-                                                     ts_args = [];
-                                                     ts_alias = None },
-                                                   []))
-                                                }
-                                               ]
-                                             ))
-                                          });
+                                             { Ttypes.ts_ident = integer;
+                                               ts_args = []; ts_alias = None },
+                                             []))
+                                          }
+                                         ]
+                                       ))
+                                    };
                                   t_attrs = []; t_loc = foo.mli:21:29 }
                                 ]
                               ));
-                           t_ty = None; t_attrs = []; t_loc = foo.mli:21:17 });
-                      t_ty = None; t_attrs = []; t_loc = foo.mli:21:13 }
+                           t_ty =
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = bool; ts_args = [];
+                                  ts_alias = None },
+                                []))
+                             };
+                           t_attrs = []; t_loc = foo.mli:21:17 });
+                      t_ty =
+                      { Ttypes.ty_node =
+                        (Ttypes.Tyapp (
+                           { Ttypes.ts_ident = bool; ts_args = [];
+                             ts_alias = None },
+                           []))
+                        };
+                      t_attrs = []; t_loc = foo.mli:21:13 }
                      ];
                    fun_ens =
-                   [{ Tterm.t_node = Tterm.Ttrue; t_ty = None; t_attrs = [];
-                      t_loc = foo.mli:22:12 }
+                   [{ Tterm.t_node = Tterm.Ttrue;
+                      t_ty =
+                      { Ttypes.ty_node =
+                        (Ttypes.Tyapp (
+                           { Ttypes.ts_ident = bool; ts_args = [];
+                             ts_alias = None },
+                           []))
+                        };
+                      t_attrs = []; t_loc = foo.mli:22:12 }
                      ];
                    fun_variant = []; fun_coer = false;
                    fun_text =
@@ -896,7 +911,13 @@ First, create a test artifact:
                    ))
                 }
                ];
-             ls_value = None; ls_constr = false; ls_field = false };
+             ls_value =
+             { Ttypes.ty_node =
+               (Ttypes.Tyapp (
+                  { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None }, 
+                  []))
+               };
+             ls_constr = false; ls_field = false };
            fun_rec = true;
            fun_params =
            [{ Symbols.vs_name = l;
@@ -918,819 +939,655 @@ First, create a test artifact:
              ];
            fun_def =
            (Some { Tterm.t_node =
-                   (Tterm.Tapp (
-                      { Symbols.ls_name = infix =;
-                        ls_args =
-                        [{ Ttypes.ty_node =
-                           (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) };
-                          { Ttypes.ty_node =
-                            (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) }
-                          ];
-                        ls_value = None; ls_constr = false; ls_field = false },
-                      [{ Tterm.t_node =
-                         (Tterm.Tcase (
-                            { Tterm.t_node =
-                              (Tterm.Tvar
-                                 { Symbols.vs_name = l;
-                                   vs_ty =
-                                   { Ttypes.ty_node =
+                   (Tterm.Tcase (
+                      { Tterm.t_node =
+                        (Tterm.Tvar
+                           { Symbols.vs_name = l;
+                             vs_ty =
+                             { Ttypes.ty_node =
+                               (Ttypes.Tyapp (
+                                  { Ttypes.ts_ident = list;
+                                    ts_args = [{ Ttypes.tv_name = a_1 }];
+                                    ts_alias = None },
+                                  [{ Ttypes.ty_node =
                                      (Ttypes.Tyapp (
-                                        { Ttypes.ts_ident = list;
-                                          ts_args = [{ Ttypes.tv_name = a_1 }];
+                                        { Ttypes.ts_ident = int; ts_args = [];
                                           ts_alias = None },
-                                        [{ Ttypes.ty_node =
-                                           (Ttypes.Tyapp (
-                                              { Ttypes.ts_ident = int;
-                                                ts_args = []; ts_alias = None },
-                                              []))
-                                           }
-                                          ]
-                                        ))
+                                        []))
                                      }
-                                   });
-                              t_ty =
-                              (Some { Ttypes.ty_node =
+                                    ]
+                                  ))
+                               }
+                             });
+                        t_ty =
+                        { Ttypes.ty_node =
+                          (Ttypes.Tyapp (
+                             { Ttypes.ts_ident = list;
+                               ts_args = [{ Ttypes.tv_name = a_1 }];
+                               ts_alias = None },
+                             [{ Ttypes.ty_node =
+                                (Ttypes.Tyapp (
+                                   { Ttypes.ts_ident = int; ts_args = [];
+                                     ts_alias = None },
+                                   []))
+                                }
+                               ]
+                             ))
+                          };
+                        t_attrs = []; t_loc = foo.mli:24:55 },
+                      [({ Tterm.p_node =
+                          (Tterm.Por (
+                             { Tterm.p_node =
+                               (Tterm.Papp (
+                                  { Symbols.ls_name = []; ls_args = [];
+                                    ls_value =
+                                    { Ttypes.ty_node =
                                       (Ttypes.Tyapp (
                                          { Ttypes.ts_ident = list;
                                            ts_args = [{ Ttypes.tv_name = a_1 }];
                                            ts_alias = None },
                                          [{ Ttypes.ty_node =
-                                            (Ttypes.Tyapp (
-                                               { Ttypes.ts_ident = int;
-                                                 ts_args = []; ts_alias = None
-                                                 },
-                                               []))
+                                            (Ttypes.Tyvar
+                                               { Ttypes.tv_name = a_1 })
                                             }
                                            ]
                                          ))
-                                      });
-                              t_attrs = []; t_loc = foo.mli:24:55 },
-                            [({ Tterm.p_node =
-                                (Tterm.Por (
-                                   { Tterm.p_node =
-                                     (Tterm.Papp (
-                                        { Symbols.ls_name = []; ls_args = [];
-                                          ls_value =
-                                          (Some { Ttypes.ty_node =
-                                                  (Ttypes.Tyapp (
-                                                     { Ttypes.ts_ident = list;
-                                                       ts_args =
-                                                       [{ Ttypes.tv_name = a_1
-                                                          }
-                                                         ];
-                                                       ts_alias = None },
-                                                     [{ Ttypes.ty_node =
-                                                        (Ttypes.Tyvar
-                                                           { Ttypes.tv_name =
-                                                             a_1 })
-                                                        }
-                                                       ]
-                                                     ))
-                                                  });
-                                          ls_constr = true; ls_field = false },
-                                        []));
+                                      };
+                                    ls_constr = true; ls_field = false },
+                                  []));
+                               p_ty =
+                               { Ttypes.ty_node =
+                                 (Ttypes.Tyapp (
+                                    { Ttypes.ts_ident = list;
+                                      ts_args = [{ Ttypes.tv_name = a_1 }];
+                                      ts_alias = None },
+                                    [{ Ttypes.ty_node =
+                                       (Ttypes.Tyapp (
+                                          { Ttypes.ts_ident = int;
+                                            ts_args = []; ts_alias = None },
+                                          []))
+                                       }
+                                      ]
+                                    ))
+                                 };
+                               p_loc = foo.mli:25:8 },
+                             { Tterm.p_node =
+                               (Tterm.Papp (
+                                  { Symbols.ls_name = infix ::;
+                                    ls_args =
+                                    [{ Ttypes.ty_node =
+                                       (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
+                                       };
+                                      { Ttypes.ty_node =
+                                        (Ttypes.Tyapp (
+                                           { Ttypes.ts_ident = list;
+                                             ts_args =
+                                             [{ Ttypes.tv_name = a_1 }];
+                                             ts_alias = None },
+                                           [{ Ttypes.ty_node =
+                                              (Ttypes.Tyvar
+                                                 { Ttypes.tv_name = a_1 })
+                                              }
+                                             ]
+                                           ))
+                                        }
+                                      ];
+                                    ls_value =
+                                    { Ttypes.ty_node =
+                                      (Ttypes.Tyapp (
+                                         { Ttypes.ts_ident = list;
+                                           ts_args = [{ Ttypes.tv_name = a_1 }];
+                                           ts_alias = None },
+                                         [{ Ttypes.ty_node =
+                                            (Ttypes.Tyvar
+                                               { Ttypes.tv_name = a_1 })
+                                            }
+                                           ]
+                                         ))
+                                      };
+                                    ls_constr = true; ls_field = false },
+                                  [{ Tterm.p_node = Tterm.Pwild;
                                      p_ty =
                                      { Ttypes.ty_node =
                                        (Ttypes.Tyapp (
-                                          { Ttypes.ts_ident = list;
-                                            ts_args =
-                                            [{ Ttypes.tv_name = a_1 }];
-                                            ts_alias = None },
-                                          [{ Ttypes.ty_node =
-                                             (Ttypes.Tyapp (
-                                                { Ttypes.ts_ident = int;
-                                                  ts_args = []; ts_alias = None
-                                                  },
-                                                []))
-                                             }
-                                            ]
-                                          ))
+                                          { Ttypes.ts_ident = int;
+                                            ts_args = []; ts_alias = None },
+                                          []))
                                        };
-                                     p_loc = foo.mli:25:8 },
-                                   { Tterm.p_node =
-                                     (Tterm.Papp (
-                                        { Symbols.ls_name = infix ::;
-                                          ls_args =
-                                          [{ Ttypes.ty_node =
-                                             (Ttypes.Tyvar
-                                                { Ttypes.tv_name = a_1 })
-                                             };
-                                            { Ttypes.ty_node =
-                                              (Ttypes.Tyapp (
-                                                 { Ttypes.ts_ident = list;
-                                                   ts_args =
-                                                   [{ Ttypes.tv_name = a_1 }];
-                                                   ts_alias = None },
-                                                 [{ Ttypes.ty_node =
-                                                    (Ttypes.Tyvar
-                                                       { Ttypes.tv_name = a_1 })
-                                                    }
-                                                   ]
-                                                 ))
-                                              }
-                                            ];
-                                          ls_value =
-                                          (Some { Ttypes.ty_node =
-                                                  (Ttypes.Tyapp (
-                                                     { Ttypes.ts_ident = list;
-                                                       ts_args =
-                                                       [{ Ttypes.tv_name = a_1
-                                                          }
-                                                         ];
-                                                       ts_alias = None },
-                                                     [{ Ttypes.ty_node =
-                                                        (Ttypes.Tyvar
-                                                           { Ttypes.tv_name =
-                                                             a_1 })
-                                                        }
-                                                       ]
-                                                     ))
-                                                  });
-                                          ls_constr = true; ls_field = false },
-                                        [{ Tterm.p_node = Tterm.Pwild;
-                                           p_ty =
+                                     p_loc = foo.mli:25:13 };
+                                    { Tterm.p_node =
+                                      (Tterm.Papp (
+                                         { Symbols.ls_name = []; ls_args = [];
+                                           ls_value =
                                            { Ttypes.ty_node =
                                              (Ttypes.Tyapp (
-                                                { Ttypes.ts_ident = int;
-                                                  ts_args = []; ts_alias = None
-                                                  },
-                                                []))
+                                                { Ttypes.ts_ident = list;
+                                                  ts_args =
+                                                  [{ Ttypes.tv_name = a_1 }];
+                                                  ts_alias = None },
+                                                [{ Ttypes.ty_node =
+                                                   (Ttypes.Tyvar
+                                                      { Ttypes.tv_name = a_1 })
+                                                   }
+                                                  ]
+                                                ))
                                              };
-                                           p_loc = foo.mli:25:13 };
-                                          { Tterm.p_node =
-                                            (Tterm.Papp (
-                                               { Symbols.ls_name = [];
-                                                 ls_args = [];
-                                                 ls_value =
-                                                 (Some { Ttypes.ty_node =
-                                                         (Ttypes.Tyapp (
-                                                            { Ttypes.ts_ident =
-                                                              list;
-                                                              ts_args =
-                                                              [{ Ttypes.tv_name =
-                                                                 a_1 }
-                                                                ];
-                                                              ts_alias = None },
-                                                            [{ Ttypes.ty_node =
-                                                               (Ttypes.Tyvar
-                                                                  { Ttypes.tv_name =
-                                                                    a_1 })
-                                                               }
-                                                              ]
-                                                            ))
-                                                         });
-                                                 ls_constr = true;
-                                                 ls_field = false },
-                                               []));
-                                            p_ty =
-                                            { Ttypes.ty_node =
-                                              (Ttypes.Tyapp (
-                                                 { Ttypes.ts_ident = list;
-                                                   ts_args =
-                                                   [{ Ttypes.tv_name = a_1 }];
-                                                   ts_alias = None },
-                                                 [{ Ttypes.ty_node =
-                                                    (Ttypes.Tyapp (
-                                                       { Ttypes.ts_ident = int;
-                                                         ts_args = [];
-                                                         ts_alias = None },
-                                                       []))
-                                                    }
-                                                   ]
-                                                 ))
-                                              };
-                                            p_loc = foo.mli:25:18 }
-                                          ]
-                                        ));
-                                     p_ty =
-                                     { Ttypes.ty_node =
-                                       (Ttypes.Tyapp (
-                                          { Ttypes.ts_ident = list;
-                                            ts_args =
-                                            [{ Ttypes.tv_name = a_1 }];
-                                            ts_alias = None },
-                                          [{ Ttypes.ty_node =
-                                             (Ttypes.Tyapp (
-                                                { Ttypes.ts_ident = int;
-                                                  ts_args = []; ts_alias = None
-                                                  },
-                                                []))
-                                             }
-                                            ]
-                                          ))
-                                       };
-                                     p_loc = foo.mli:25:13 }
-                                   ));
-                                p_ty =
-                                { Ttypes.ty_node =
-                                  (Ttypes.Tyapp (
-                                     { Ttypes.ts_ident = list;
-                                       ts_args = [{ Ttypes.tv_name = a_1 }];
-                                       ts_alias = None },
-                                     [{ Ttypes.ty_node =
+                                           ls_constr = true; ls_field = false },
+                                         []));
+                                      p_ty =
+                                      { Ttypes.ty_node =
                                         (Ttypes.Tyapp (
-                                           { Ttypes.ts_ident = int;
-                                             ts_args = []; ts_alias = None },
-                                           []))
-                                        }
-                                       ]
-                                     ))
-                                  };
-                                p_loc = foo.mli:25:8 },
-                              None,
-                              { Tterm.t_node =
-                                (Tterm.Tapp (
-                                   { Symbols.ls_name = true; ls_args = [];
-                                     ls_value =
-                                     (Some { Ttypes.ty_node =
-                                             (Ttypes.Tyapp (
-                                                { Ttypes.ts_ident = bool;
-                                                  ts_args = []; ts_alias = None
-                                                  },
-                                                []))
-                                             });
-                                     ls_constr = true; ls_field = false },
-                                   []));
-                                t_ty =
-                                (Some { Ttypes.ty_node =
-                                        (Ttypes.Tyapp (
-                                           { Ttypes.ts_ident = bool;
-                                             ts_args = []; ts_alias = None },
-                                           []))
-                                        });
-                                t_attrs = []; t_loc = foo.mli:25:24 });
-                              ({ Tterm.p_node =
-                                 (Tterm.Papp (
-                                    { Symbols.ls_name = infix ::;
-                                      ls_args =
-                                      [{ Ttypes.ty_node =
-                                         (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
-                                         };
-                                        { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = list;
-                                               ts_args =
-                                               [{ Ttypes.tv_name = a_1 }];
-                                               ts_alias = None },
-                                             [{ Ttypes.ty_node =
-                                                (Ttypes.Tyvar
-                                                   { Ttypes.tv_name = a_1 })
-                                                }
-                                               ]
-                                             ))
-                                          }
-                                        ];
-                                      ls_value =
-                                      (Some { Ttypes.ty_node =
-                                              (Ttypes.Tyapp (
-                                                 { Ttypes.ts_ident = list;
-                                                   ts_args =
-                                                   [{ Ttypes.tv_name = a_1 }];
-                                                   ts_alias = None },
-                                                 [{ Ttypes.ty_node =
-                                                    (Ttypes.Tyvar
-                                                       { Ttypes.tv_name = a_1 })
-                                                    }
-                                                   ]
-                                                 ))
-                                              });
-                                      ls_constr = true; ls_field = false },
-                                    [{ Tterm.p_node =
-                                       (Tterm.Pvar
-                                          { Symbols.vs_name = h;
-                                            vs_ty =
-                                            { Ttypes.ty_node =
+                                           { Ttypes.ts_ident = list;
+                                             ts_args =
+                                             [{ Ttypes.tv_name = a_1 }];
+                                             ts_alias = None },
+                                           [{ Ttypes.ty_node =
                                               (Ttypes.Tyapp (
                                                  { Ttypes.ts_ident = int;
                                                    ts_args = [];
                                                    ts_alias = None },
                                                  []))
                                               }
-                                            });
-                                       p_ty =
-                                       { Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = int;
-                                              ts_args = []; ts_alias = None },
-                                            []))
-                                         };
-                                       p_loc = foo.mli:26:8 };
-                                      { Tterm.p_node =
-                                        (Tterm.Pas (
-                                           { Tterm.p_node =
-                                             (Tterm.Papp (
-                                                { Symbols.ls_name = infix ::;
-                                                  ls_args =
-                                                  [{ Ttypes.ty_node =
-                                                     (Ttypes.Tyvar
-                                                        { Ttypes.tv_name = a_1
-                                                          })
-                                                     };
-                                                    { Ttypes.ty_node =
-                                                      (Ttypes.Tyapp (
-                                                         { Ttypes.ts_ident =
-                                                           list;
-                                                           ts_args =
-                                                           [{ Ttypes.tv_name =
-                                                              a_1 }
-                                                             ];
-                                                           ts_alias = None },
-                                                         [{ Ttypes.ty_node =
-                                                            (Ttypes.Tyvar
-                                                               { Ttypes.tv_name =
-                                                                 a_1 })
-                                                            }
-                                                           ]
-                                                         ))
-                                                      }
-                                                    ];
-                                                  ls_value =
-                                                  (Some { Ttypes.ty_node =
-                                                          (Ttypes.Tyapp (
-                                                             { Ttypes.ts_ident =
-                                                               list;
-                                                               ts_args =
-                                                               [{ Ttypes.tv_name =
-                                                                  a_1 }
-                                                                 ];
-                                                               ts_alias = None
-                                                               },
-                                                             [{ Ttypes.ty_node =
-                                                                (Ttypes.Tyvar
-                                                                   { Ttypes.tv_name =
-                                                                     a_1 })
-                                                                }
-                                                               ]
-                                                             ))
-                                                          });
-                                                  ls_constr = true;
-                                                  ls_field = false },
-                                                [{ Tterm.p_node =
-                                                   (Tterm.Pvar
-                                                      { Symbols.vs_name = y;
-                                                        vs_ty =
-                                                        { Ttypes.ty_node =
-                                                          (Ttypes.Tyapp (
-                                                             { Ttypes.ts_ident =
-                                                               int;
-                                                               ts_args = [];
-                                                               ts_alias = None
-                                                               },
-                                                             []))
-                                                          }
-                                                        });
-                                                   p_ty =
-                                                   { Ttypes.ty_node =
-                                                     (Ttypes.Tyapp (
-                                                        { Ttypes.ts_ident = int;
-                                                          ts_args = [];
-                                                          ts_alias = None },
-                                                        []))
-                                                     };
-                                                   p_loc = foo.mli:26:14 };
-                                                  { Tterm.p_node = Tterm.Pwild;
-                                                    p_ty =
-                                                    { Ttypes.ty_node =
-                                                      (Ttypes.Tyapp (
-                                                         { Ttypes.ts_ident =
-                                                           list;
-                                                           ts_args =
-                                                           [{ Ttypes.tv_name =
-                                                              a_1 }
-                                                             ];
-                                                           ts_alias = None },
-                                                         [{ Ttypes.ty_node =
-                                                            (Ttypes.Tyapp (
-                                                               { Ttypes.ts_ident =
-                                                                 int;
-                                                                 ts_args = [];
-                                                                 ts_alias =
-                                                                 None },
-                                                               []))
-                                                            }
-                                                           ]
-                                                         ))
-                                                      };
-                                                    p_loc = foo.mli:26:19 }
-                                                  ]
-                                                ));
-                                             p_ty =
-                                             { Ttypes.ty_node =
-                                               (Ttypes.Tyapp (
-                                                  { Ttypes.ts_ident = list;
-                                                    ts_args =
-                                                    [{ Ttypes.tv_name = a_1 }];
-                                                    ts_alias = None },
-                                                  [{ Ttypes.ty_node =
-                                                     (Ttypes.Tyapp (
-                                                        { Ttypes.ts_ident = int;
-                                                          ts_args = [];
-                                                          ts_alias = None },
-                                                        []))
-                                                     }
-                                                    ]
-                                                  ))
-                                               };
-                                             p_loc = foo.mli:26:14 },
-                                           { Symbols.vs_name = t_2;
-                                             vs_ty =
-                                             { Ttypes.ty_node =
-                                               (Ttypes.Tyapp (
-                                                  { Ttypes.ts_ident = list;
-                                                    ts_args =
-                                                    [{ Ttypes.tv_name = a_1 }];
-                                                    ts_alias = None },
-                                                  [{ Ttypes.ty_node =
-                                                     (Ttypes.Tyapp (
-                                                        { Ttypes.ts_ident = int;
-                                                          ts_args = [];
-                                                          ts_alias = None },
-                                                        []))
-                                                     }
-                                                    ]
-                                                  ))
-                                               }
-                                             }
-                                           ));
-                                        p_ty =
-                                        { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = list;
-                                               ts_args =
-                                               [{ Ttypes.tv_name = a_1 }];
-                                               ts_alias = None },
-                                             [{ Ttypes.ty_node =
-                                                (Ttypes.Tyapp (
-                                                   { Ttypes.ts_ident = int;
-                                                     ts_args = [];
-                                                     ts_alias = None },
-                                                   []))
-                                                }
-                                               ]
-                                             ))
-                                          };
-                                        p_loc = foo.mli:26:13 }
+                                             ]
+                                           ))
+                                        };
+                                      p_loc = foo.mli:25:18 }
+                                    ]
+                                  ));
+                               p_ty =
+                               { Ttypes.ty_node =
+                                 (Ttypes.Tyapp (
+                                    { Ttypes.ts_ident = list;
+                                      ts_args = [{ Ttypes.tv_name = a_1 }];
+                                      ts_alias = None },
+                                    [{ Ttypes.ty_node =
+                                       (Ttypes.Tyapp (
+                                          { Ttypes.ts_ident = int;
+                                            ts_args = []; ts_alias = None },
+                                          []))
+                                       }
                                       ]
-                                    ));
+                                    ))
+                                 };
+                               p_loc = foo.mli:25:13 }
+                             ));
+                          p_ty =
+                          { Ttypes.ty_node =
+                            (Ttypes.Tyapp (
+                               { Ttypes.ts_ident = list;
+                                 ts_args = [{ Ttypes.tv_name = a_1 }];
+                                 ts_alias = None },
+                               [{ Ttypes.ty_node =
+                                  (Ttypes.Tyapp (
+                                     { Ttypes.ts_ident = int; ts_args = [];
+                                       ts_alias = None },
+                                     []))
+                                  }
+                                 ]
+                               ))
+                            };
+                          p_loc = foo.mli:25:8 },
+                        None,
+                        { Tterm.t_node = Tterm.Ttrue;
+                          t_ty =
+                          { Ttypes.ty_node =
+                            (Ttypes.Tyapp (
+                               { Ttypes.ts_ident = bool; ts_args = [];
+                                 ts_alias = None },
+                               []))
+                            };
+                          t_attrs = []; t_loc = foo.mli:25:24 });
+                        ({ Tterm.p_node =
+                           (Tterm.Papp (
+                              { Symbols.ls_name = infix ::;
+                                ls_args =
+                                [{ Ttypes.ty_node =
+                                   (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) };
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = list;
+                                         ts_args = [{ Ttypes.tv_name = a_1 }];
+                                         ts_alias = None },
+                                       [{ Ttypes.ty_node =
+                                          (Ttypes.Tyvar
+                                             { Ttypes.tv_name = a_1 })
+                                          }
+                                         ]
+                                       ))
+                                    }
+                                  ];
+                                ls_value =
+                                { Ttypes.ty_node =
+                                  (Ttypes.Tyapp (
+                                     { Ttypes.ts_ident = list;
+                                       ts_args = [{ Ttypes.tv_name = a_1 }];
+                                       ts_alias = None },
+                                     [{ Ttypes.ty_node =
+                                        (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
+                                        }
+                                       ]
+                                     ))
+                                  };
+                                ls_constr = true; ls_field = false },
+                              [{ Tterm.p_node =
+                                 (Tterm.Pvar
+                                    { Symbols.vs_name = h;
+                                      vs_ty =
+                                      { Ttypes.ty_node =
+                                        (Ttypes.Tyapp (
+                                           { Ttypes.ts_ident = int;
+                                             ts_args = []; ts_alias = None },
+                                           []))
+                                        }
+                                      });
                                  p_ty =
                                  { Ttypes.ty_node =
                                    (Ttypes.Tyapp (
-                                      { Ttypes.ts_ident = list;
-                                        ts_args = [{ Ttypes.tv_name = a_1 }];
+                                      { Ttypes.ts_ident = int; ts_args = [];
                                         ts_alias = None },
-                                      [{ Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = int;
-                                              ts_args = []; ts_alias = None },
-                                            []))
-                                         }
-                                        ]
-                                      ))
+                                      []))
                                    };
-                                 p_loc = foo.mli:26:8 },
-                               None,
-                               { Tterm.t_node =
-                                 (Tterm.Tif (
-                                    { Tterm.t_node =
-                                      (Tterm.Tbinop (Tterm.Tand,
-                                         { Tterm.t_node =
-                                           (Tterm.Tapp (
-                                              { Symbols.ls_name =
-                                                Gospelstdlib.infix <=;
-                                                ls_args =
-                                                [{ Ttypes.ty_node =
-                                                   (Ttypes.Tyapp (
-                                                      { Ttypes.ts_ident =
-                                                        integer; ts_args = [];
-                                                        ts_alias = None },
-                                                      []))
-                                                   };
+                                 p_loc = foo.mli:26:8 };
+                                { Tterm.p_node =
+                                  (Tterm.Pas (
+                                     { Tterm.p_node =
+                                       (Tterm.Papp (
+                                          { Symbols.ls_name = infix ::;
+                                            ls_args =
+                                            [{ Ttypes.ty_node =
+                                               (Ttypes.Tyvar
+                                                  { Ttypes.tv_name = a_1 })
+                                               };
+                                              { Ttypes.ty_node =
+                                                (Ttypes.Tyapp (
+                                                   { Ttypes.ts_ident = list;
+                                                     ts_args =
+                                                     [{ Ttypes.tv_name = a_1 }];
+                                                     ts_alias = None },
+                                                   [{ Ttypes.ty_node =
+                                                      (Ttypes.Tyvar
+                                                         { Ttypes.tv_name = a_1
+                                                           })
+                                                      }
+                                                     ]
+                                                   ))
+                                                }
+                                              ];
+                                            ls_value =
+                                            { Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = list;
+                                                   ts_args =
+                                                   [{ Ttypes.tv_name = a_1 }];
+                                                   ts_alias = None },
+                                                 [{ Ttypes.ty_node =
+                                                    (Ttypes.Tyvar
+                                                       { Ttypes.tv_name = a_1 })
+                                                    }
+                                                   ]
+                                                 ))
+                                              };
+                                            ls_constr = true; ls_field = false
+                                            },
+                                          [{ Tterm.p_node =
+                                             (Tterm.Pvar
+                                                { Symbols.vs_name = y;
+                                                  vs_ty =
                                                   { Ttypes.ty_node =
                                                     (Ttypes.Tyapp (
-                                                       { Ttypes.ts_ident =
-                                                         integer; ts_args = [];
+                                                       { Ttypes.ts_ident = int;
+                                                         ts_args = [];
                                                          ts_alias = None },
                                                        []))
                                                     }
-                                                  ];
-                                                ls_value = None;
-                                                ls_constr = false;
-                                                ls_field = false },
-                                              [{ Tterm.t_node =
-                                                 (Tterm.Tapp (
-                                                    { Symbols.ls_name =
-                                                      Gospelstdlib.integer_of_int;
-                                                      ls_args =
-                                                      [{ Ttypes.ty_node =
-                                                         (Ttypes.Tyapp (
-                                                            { Ttypes.ts_ident =
-                                                              int;
-                                                              ts_args = [];
-                                                              ts_alias = None },
-                                                            []))
-                                                         }
-                                                        ];
-                                                      ls_value =
-                                                      (Some { Ttypes.ty_node =
-                                                              (Ttypes.Tyapp (
-                                                                 { Ttypes.ts_ident =
-                                                                   integer;
-                                                                   ts_args = [];
-                                                                   ts_alias =
-                                                                   None },
-                                                                 []))
-                                                              });
-                                                      ls_constr = false;
-                                                      ls_field = false },
-                                                    [{ Tterm.t_node =
-                                                       (Tterm.Tvar
-                                                          { Symbols.vs_name = h;
-                                                            vs_ty =
-                                                            { Ttypes.ty_node =
-                                                              (Ttypes.Tyapp (
-                                                                 { Ttypes.ts_ident =
-                                                                   int;
-                                                                   ts_args = [];
-                                                                   ts_alias =
-                                                                   None },
-                                                                 []))
-                                                              }
-                                                            });
-                                                       t_ty =
-                                                       (Some { Ttypes.ty_node =
-                                                               (Ttypes.Tyapp (
-                                                                  { Ttypes.ts_ident =
-                                                                    int;
-                                                                    ts_args =
-                                                                    [];
-                                                                    ts_alias =
-                                                                    None },
-                                                                  []))
-                                                               });
-                                                       t_attrs = [];
-                                                       t_loc = foo.mli:26:30 }
-                                                      ]
-                                                    ));
-                                                 t_ty =
-                                                 (Some { Ttypes.ty_node =
-                                                         (Ttypes.Tyapp (
-                                                            { Ttypes.ts_ident =
-                                                              integer;
-                                                              ts_args = [];
-                                                              ts_alias = None },
-                                                            []))
-                                                         });
-                                                 t_attrs = [];
-                                                 t_loc = foo.mli:26:30 };
-                                                { Tterm.t_node =
-                                                  (Tterm.Tapp (
-                                                     { Symbols.ls_name =
-                                                       Gospelstdlib.integer_of_int;
-                                                       ls_args =
-                                                       [{ Ttypes.ty_node =
-                                                          (Ttypes.Tyapp (
-                                                             { Ttypes.ts_ident =
-                                                               int;
-                                                               ts_args = [];
-                                                               ts_alias = None
-                                                               },
-                                                             []))
-                                                          }
-                                                         ];
-                                                       ls_value =
-                                                       (Some { Ttypes.ty_node =
-                                                               (Ttypes.Tyapp (
-                                                                  { Ttypes.ts_ident =
-                                                                    integer;
-                                                                    ts_args =
-                                                                    [];
-                                                                    ts_alias =
-                                                                    None },
-                                                                  []))
-                                                               });
-                                                       ls_constr = false;
-                                                       ls_field = false },
-                                                     [{ Tterm.t_node =
-                                                        (Tterm.Tvar
-                                                           { Symbols.vs_name =
-                                                             y;
-                                                             vs_ty =
-                                                             { Ttypes.ty_node =
-                                                               (Ttypes.Tyapp (
-                                                                  { Ttypes.ts_ident =
-                                                                    int;
-                                                                    ts_args =
-                                                                    [];
-                                                                    ts_alias =
-                                                                    None },
-                                                                  []))
-                                                               }
-                                                             });
-                                                        t_ty =
-                                                        (Some { Ttypes.ty_node =
-                                                                (Ttypes.Tyapp (
-                                                                   { Ttypes.ts_ident =
-                                                                     int;
-                                                                     ts_args =
-                                                                     [];
-                                                                     ts_alias =
-                                                                     None },
-                                                                   []))
-                                                                });
-                                                        t_attrs = [];
-                                                        t_loc = foo.mli:26:35 }
-                                                       ]
-                                                     ));
-                                                  t_ty =
-                                                  (Some { Ttypes.ty_node =
-                                                          (Ttypes.Tyapp (
-                                                             { Ttypes.ts_ident =
-                                                               integer;
-                                                               ts_args = [];
-                                                               ts_alias = None
-                                                               },
-                                                             []))
-                                                          });
-                                                  t_attrs = [];
-                                                  t_loc = foo.mli:26:35 }
-                                                ]
-                                              ));
-                                           t_ty = None; t_attrs = [];
-                                           t_loc = foo.mli:26:30 },
-                                         { Tterm.t_node =
-                                           (Tterm.Tapp (
-                                              { Symbols.ls_name =
-                                                Foo.is_sorted_list;
-                                                ls_args =
-                                                [{ Ttypes.ty_node =
-                                                   (Ttypes.Tyapp (
-                                                      { Ttypes.ts_ident = list;
-                                                        ts_args =
-                                                        [{ Ttypes.tv_name = a_1
-                                                           }
-                                                          ];
-                                                        ts_alias = None },
-                                                      [{ Ttypes.ty_node =
-                                                         (Ttypes.Tyapp (
-                                                            { Ttypes.ts_ident =
-                                                              int;
-                                                              ts_args = [];
-                                                              ts_alias = None },
-                                                            []))
-                                                         }
-                                                        ]
-                                                      ))
-                                                   }
-                                                  ];
-                                                ls_value = None;
-                                                ls_constr = false;
-                                                ls_field = false },
-                                              [{ Tterm.t_node =
-                                                 (Tterm.Tvar
-                                                    { Symbols.vs_name = t_2;
-                                                      vs_ty =
-                                                      { Ttypes.ty_node =
-                                                        (Ttypes.Tyapp (
-                                                           { Ttypes.ts_ident =
-                                                             list;
-                                                             ts_args =
-                                                             [{ Ttypes.tv_name =
-                                                                a_1 }
-                                                               ];
-                                                             ts_alias = None },
-                                                           [{ Ttypes.ty_node =
-                                                              (Ttypes.Tyapp (
-                                                                 { Ttypes.ts_ident =
-                                                                   int;
-                                                                   ts_args = [];
-                                                                   ts_alias =
-                                                                   None },
-                                                                 []))
-                                                              }
-                                                             ]
-                                                           ))
-                                                        }
-                                                      });
-                                                 t_ty =
-                                                 (Some { Ttypes.ty_node =
-                                                         (Ttypes.Tyapp (
-                                                            { Ttypes.ts_ident =
-                                                              list;
-                                                              ts_args =
-                                                              [{ Ttypes.tv_name =
-                                                                 a_1 }
-                                                                ];
-                                                              ts_alias = None },
-                                                            [{ Ttypes.ty_node =
-                                                               (Ttypes.Tyapp (
-                                                                  { Ttypes.ts_ident =
-                                                                    int;
-                                                                    ts_args =
-                                                                    [];
-                                                                    ts_alias =
-                                                                    None },
-                                                                  []))
-                                                               }
-                                                              ]
-                                                            ))
-                                                         });
-                                                 t_attrs = [];
-                                                 t_loc = foo.mli:26:55 }
-                                                ]
-                                              ));
-                                           t_ty = None; t_attrs = [];
-                                           t_loc = foo.mli:26:40 }
-                                         ));
-                                      t_ty = None; t_attrs = [];
-                                      t_loc = foo.mli:26:30 },
-                                    { Tterm.t_node =
-                                      (Tterm.Tapp (
-                                         { Symbols.ls_name = true;
-                                           ls_args = [];
-                                           ls_value =
-                                           (Some { Ttypes.ty_node =
-                                                   (Ttypes.Tyapp (
-                                                      { Ttypes.ts_ident = bool;
-                                                        ts_args = [];
-                                                        ts_alias = None },
-                                                      []))
-                                                   });
-                                           ls_constr = true; ls_field = false },
-                                         []));
-                                      t_ty =
-                                      (Some { Ttypes.ty_node =
-                                              (Ttypes.Tyapp (
-                                                 { Ttypes.ts_ident = bool;
-                                                   ts_args = [];
-                                                   ts_alias = None },
-                                                 []))
-                                              });
-                                      t_attrs = []; t_loc = foo.mli:26:30 },
-                                    { Tterm.t_node =
-                                      (Tterm.Tapp (
-                                         { Symbols.ls_name = false;
-                                           ls_args = [];
-                                           ls_value =
-                                           (Some { Ttypes.ty_node =
-                                                   (Ttypes.Tyapp (
-                                                      { Ttypes.ts_ident = bool;
-                                                        ts_args = [];
-                                                        ts_alias = None },
-                                                      []))
-                                                   });
-                                           ls_constr = true; ls_field = false },
-                                         []));
-                                      t_ty =
-                                      (Some { Ttypes.ty_node =
-                                              (Ttypes.Tyapp (
-                                                 { Ttypes.ts_ident = bool;
-                                                   ts_args = [];
-                                                   ts_alias = None },
-                                                 []))
-                                              });
-                                      t_attrs = []; t_loc = foo.mli:26:30 }
-                                    ));
-                                 t_ty =
-                                 (Some { Ttypes.ty_node =
+                                                  });
+                                             p_ty =
+                                             { Ttypes.ty_node =
+                                               (Ttypes.Tyapp (
+                                                  { Ttypes.ts_ident = int;
+                                                    ts_args = [];
+                                                    ts_alias = None },
+                                                  []))
+                                               };
+                                             p_loc = foo.mli:26:14 };
+                                            { Tterm.p_node = Tterm.Pwild;
+                                              p_ty =
+                                              { Ttypes.ty_node =
+                                                (Ttypes.Tyapp (
+                                                   { Ttypes.ts_ident = list;
+                                                     ts_args =
+                                                     [{ Ttypes.tv_name = a_1 }];
+                                                     ts_alias = None },
+                                                   [{ Ttypes.ty_node =
+                                                      (Ttypes.Tyapp (
+                                                         { Ttypes.ts_ident =
+                                                           int; ts_args = [];
+                                                           ts_alias = None },
+                                                         []))
+                                                      }
+                                                     ]
+                                                   ))
+                                                };
+                                              p_loc = foo.mli:26:19 }
+                                            ]
+                                          ));
+                                       p_ty =
+                                       { Ttypes.ty_node =
                                          (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = bool;
+                                            { Ttypes.ts_ident = list;
+                                              ts_args =
+                                              [{ Ttypes.tv_name = a_1 }];
+                                              ts_alias = None },
+                                            [{ Ttypes.ty_node =
+                                               (Ttypes.Tyapp (
+                                                  { Ttypes.ts_ident = int;
+                                                    ts_args = [];
+                                                    ts_alias = None },
+                                                  []))
+                                               }
+                                              ]
+                                            ))
+                                         };
+                                       p_loc = foo.mli:26:14 },
+                                     { Symbols.vs_name = t_2;
+                                       vs_ty =
+                                       { Ttypes.ty_node =
+                                         (Ttypes.Tyapp (
+                                            { Ttypes.ts_ident = list;
+                                              ts_args =
+                                              [{ Ttypes.tv_name = a_1 }];
+                                              ts_alias = None },
+                                            [{ Ttypes.ty_node =
+                                               (Ttypes.Tyapp (
+                                                  { Ttypes.ts_ident = int;
+                                                    ts_args = [];
+                                                    ts_alias = None },
+                                                  []))
+                                               }
+                                              ]
+                                            ))
+                                         }
+                                       }
+                                     ));
+                                  p_ty =
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = list;
+                                         ts_args = [{ Ttypes.tv_name = a_1 }];
+                                         ts_alias = None },
+                                       [{ Ttypes.ty_node =
+                                          (Ttypes.Tyapp (
+                                             { Ttypes.ts_ident = int;
+                                               ts_args = []; ts_alias = None },
+                                             []))
+                                          }
+                                         ]
+                                       ))
+                                    };
+                                  p_loc = foo.mli:26:13 }
+                                ]
+                              ));
+                           p_ty =
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = list;
+                                  ts_args = [{ Ttypes.tv_name = a_1 }];
+                                  ts_alias = None },
+                                [{ Ttypes.ty_node =
+                                   (Ttypes.Tyapp (
+                                      { Ttypes.ts_ident = int; ts_args = [];
+                                        ts_alias = None },
+                                      []))
+                                   }
+                                  ]
+                                ))
+                             };
+                           p_loc = foo.mli:26:8 },
+                         None,
+                         { Tterm.t_node =
+                           (Tterm.Tbinop (Tterm.Tand,
+                              { Tterm.t_node =
+                                (Tterm.Tapp (
+                                   { Symbols.ls_name = Gospelstdlib.infix <=;
+                                     ls_args =
+                                     [{ Ttypes.ty_node =
+                                        (Ttypes.Tyapp (
+                                           { Ttypes.ts_ident = integer;
+                                             ts_args = []; ts_alias = None },
+                                           []))
+                                        };
+                                       { Ttypes.ty_node =
+                                         (Ttypes.Tyapp (
+                                            { Ttypes.ts_ident = integer;
                                               ts_args = []; ts_alias = None },
                                             []))
-                                         });
-                                 t_attrs = []; t_loc = foo.mli:26:30 })
-                              ]
-                            ));
-                         t_ty =
-                         (Some { Ttypes.ty_node =
-                                 (Ttypes.Tyapp (
-                                    { Ttypes.ts_ident = bool; ts_args = [];
-                                      ts_alias = None },
-                                    []))
-                                 });
-                         t_attrs = []; t_loc = foo.mli:24:49 };
-                        { Tterm.t_node =
-                          (Tterm.Tapp (
-                             { Symbols.ls_name = true; ls_args = [];
-                               ls_value =
-                               (Some { Ttypes.ty_node =
+                                         }
+                                       ];
+                                     ls_value =
+                                     { Ttypes.ty_node =
                                        (Ttypes.Tyapp (
                                           { Ttypes.ts_ident = bool;
                                             ts_args = []; ts_alias = None },
                                           []))
-                                       });
-                               ls_constr = true; ls_field = false },
-                             []));
-                          t_ty =
-                          (Some { Ttypes.ty_node =
+                                       };
+                                     ls_constr = false; ls_field = false },
+                                   [{ Tterm.t_node =
+                                      (Tterm.Tapp (
+                                         { Symbols.ls_name =
+                                           Gospelstdlib.integer_of_int;
+                                           ls_args =
+                                           [{ Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = int;
+                                                   ts_args = [];
+                                                   ts_alias = None },
+                                                 []))
+                                              }
+                                             ];
+                                           ls_value =
+                                           { Ttypes.ty_node =
+                                             (Ttypes.Tyapp (
+                                                { Ttypes.ts_ident = integer;
+                                                  ts_args = []; ts_alias = None
+                                                  },
+                                                []))
+                                             };
+                                           ls_constr = false; ls_field = false
+                                           },
+                                         [{ Tterm.t_node =
+                                            (Tterm.Tvar
+                                               { Symbols.vs_name = h;
+                                                 vs_ty =
+                                                 { Ttypes.ty_node =
+                                                   (Ttypes.Tyapp (
+                                                      { Ttypes.ts_ident = int;
+                                                        ts_args = [];
+                                                        ts_alias = None },
+                                                      []))
+                                                   }
+                                                 });
+                                            t_ty =
+                                            { Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = int;
+                                                   ts_args = [];
+                                                   ts_alias = None },
+                                                 []))
+                                              };
+                                            t_attrs = []; t_loc = foo.mli:26:30
+                                            }
+                                           ]
+                                         ));
+                                      t_ty =
+                                      { Ttypes.ty_node =
+                                        (Ttypes.Tyapp (
+                                           { Ttypes.ts_ident = integer;
+                                             ts_args = []; ts_alias = None },
+                                           []))
+                                        };
+                                      t_attrs = []; t_loc = foo.mli:26:30 };
+                                     { Tterm.t_node =
+                                       (Tterm.Tapp (
+                                          { Symbols.ls_name =
+                                            Gospelstdlib.integer_of_int;
+                                            ls_args =
+                                            [{ Ttypes.ty_node =
+                                               (Ttypes.Tyapp (
+                                                  { Ttypes.ts_ident = int;
+                                                    ts_args = [];
+                                                    ts_alias = None },
+                                                  []))
+                                               }
+                                              ];
+                                            ls_value =
+                                            { Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = integer;
+                                                   ts_args = [];
+                                                   ts_alias = None },
+                                                 []))
+                                              };
+                                            ls_constr = false; ls_field = false
+                                            },
+                                          [{ Tterm.t_node =
+                                             (Tterm.Tvar
+                                                { Symbols.vs_name = y;
+                                                  vs_ty =
+                                                  { Ttypes.ty_node =
+                                                    (Ttypes.Tyapp (
+                                                       { Ttypes.ts_ident = int;
+                                                         ts_args = [];
+                                                         ts_alias = None },
+                                                       []))
+                                                    }
+                                                  });
+                                             t_ty =
+                                             { Ttypes.ty_node =
+                                               (Ttypes.Tyapp (
+                                                  { Ttypes.ts_ident = int;
+                                                    ts_args = [];
+                                                    ts_alias = None },
+                                                  []))
+                                               };
+                                             t_attrs = [];
+                                             t_loc = foo.mli:26:35 }
+                                            ]
+                                          ));
+                                       t_ty =
+                                       { Ttypes.ty_node =
+                                         (Ttypes.Tyapp (
+                                            { Ttypes.ts_ident = integer;
+                                              ts_args = []; ts_alias = None },
+                                            []))
+                                         };
+                                       t_attrs = []; t_loc = foo.mli:26:35 }
+                                     ]
+                                   ));
+                                t_ty =
+                                { Ttypes.ty_node =
                                   (Ttypes.Tyapp (
                                      { Ttypes.ts_ident = bool; ts_args = [];
                                        ts_alias = None },
                                      []))
-                                  });
-                          t_attrs = []; t_loc = foo.mli:24:49 }
+                                  };
+                                t_attrs = []; t_loc = foo.mli:26:30 },
+                              { Tterm.t_node =
+                                (Tterm.Tapp (
+                                   { Symbols.ls_name = Foo.is_sorted_list;
+                                     ls_args =
+                                     [{ Ttypes.ty_node =
+                                        (Ttypes.Tyapp (
+                                           { Ttypes.ts_ident = list;
+                                             ts_args =
+                                             [{ Ttypes.tv_name = a_1 }];
+                                             ts_alias = None },
+                                           [{ Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = int;
+                                                   ts_args = [];
+                                                   ts_alias = None },
+                                                 []))
+                                              }
+                                             ]
+                                           ))
+                                        }
+                                       ];
+                                     ls_value =
+                                     { Ttypes.ty_node =
+                                       (Ttypes.Tyapp (
+                                          { Ttypes.ts_ident = bool;
+                                            ts_args = []; ts_alias = None },
+                                          []))
+                                       };
+                                     ls_constr = false; ls_field = false },
+                                   [{ Tterm.t_node =
+                                      (Tterm.Tvar
+                                         { Symbols.vs_name = t_2;
+                                           vs_ty =
+                                           { Ttypes.ty_node =
+                                             (Ttypes.Tyapp (
+                                                { Ttypes.ts_ident = list;
+                                                  ts_args =
+                                                  [{ Ttypes.tv_name = a_1 }];
+                                                  ts_alias = None },
+                                                [{ Ttypes.ty_node =
+                                                   (Ttypes.Tyapp (
+                                                      { Ttypes.ts_ident = int;
+                                                        ts_args = [];
+                                                        ts_alias = None },
+                                                      []))
+                                                   }
+                                                  ]
+                                                ))
+                                             }
+                                           });
+                                      t_ty =
+                                      { Ttypes.ty_node =
+                                        (Ttypes.Tyapp (
+                                           { Ttypes.ts_ident = list;
+                                             ts_args =
+                                             [{ Ttypes.tv_name = a_1 }];
+                                             ts_alias = None },
+                                           [{ Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = int;
+                                                   ts_args = [];
+                                                   ts_alias = None },
+                                                 []))
+                                              }
+                                             ]
+                                           ))
+                                        };
+                                      t_attrs = []; t_loc = foo.mli:26:55 }
+                                     ]
+                                   ));
+                                t_ty =
+                                { Ttypes.ty_node =
+                                  (Ttypes.Tyapp (
+                                     { Ttypes.ts_ident = bool; ts_args = [];
+                                       ts_alias = None },
+                                     []))
+                                  };
+                                t_attrs = []; t_loc = foo.mli:26:40 }
+                              ));
+                           t_ty =
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = bool; ts_args = [];
+                                  ts_alias = None },
+                                []))
+                             };
+                           t_attrs = []; t_loc = foo.mli:26:30 })
                         ]
                       ));
-                   t_ty = None; t_attrs = []; t_loc = foo.mli:24:49 });
+                   t_ty =
+                   { Ttypes.ty_node =
+                     (Ttypes.Tyapp (
+                        { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None
+                          },
+                        []))
+                     };
+                   t_attrs = []; t_loc = foo.mli:24:49 });
            fun_spec = None;
            fun_text =
            " predicate rec is_sorted_list (l: int list) = match l with\n      | [] | _ :: [] -> true\n      | h :: (y :: _ as t) -> h <= y /\\ is_sorted_list t ";
@@ -1794,8 +1651,14 @@ First, create a test artifact:
                              { Ttypes.ty_node =
                                (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) }
                              ];
-                           ls_value = None; ls_constr = false; ls_field = false
-                           },
+                           ls_value =
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = bool; ts_args = [];
+                                  ts_alias = None },
+                                []))
+                             };
+                           ls_constr = false; ls_field = false },
                          [{ Tterm.t_node =
                             (Tterm.Tfield (
                                { Tterm.t_node =
@@ -1816,19 +1679,17 @@ First, create a test artifact:
                                         }
                                       });
                                  t_ty =
-                                 (Some { Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = t;
-                                              ts_args =
-                                              [{ Ttypes.tv_name = a }];
-                                              ts_alias = None },
-                                            [{ Ttypes.ty_node =
-                                               (Ttypes.Tyvar
-                                                  { Ttypes.tv_name = a })
-                                               }
-                                              ]
-                                            ))
-                                         });
+                                 { Ttypes.ty_node =
+                                   (Ttypes.Tyapp (
+                                      { Ttypes.ts_ident = t;
+                                        ts_args = [{ Ttypes.tv_name = a }];
+                                        ts_alias = None },
+                                      [{ Ttypes.ty_node =
+                                         (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                         }
+                                        ]
+                                      ))
+                                   };
                                  t_attrs = []; t_loc = foo.mli:32:12 },
                                { Symbols.ls_name = contents;
                                  ls_args =
@@ -1845,60 +1706,111 @@ First, create a test artifact:
                                     }
                                    ];
                                  ls_value =
-                                 (Some { Ttypes.ty_node =
-                                         (Ttypes.Tyapp (
-                                            { Ttypes.ts_ident = list;
-                                              ts_args =
-                                              [{ Ttypes.tv_name = a_1 }];
-                                              ts_alias = None },
-                                            [{ Ttypes.ty_node =
-                                               (Ttypes.Tyvar
-                                                  { Ttypes.tv_name = a })
-                                               }
-                                              ]
-                                            ))
-                                         });
+                                 { Ttypes.ty_node =
+                                   (Ttypes.Tyapp (
+                                      { Ttypes.ts_ident = list;
+                                        ts_args = [{ Ttypes.tv_name = a_1 }];
+                                        ts_alias = None },
+                                      [{ Ttypes.ty_node =
+                                         (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                         }
+                                        ]
+                                      ))
+                                   };
                                  ls_constr = false; ls_field = true }
                                ));
                             t_ty =
-                            (Some { Ttypes.ty_node =
-                                    (Ttypes.Tyapp (
-                                       { Ttypes.ts_ident = list;
-                                         ts_args = [{ Ttypes.tv_name = a_1 }];
-                                         ts_alias = None },
-                                       [{ Ttypes.ty_node =
-                                          (Ttypes.Tyvar { Ttypes.tv_name = a })
-                                          }
-                                         ]
-                                       ))
-                                    });
+                            { Ttypes.ty_node =
+                              (Ttypes.Tyapp (
+                                 { Ttypes.ts_ident = list;
+                                   ts_args = [{ Ttypes.tv_name = a_1 }];
+                                   ts_alias = None },
+                                 [{ Ttypes.ty_node =
+                                    (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                   ]
+                                 ))
+                              };
                             t_attrs = []; t_loc = foo.mli:32:12 };
                            { Tterm.t_node =
                              (Tterm.Tif (
                                 { Tterm.t_node =
                                   (Tterm.Tapp (
-                                     { Symbols.ls_name = infix =;
+                                     { Symbols.ls_name = Foo.is_full;
                                        ls_args =
                                        [{ Ttypes.ty_node =
-                                          (Ttypes.Tyvar
-                                             { Ttypes.tv_name = a_2 })
+                                          (Ttypes.Tyapp (
+                                             { Ttypes.ts_ident = list;
+                                               ts_args =
+                                               [{ Ttypes.tv_name = a_1 }];
+                                               ts_alias = None },
+                                             [{ Ttypes.ty_node =
+                                                (Ttypes.Tyvar
+                                                   { Ttypes.tv_name = a })
+                                                }
+                                               ]
+                                             ))
                                           };
                                          { Ttypes.ty_node =
-                                           (Ttypes.Tyvar
-                                              { Ttypes.tv_name = a_2 })
+                                           (Ttypes.Tyapp (
+                                              { Ttypes.ts_ident = integer;
+                                                ts_args = []; ts_alias = None },
+                                              []))
                                            }
                                          ];
-                                       ls_value = None; ls_constr = false;
-                                       ls_field = false },
+                                       ls_value =
+                                       { Ttypes.ty_node =
+                                         (Ttypes.Tyapp (
+                                            { Ttypes.ts_ident = bool;
+                                              ts_args = []; ts_alias = None },
+                                            []))
+                                         };
+                                       ls_constr = false; ls_field = false },
                                      [{ Tterm.t_node =
-                                        (Tterm.Tapp (
-                                           { Symbols.ls_name = Foo.is_full;
+                                        (Tterm.Tfield (
+                                           { Tterm.t_node =
+                                             (Tterm.Tvar
+                                                { Symbols.vs_name = t_3;
+                                                  vs_ty =
+                                                  { Ttypes.ty_node =
+                                                    (Ttypes.Tyapp (
+                                                       { Ttypes.ts_ident = t;
+                                                         ts_args =
+                                                         [{ Ttypes.tv_name = a
+                                                            }
+                                                           ];
+                                                         ts_alias = None },
+                                                       [{ Ttypes.ty_node =
+                                                          (Ttypes.Tyvar
+                                                             { Ttypes.tv_name =
+                                                               a })
+                                                          }
+                                                         ]
+                                                       ))
+                                                    }
+                                                  });
+                                             t_ty =
+                                             { Ttypes.ty_node =
+                                               (Ttypes.Tyapp (
+                                                  { Ttypes.ts_ident = t;
+                                                    ts_args =
+                                                    [{ Ttypes.tv_name = a }];
+                                                    ts_alias = None },
+                                                  [{ Ttypes.ty_node =
+                                                     (Ttypes.Tyvar
+                                                        { Ttypes.tv_name = a })
+                                                     }
+                                                    ]
+                                                  ))
+                                               };
+                                             t_attrs = [];
+                                             t_loc = foo.mli:32:36 },
+                                           { Symbols.ls_name = contents;
                                              ls_args =
                                              [{ Ttypes.ty_node =
                                                 (Ttypes.Tyapp (
-                                                   { Ttypes.ts_ident = list;
+                                                   { Ttypes.ts_ident = t;
                                                      ts_args =
-                                                     [{ Ttypes.tv_name = a_1 }];
+                                                     [{ Ttypes.tv_name = a }];
                                                      ts_alias = None },
                                                    [{ Ttypes.ty_node =
                                                       (Ttypes.Tyvar
@@ -1906,52 +1818,70 @@ First, create a test artifact:
                                                       }
                                                      ]
                                                    ))
-                                                };
-                                               { Ttypes.ty_node =
+                                                }
+                                               ];
+                                             ls_value =
+                                             { Ttypes.ty_node =
+                                               (Ttypes.Tyapp (
+                                                  { Ttypes.ts_ident = list;
+                                                    ts_args =
+                                                    [{ Ttypes.tv_name = a_1 }];
+                                                    ts_alias = None },
+                                                  [{ Ttypes.ty_node =
+                                                     (Ttypes.Tyvar
+                                                        { Ttypes.tv_name = a })
+                                                     }
+                                                    ]
+                                                  ))
+                                               };
+                                             ls_constr = false; ls_field = true
+                                             }
+                                           ));
+                                        t_ty =
+                                        { Ttypes.ty_node =
+                                          (Ttypes.Tyapp (
+                                             { Ttypes.ts_ident = list;
+                                               ts_args =
+                                               [{ Ttypes.tv_name = a_1 }];
+                                               ts_alias = None },
+                                             [{ Ttypes.ty_node =
+                                                (Ttypes.Tyvar
+                                                   { Ttypes.tv_name = a })
+                                                }
+                                               ]
+                                             ))
+                                          };
+                                        t_attrs = []; t_loc = foo.mli:32:36 };
+                                       { Tterm.t_node =
+                                         (Tterm.Tapp (
+                                            { Symbols.ls_name =
+                                              Gospelstdlib.integer_of_int;
+                                              ls_args =
+                                              [{ Ttypes.ty_node =
                                                  (Ttypes.Tyapp (
-                                                    { Ttypes.ts_ident = integer;
+                                                    { Ttypes.ts_ident = int;
                                                       ts_args = [];
                                                       ts_alias = None },
                                                     []))
                                                  }
-                                               ];
-                                             ls_value =
-                                             (Some { Ttypes.ty_node =
-                                                     (Ttypes.Tyapp (
-                                                        { Ttypes.ts_ident =
-                                                          bool; ts_args = [];
-                                                          ts_alias = None },
-                                                        []))
-                                                     });
-                                             ls_constr = false;
-                                             ls_field = false },
-                                           [{ Tterm.t_node =
-                                              (Tterm.Tfield (
-                                                 { Tterm.t_node =
-                                                   (Tterm.Tvar
-                                                      { Symbols.vs_name = t_3;
-                                                        vs_ty =
-                                                        { Ttypes.ty_node =
-                                                          (Ttypes.Tyapp (
-                                                             { Ttypes.ts_ident =
-                                                               t;
-                                                               ts_args =
-                                                               [{ Ttypes.tv_name =
-                                                                  a }
-                                                                 ];
-                                                               ts_alias = None
-                                                               },
-                                                             [{ Ttypes.ty_node =
-                                                                (Ttypes.Tyvar
-                                                                   { Ttypes.tv_name =
-                                                                     a })
-                                                                }
-                                                               ]
-                                                             ))
-                                                          }
-                                                        });
-                                                   t_ty =
-                                                   (Some { Ttypes.ty_node =
+                                                ];
+                                              ls_value =
+                                              { Ttypes.ty_node =
+                                                (Ttypes.Tyapp (
+                                                   { Ttypes.ts_ident = integer;
+                                                     ts_args = [];
+                                                     ts_alias = None },
+                                                   []))
+                                                };
+                                              ls_constr = false;
+                                              ls_field = false },
+                                            [{ Tterm.t_node =
+                                               (Tterm.Tfield (
+                                                  { Tterm.t_node =
+                                                    (Tterm.Tvar
+                                                       { Symbols.vs_name = t_3;
+                                                         vs_ty =
+                                                         { Ttypes.ty_node =
                                                            (Ttypes.Tyapp (
                                                               { Ttypes.ts_ident =
                                                                 t;
@@ -1968,12 +1898,10 @@ First, create a test artifact:
                                                                  }
                                                                 ]
                                                               ))
-                                                           });
-                                                   t_attrs = [];
-                                                   t_loc = foo.mli:32:36 },
-                                                 { Symbols.ls_name = contents;
-                                                   ls_args =
-                                                   [{ Ttypes.ty_node =
+                                                           }
+                                                         });
+                                                    t_ty =
+                                                    { Ttypes.ty_node =
                                                       (Ttypes.Tyapp (
                                                          { Ttypes.ts_ident = t;
                                                            ts_args =
@@ -1988,217 +1916,69 @@ First, create a test artifact:
                                                             }
                                                            ]
                                                          ))
-                                                      }
-                                                     ];
-                                                   ls_value =
-                                                   (Some { Ttypes.ty_node =
-                                                           (Ttypes.Tyapp (
-                                                              { Ttypes.ts_ident =
-                                                                list;
-                                                                ts_args =
-                                                                [{ Ttypes.tv_name =
-                                                                   a_1 }
-                                                                  ];
-                                                                ts_alias = None
-                                                                },
-                                                              [{ Ttypes.ty_node =
-                                                                 (Ttypes.Tyvar
-                                                                    { Ttypes.tv_name =
-                                                                      a })
-                                                                 }
-                                                                ]
-                                                              ))
-                                                           });
-                                                   ls_constr = false;
-                                                   ls_field = true }
-                                                 ));
-                                              t_ty =
-                                              (Some { Ttypes.ty_node =
-                                                      (Ttypes.Tyapp (
-                                                         { Ttypes.ts_ident =
-                                                           list;
-                                                           ts_args =
-                                                           [{ Ttypes.tv_name =
-                                                              a_1 }
-                                                             ];
-                                                           ts_alias = None },
-                                                         [{ Ttypes.ty_node =
-                                                            (Ttypes.Tyvar
-                                                               { Ttypes.tv_name =
-                                                                 a })
-                                                            }
-                                                           ]
-                                                         ))
-                                                      });
-                                              t_attrs = [];
-                                              t_loc = foo.mli:32:36 };
-                                             { Tterm.t_node =
-                                               (Tterm.Tapp (
-                                                  { Symbols.ls_name =
-                                                    Gospelstdlib.integer_of_int;
+                                                      };
+                                                    t_attrs = [];
+                                                    t_loc = foo.mli:32:47 },
+                                                  { Symbols.ls_name = size;
                                                     ls_args =
                                                     [{ Ttypes.ty_node =
                                                        (Ttypes.Tyapp (
-                                                          { Ttypes.ts_ident =
-                                                            int; ts_args = [];
+                                                          { Ttypes.ts_ident = t;
+                                                            ts_args =
+                                                            [{ Ttypes.tv_name =
+                                                               a }
+                                                              ];
                                                             ts_alias = None },
-                                                          []))
+                                                          [{ Ttypes.ty_node =
+                                                             (Ttypes.Tyvar
+                                                                { Ttypes.tv_name =
+                                                                  a })
+                                                             }
+                                                            ]
+                                                          ))
                                                        }
                                                       ];
                                                     ls_value =
-                                                    (Some { Ttypes.ty_node =
-                                                            (Ttypes.Tyapp (
-                                                               { Ttypes.ts_ident =
-                                                                 integer;
-                                                                 ts_args = [];
-                                                                 ts_alias =
-                                                                 None },
-                                                               []))
-                                                            });
-                                                    ls_constr = false;
-                                                    ls_field = false },
-                                                  [{ Tterm.t_node =
-                                                     (Tterm.Tfield (
-                                                        { Tterm.t_node =
-                                                          (Tterm.Tvar
-                                                             { Symbols.vs_name =
-                                                               t_3;
-                                                               vs_ty =
-                                                               { Ttypes.ty_node =
-                                                                 (Ttypes.Tyapp (
-                                                                    { Ttypes.ts_ident =
-                                                                      t;
-                                                                      ts_args =
-                                                                      [{ Ttypes.tv_name =
-                                                                      a }];
-                                                                      ts_alias =
-                                                                      None },
-                                                                    [{ Ttypes.ty_node =
-                                                                      (Ttypes.Tyvar
-                                                                      { Ttypes.tv_name =
-                                                                      a }) }]
-                                                                    ))
-                                                                 }
-                                                               });
-                                                          t_ty =
-                                                          (Some { Ttypes.ty_node =
-                                                                  (Ttypes.Tyapp (
-                                                                     { Ttypes.ts_ident =
-                                                                      t;
-                                                                      ts_args =
-                                                                      [{ Ttypes.tv_name =
-                                                                      a }];
-                                                                      ts_alias =
-                                                                      None },
-                                                                     [{ Ttypes.ty_node =
-                                                                      (Ttypes.Tyvar
-                                                                      { Ttypes.tv_name =
-                                                                      a }) }]
-                                                                     ))
-                                                                  });
-                                                          t_attrs = [];
-                                                          t_loc = foo.mli:32:47
-                                                          },
-                                                        { Symbols.ls_name =
-                                                          size;
-                                                          ls_args =
-                                                          [{ Ttypes.ty_node =
-                                                             (Ttypes.Tyapp (
-                                                                { Ttypes.ts_ident =
-                                                                  t;
-                                                                  ts_args =
-                                                                  [{ Ttypes.tv_name =
-                                                                     a }
-                                                                    ];
-                                                                  ts_alias =
-                                                                  None },
-                                                                [{ Ttypes.ty_node =
-                                                                   (Ttypes.Tyvar
-                                                                      { Ttypes.tv_name =
-                                                                      a })
-                                                                   }
-                                                                  ]
-                                                                ))
-                                                             }
-                                                            ];
-                                                          ls_value =
-                                                          (Some { Ttypes.ty_node =
-                                                                  (Ttypes.Tyapp (
-                                                                     { Ttypes.ts_ident =
-                                                                      int;
-                                                                      ts_args =
-                                                                      [];
-                                                                      ts_alias =
-                                                                      None },
-                                                                     []))
-                                                                  });
-                                                          ls_constr = false;
-                                                          ls_field = true }
-                                                        ));
-                                                     t_ty =
-                                                     (Some { Ttypes.ty_node =
-                                                             (Ttypes.Tyapp (
-                                                                { Ttypes.ts_ident =
-                                                                  int;
-                                                                  ts_args = [];
-                                                                  ts_alias =
-                                                                  None },
-                                                                []))
-                                                             });
-                                                     t_attrs = [];
-                                                     t_loc = foo.mli:32:47 }
-                                                    ]
-                                                  ));
-                                               t_ty =
-                                               (Some { Ttypes.ty_node =
-                                                       (Ttypes.Tyapp (
-                                                          { Ttypes.ts_ident =
-                                                            integer;
-                                                            ts_args = [];
-                                                            ts_alias = None },
-                                                          []))
-                                                       });
-                                               t_attrs = [];
-                                               t_loc = foo.mli:32:47 }
-                                             ]
-                                           ));
-                                        t_ty =
-                                        (Some { Ttypes.ty_node =
-                                                (Ttypes.Tyapp (
-                                                   { Ttypes.ts_ident = bool;
-                                                     ts_args = [];
-                                                     ts_alias = None },
-                                                   []))
-                                                });
-                                        t_attrs = []; t_loc = foo.mli:32:28 };
-                                       { Tterm.t_node =
-                                         (Tterm.Tapp (
-                                            { Symbols.ls_name = true;
-                                              ls_args = [];
-                                              ls_value =
-                                              (Some { Ttypes.ty_node =
+                                                    { Ttypes.ty_node =
                                                       (Ttypes.Tyapp (
                                                          { Ttypes.ts_ident =
-                                                           bool; ts_args = [];
+                                                           int; ts_args = [];
                                                            ts_alias = None },
                                                          []))
-                                                      });
-                                              ls_constr = true;
-                                              ls_field = false },
-                                            []));
-                                         t_ty =
-                                         (Some { Ttypes.ty_node =
+                                                      };
+                                                    ls_constr = false;
+                                                    ls_field = true }
+                                                  ));
+                                               t_ty =
+                                               { Ttypes.ty_node =
                                                  (Ttypes.Tyapp (
-                                                    { Ttypes.ts_ident = bool;
+                                                    { Ttypes.ts_ident = int;
                                                       ts_args = [];
                                                       ts_alias = None },
                                                     []))
-                                                 });
-                                         t_attrs = []; t_loc = foo.mli:32:28 }
+                                                 };
+                                               t_attrs = [];
+                                               t_loc = foo.mli:32:47 }
+                                              ]
+                                            ));
+                                         t_ty =
+                                         { Ttypes.ty_node =
+                                           (Ttypes.Tyapp (
+                                              { Ttypes.ts_ident = integer;
+                                                ts_args = []; ts_alias = None },
+                                              []))
+                                           };
+                                         t_attrs = []; t_loc = foo.mli:32:47 }
                                        ]
                                      ));
-                                  t_ty = None; t_attrs = [];
-                                  t_loc = foo.mli:32:28 },
+                                  t_ty =
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = bool; ts_args = [];
+                                         ts_alias = None },
+                                       []))
+                                    };
+                                  t_attrs = []; t_loc = foo.mli:32:28 },
                                 { Tterm.t_node =
                                   (Tterm.Told
                                      { Tterm.t_node =
@@ -2224,22 +2004,19 @@ First, create a test artifact:
                                                    }
                                                  });
                                             t_ty =
-                                            (Some { Ttypes.ty_node =
-                                                    (Ttypes.Tyapp (
-                                                       { Ttypes.ts_ident = t;
-                                                         ts_args =
-                                                         [{ Ttypes.tv_name = a
-                                                            }
-                                                           ];
-                                                         ts_alias = None },
-                                                       [{ Ttypes.ty_node =
-                                                          (Ttypes.Tyvar
-                                                             { Ttypes.tv_name =
-                                                               a })
-                                                          }
-                                                         ]
-                                                       ))
-                                                    });
+                                            { Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = t;
+                                                   ts_args =
+                                                   [{ Ttypes.tv_name = a }];
+                                                   ts_alias = None },
+                                                 [{ Ttypes.ty_node =
+                                                    (Ttypes.Tyvar
+                                                       { Ttypes.tv_name = a })
+                                                    }
+                                                   ]
+                                                 ))
+                                              };
                                             t_attrs = []; t_loc = foo.mli:33:34
                                             },
                                           { Symbols.ls_name = contents;
@@ -2259,54 +2036,49 @@ First, create a test artifact:
                                                }
                                               ];
                                             ls_value =
-                                            (Some { Ttypes.ty_node =
-                                                    (Ttypes.Tyapp (
-                                                       { Ttypes.ts_ident = list;
-                                                         ts_args =
-                                                         [{ Ttypes.tv_name =
-                                                            a_1 }
-                                                           ];
-                                                         ts_alias = None },
-                                                       [{ Ttypes.ty_node =
-                                                          (Ttypes.Tyvar
-                                                             { Ttypes.tv_name =
-                                                               a })
-                                                          }
-                                                         ]
-                                                       ))
-                                                    });
+                                            { Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = list;
+                                                   ts_args =
+                                                   [{ Ttypes.tv_name = a_1 }];
+                                                   ts_alias = None },
+                                                 [{ Ttypes.ty_node =
+                                                    (Ttypes.Tyvar
+                                                       { Ttypes.tv_name = a })
+                                                    }
+                                                   ]
+                                                 ))
+                                              };
                                             ls_constr = false; ls_field = true
                                             }
                                           ));
                                        t_ty =
-                                       (Some { Ttypes.ty_node =
-                                               (Ttypes.Tyapp (
-                                                  { Ttypes.ts_ident = list;
-                                                    ts_args =
-                                                    [{ Ttypes.tv_name = a_1 }];
-                                                    ts_alias = None },
-                                                  [{ Ttypes.ty_node =
-                                                     (Ttypes.Tyvar
-                                                        { Ttypes.tv_name = a })
-                                                     }
-                                                    ]
-                                                  ))
-                                               });
+                                       { Ttypes.ty_node =
+                                         (Ttypes.Tyapp (
+                                            { Ttypes.ts_ident = list;
+                                              ts_args =
+                                              [{ Ttypes.tv_name = a_1 }];
+                                              ts_alias = None },
+                                            [{ Ttypes.ty_node =
+                                               (Ttypes.Tyvar
+                                                  { Ttypes.tv_name = a })
+                                               }
+                                              ]
+                                            ))
+                                         };
                                        t_attrs = []; t_loc = foo.mli:33:34 });
                                   t_ty =
-                                  (Some { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = list;
-                                               ts_args =
-                                               [{ Ttypes.tv_name = a_1 }];
-                                               ts_alias = None },
-                                             [{ Ttypes.ty_node =
-                                                (Ttypes.Tyvar
-                                                   { Ttypes.tv_name = a })
-                                                }
-                                               ]
-                                             ))
-                                          });
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = list;
+                                         ts_args = [{ Ttypes.tv_name = a_1 }];
+                                         ts_alias = None },
+                                       [{ Ttypes.ty_node =
+                                          (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                          }
+                                         ]
+                                       ))
+                                    };
                                   t_attrs = []; t_loc = foo.mli:33:30 },
                                 { Tterm.t_node =
                                   (Tterm.Tapp (
@@ -2331,20 +2103,19 @@ First, create a test artifact:
                                            }
                                          ];
                                        ls_value =
-                                       (Some { Ttypes.ty_node =
-                                               (Ttypes.Tyapp (
-                                                  { Ttypes.ts_ident = list;
-                                                    ts_args =
-                                                    [{ Ttypes.tv_name = a_1 }];
-                                                    ts_alias = None },
-                                                  [{ Ttypes.ty_node =
-                                                     (Ttypes.Tyvar
-                                                        { Ttypes.tv_name = a_1
-                                                          })
-                                                     }
-                                                    ]
-                                                  ))
-                                               });
+                                       { Ttypes.ty_node =
+                                         (Ttypes.Tyapp (
+                                            { Ttypes.ts_ident = list;
+                                              ts_args =
+                                              [{ Ttypes.tv_name = a_1 }];
+                                              ts_alias = None },
+                                            [{ Ttypes.ty_node =
+                                               (Ttypes.Tyvar
+                                                  { Ttypes.tv_name = a_1 })
+                                               }
+                                              ]
+                                            ))
+                                         };
                                        ls_constr = true; ls_field = false },
                                      [{ Tterm.t_node =
                                         (Tterm.Tvar
@@ -2356,10 +2127,9 @@ First, create a test artifact:
                                                }
                                              });
                                         t_ty =
-                                        (Some { Ttypes.ty_node =
-                                                (Ttypes.Tyvar
-                                                   { Ttypes.tv_name = a })
-                                                });
+                                        { Ttypes.ty_node =
+                                          (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                          };
                                         t_attrs = []; t_loc = foo.mli:34:30 };
                                        { Tterm.t_node =
                                          (Tterm.Told
@@ -2389,24 +2159,22 @@ First, create a test artifact:
                                                           }
                                                         });
                                                    t_ty =
-                                                   (Some { Ttypes.ty_node =
-                                                           (Ttypes.Tyapp (
-                                                              { Ttypes.ts_ident =
-                                                                t;
-                                                                ts_args =
-                                                                [{ Ttypes.tv_name =
-                                                                   a }
-                                                                  ];
-                                                                ts_alias = None
-                                                                },
-                                                              [{ Ttypes.ty_node =
-                                                                 (Ttypes.Tyvar
-                                                                    { Ttypes.tv_name =
-                                                                      a })
-                                                                 }
-                                                                ]
-                                                              ))
-                                                           });
+                                                   { Ttypes.ty_node =
+                                                     (Ttypes.Tyapp (
+                                                        { Ttypes.ts_ident = t;
+                                                          ts_args =
+                                                          [{ Ttypes.tv_name = a
+                                                             }
+                                                            ];
+                                                          ts_alias = None },
+                                                        [{ Ttypes.ty_node =
+                                                           (Ttypes.Tyvar
+                                                              { Ttypes.tv_name =
+                                                                a })
+                                                           }
+                                                          ]
+                                                        ))
+                                                     };
                                                    t_attrs = [];
                                                    t_loc = foo.mli:34:40 },
                                                  { Symbols.ls_name = contents;
@@ -2429,98 +2197,95 @@ First, create a test artifact:
                                                       }
                                                      ];
                                                    ls_value =
-                                                   (Some { Ttypes.ty_node =
-                                                           (Ttypes.Tyapp (
-                                                              { Ttypes.ts_ident =
-                                                                list;
-                                                                ts_args =
-                                                                [{ Ttypes.tv_name =
-                                                                   a_1 }
-                                                                  ];
-                                                                ts_alias = None
-                                                                },
-                                                              [{ Ttypes.ty_node =
-                                                                 (Ttypes.Tyvar
-                                                                    { Ttypes.tv_name =
-                                                                      a })
-                                                                 }
-                                                                ]
-                                                              ))
-                                                           });
+                                                   { Ttypes.ty_node =
+                                                     (Ttypes.Tyapp (
+                                                        { Ttypes.ts_ident =
+                                                          list;
+                                                          ts_args =
+                                                          [{ Ttypes.tv_name =
+                                                             a_1 }
+                                                            ];
+                                                          ts_alias = None },
+                                                        [{ Ttypes.ty_node =
+                                                           (Ttypes.Tyvar
+                                                              { Ttypes.tv_name =
+                                                                a })
+                                                           }
+                                                          ]
+                                                        ))
+                                                     };
                                                    ls_constr = false;
                                                    ls_field = true }
                                                  ));
                                               t_ty =
-                                              (Some { Ttypes.ty_node =
-                                                      (Ttypes.Tyapp (
-                                                         { Ttypes.ts_ident =
-                                                           list;
-                                                           ts_args =
-                                                           [{ Ttypes.tv_name =
-                                                              a_1 }
-                                                             ];
-                                                           ts_alias = None },
-                                                         [{ Ttypes.ty_node =
-                                                            (Ttypes.Tyvar
-                                                               { Ttypes.tv_name =
-                                                                 a })
-                                                            }
-                                                           ]
-                                                         ))
-                                                      });
+                                              { Ttypes.ty_node =
+                                                (Ttypes.Tyapp (
+                                                   { Ttypes.ts_ident = list;
+                                                     ts_args =
+                                                     [{ Ttypes.tv_name = a_1 }];
+                                                     ts_alias = None },
+                                                   [{ Ttypes.ty_node =
+                                                      (Ttypes.Tyvar
+                                                         { Ttypes.tv_name = a })
+                                                      }
+                                                     ]
+                                                   ))
+                                                };
                                               t_attrs = [];
                                               t_loc = foo.mli:34:40 });
                                          t_ty =
-                                         (Some { Ttypes.ty_node =
-                                                 (Ttypes.Tyapp (
-                                                    { Ttypes.ts_ident = list;
-                                                      ts_args =
-                                                      [{ Ttypes.tv_name = a_1 }
-                                                        ];
-                                                      ts_alias = None },
-                                                    [{ Ttypes.ty_node =
-                                                       (Ttypes.Tyvar
-                                                          { Ttypes.tv_name = a
-                                                            })
-                                                       }
-                                                      ]
-                                                    ))
-                                                 });
+                                         { Ttypes.ty_node =
+                                           (Ttypes.Tyapp (
+                                              { Ttypes.ts_ident = list;
+                                                ts_args =
+                                                [{ Ttypes.tv_name = a_1 }];
+                                                ts_alias = None },
+                                              [{ Ttypes.ty_node =
+                                                 (Ttypes.Tyvar
+                                                    { Ttypes.tv_name = a })
+                                                 }
+                                                ]
+                                              ))
+                                           };
                                          t_attrs = []; t_loc = foo.mli:34:35 }
                                        ]
                                      ));
                                   t_ty =
-                                  (Some { Ttypes.ty_node =
-                                          (Ttypes.Tyapp (
-                                             { Ttypes.ts_ident = list;
-                                               ts_args =
-                                               [{ Ttypes.tv_name = a_1 }];
-                                               ts_alias = None },
-                                             [{ Ttypes.ty_node =
-                                                (Ttypes.Tyvar
-                                                   { Ttypes.tv_name = a })
-                                                }
-                                               ]
-                                             ))
-                                          });
+                                  { Ttypes.ty_node =
+                                    (Ttypes.Tyapp (
+                                       { Ttypes.ts_ident = list;
+                                         ts_args = [{ Ttypes.tv_name = a_1 }];
+                                         ts_alias = None },
+                                       [{ Ttypes.ty_node =
+                                          (Ttypes.Tyvar { Ttypes.tv_name = a })
+                                          }
+                                         ]
+                                       ))
+                                    };
                                   t_attrs = []; t_loc = foo.mli:34:30 }
                                 ));
                              t_ty =
-                             (Some { Ttypes.ty_node =
-                                     (Ttypes.Tyapp (
-                                        { Ttypes.ts_ident = list;
-                                          ts_args = [{ Ttypes.tv_name = a_1 }];
-                                          ts_alias = None },
-                                        [{ Ttypes.ty_node =
-                                           (Ttypes.Tyvar { Ttypes.tv_name = a })
-                                           }
-                                          ]
-                                        ))
-                                     });
+                             { Ttypes.ty_node =
+                               (Ttypes.Tyapp (
+                                  { Ttypes.ts_ident = list;
+                                    ts_args = [{ Ttypes.tv_name = a_1 }];
+                                    ts_alias = None },
+                                  [{ Ttypes.ty_node =
+                                     (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                    ]
+                                  ))
+                               };
                              t_attrs = []; t_loc = foo.mli:32:25 }
                            ]
                          ));
-                      t_ty = None; t_attrs = []; t_loc = foo.mli:32:12 }
+                      t_ty =
+                      { Ttypes.ty_node =
+                        (Ttypes.Tyapp (
+                           { Ttypes.ts_ident = bool; ts_args = [];
+                             ts_alias = None },
+                           []))
+                        };
+                      t_attrs = []; t_loc = foo.mli:32:12 }
                      ];
                    sp_xpost = [];
                    sp_wr =
@@ -2542,17 +2307,16 @@ First, create a test artifact:
                                   }
                                 });
                            t_ty =
-                           (Some { Ttypes.ty_node =
-                                   (Ttypes.Tyapp (
-                                      { Ttypes.ts_ident = t;
-                                        ts_args = [{ Ttypes.tv_name = a }];
-                                        ts_alias = None },
-                                      [{ Ttypes.ty_node =
-                                         (Ttypes.Tyvar { Ttypes.tv_name = a })
-                                         }
-                                        ]
-                                      ))
-                                   });
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = t;
+                                  ts_args = [{ Ttypes.tv_name = a }];
+                                  ts_alias = None },
+                                [{ Ttypes.ty_node =
+                                   (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                  ]
+                                ))
+                             };
                            t_attrs = []; t_loc = foo.mli:30:13 },
                          { Symbols.ls_name = contents;
                            ls_args =
@@ -2568,30 +2332,29 @@ First, create a test artifact:
                               }
                              ];
                            ls_value =
-                           (Some { Ttypes.ty_node =
-                                   (Ttypes.Tyapp (
-                                      { Ttypes.ts_ident = list;
-                                        ts_args = [{ Ttypes.tv_name = a_1 }];
-                                        ts_alias = None },
-                                      [{ Ttypes.ty_node =
-                                         (Ttypes.Tyvar { Ttypes.tv_name = a })
-                                         }
-                                        ]
-                                      ))
-                                   });
+                           { Ttypes.ty_node =
+                             (Ttypes.Tyapp (
+                                { Ttypes.ts_ident = list;
+                                  ts_args = [{ Ttypes.tv_name = a_1 }];
+                                  ts_alias = None },
+                                [{ Ttypes.ty_node =
+                                   (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                                  ]
+                                ))
+                             };
                            ls_constr = false; ls_field = true }
                          ));
                       t_ty =
-                      (Some { Ttypes.ty_node =
-                              (Ttypes.Tyapp (
-                                 { Ttypes.ts_ident = list;
-                                   ts_args = [{ Ttypes.tv_name = a_1 }];
-                                   ts_alias = None },
-                                 [{ Ttypes.ty_node =
-                                    (Ttypes.Tyvar { Ttypes.tv_name = a }) }
-                                   ]
-                                 ))
-                              });
+                      { Ttypes.ty_node =
+                        (Ttypes.Tyapp (
+                           { Ttypes.ts_ident = list;
+                             ts_args = [{ Ttypes.tv_name = a_1 }];
+                             ts_alias = None },
+                           [{ Ttypes.ty_node =
+                              (Ttypes.Tyvar { Ttypes.tv_name = a }) }
+                             ]
+                           ))
+                        };
                       t_attrs = []; t_loc = foo.mli:30:13 }
                      ];
                    sp_cs = []; sp_diverge = false; sp_pure = false;

--- a/test/typechecker/partial_application.mli
+++ b/test/typechecker/partial_application.mli
@@ -7,10 +7,3 @@ val mems : 'a -> 'a list list -> bool
     (* This is not; should it be? *)
     ensures r = List._exists (List.mem x) xss
 *)
-
-(* {gospel_expected|
-   [125] File "partial_application.mli", line 8, characters 29-41:
-         8 |     ensures r = List._exists (List.mem x) xss
-                                          ^^^^^^^^^^^^
-         Error: Not a function symbol: mem.
-   |gospel_expected} *)

--- a/test/typechecker/variant_integer.mli
+++ b/test/typechecker/variant_integer.mli
@@ -22,5 +22,5 @@
    [125] File "variant_integer.mli", line 13, characters 12-17:
          13 |     variant x = 0
                           ^^^^^
-         Error: A term was expected.
+         Error: This term has type bool but a term was expected of type integer.
    |gospel_expected} *)


### PR DESCRIPTION
Hello

This pull request changes the Gospel typed AST so that the types of terms are represented with `ty` instead of `ty option`, thereby eliminating the distinction between terms that evaluate to `bool` and propositions. This also means that programs are no longer transformed to turn bools into props. A few caveats: 

- There are still some functions that I want to refactor/rethink their usefulness.
- Predicates are now just syntatic sugar for functions that return bools. Should I remove them from the parser now or should I do another pr?
- Some of the tests didn't pass initially: a test about the `variant` clause didn't pass because now the error message is different. The ill typed program was `variant i = 0`. The old error message was "A term was expected" and the new error message is now "this term has type bool but was expected a value of type integer". In my opinion this message is a bit more clear, but I'm wondering what you think. Another test that failed was one where a predicate is used as an argument for a higher order function that receives a function of type `'a -> bool`. This is now valid under the new typechecker, I suppose this is fine? Another test that failed was the location test, but that is only because it dumps the entire ast, so any changes are always gonna effect it. (side note: this test seems very fragile, may I change it in a future commit so it uses grep and only prints the locations?)
Edit: I just realised that I also have the commits for the path pr here :|, not sure if I should do another pr or if we should wrap up the identifiers one first.