### PR TITLE
Adding paths to Gospel identifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,6 @@
   [\#380](https://github.com/ocaml-gospel/gospel/pull/380)
 - Remove the `gospel_expected` prologue at the end of successful tests
   [\#363](https://github.com/ocaml-gospel/gospel/pull/363)
-- Added paths to gospel identifiers.
-  [\#396](https://github.com/ocaml-gospel/gospel/pull/396)
 
 # 0.2
 
@@ -174,6 +172,8 @@
   [\#155](https://github.com/ocaml-gospel/gospel/pull/155)
 - Removed the `Pty_open` type constructor
   [\#109](https://github.com/ocaml-gospel/gospel/pull/109)
+- Added paths to gospel identifiers.
+  [\#396](https://github.com/ocaml-gospel/gospel/pull/396)
 
 
 # 0.1.0 (11-03-2021)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
   [\#380](https://github.com/ocaml-gospel/gospel/pull/380)
 - Remove the `gospel_expected` prologue at the end of successful tests
   [\#363](https://github.com/ocaml-gospel/gospel/pull/363)
+- Added paths to gospel identifiers.
+  [\#396](https://github.com/ocaml-gospel/gospel/pull/396)
 
 # 0.2
 

--- a/bin/check.ml
+++ b/bin/check.ml
@@ -23,9 +23,8 @@ let path2module p =
 
 let type_check load_path name sigs =
   let md = init_muc name in
-  let penv =
-    path2module name |> Utils.Sstr.singleton |> Typing.penv load_path
-  in
+  let mod_name = path2module name in
+  let penv = Utils.Sstr.singleton mod_name |> Typing.penv load_path in
   let md = List.fold_left (Typing.type_sig_item penv) md sigs in
   md
 

--- a/bin/check.ml
+++ b/bin/check.ml
@@ -23,8 +23,7 @@ let path2module p =
 
 let type_check load_path name sigs =
   let md = init_muc name in
-  let mod_name = path2module name in
-  let penv = Utils.Sstr.singleton mod_name |> Typing.penv load_path in
+  let penv = Utils.Sstr.singleton name |> Typing.penv load_path in
   let md = List.fold_left (Typing.type_sig_item penv) md sigs in
   md
 

--- a/bin/dumpast.ml
+++ b/bin/dumpast.ml
@@ -19,10 +19,9 @@ let path2module p =
   Filename.basename p |> Filename.chop_extension |> String.capitalize_ascii
 
 let type_check load_path name sigs =
+  let name = path2module name in
   let md = init_muc name in
-  let penv =
-    path2module name |> Utils.Sstr.singleton |> Typing.penv load_path
-  in
+  let penv = Utils.Sstr.singleton name |> Typing.penv load_path in
   let md = List.fold_left (Typing.type_sig_item penv) md sigs in
   wrap_up_muc md
 

--- a/bin/dumpast.ml
+++ b/bin/dumpast.ml
@@ -15,11 +15,7 @@ module W = Gospel.Warnings
 
 type config = { load_path : string list }
 
-let path2module p =
-  Filename.basename p |> Filename.chop_extension |> String.capitalize_ascii
-
 let type_check load_path name sigs =
-  let name = path2module name in
   let md = init_muc name in
   let penv = Utils.Sstr.singleton name |> Typing.penv load_path in
   let md = List.fold_left (Typing.type_sig_item penv) md sigs in

--- a/src/identifier.ml
+++ b/src/identifier.ml
@@ -28,6 +28,7 @@ module Ident = struct
   type t = {
     id_str : string;
     id_attrs : string list;
+    id_path : string list;
     id_loc : Location.t;
     id_tag : int;
   }
@@ -40,7 +41,7 @@ module Ident = struct
       Hashtbl.replace current s x;
       x
     in
-    let str_of_id id =
+    let str_of_id path id =
       try Hashtbl.find output id.id_tag
       with Not_found ->
         let x = current id.id_str in
@@ -48,18 +49,29 @@ module Ident = struct
           if x = 0 then id.id_str else id.id_str ^ "_" ^ string_of_int x
         in
         Hashtbl.replace output id.id_tag str;
-        str
+        if path then List.fold_right (fun e acc -> e ^ "." ^ acc) id.id_path str
+        else str
     in
-    fun ppf t -> Format.fprintf ppf "%s%a" (str_of_id t) pp_attrs t.id_attrs
+    fun path ppf t ->
+      Format.fprintf ppf "%s%a" (str_of_id path t) pp_attrs t.id_attrs
+
+  let pp_simpl = pp false
+  let pp = pp true
 
   let create =
     let tag = ref 0 in
-    fun ?(attrs = []) ~loc str ->
+    fun ?(attrs = []) ?(path = []) ~loc str ->
       incr tag;
-      { id_str = str; id_attrs = attrs; id_loc = loc; id_tag = !tag }
+      {
+        id_str = str;
+        id_attrs = attrs;
+        id_path = path;
+        id_loc = loc;
+        id_tag = !tag;
+      }
 
-  let of_preid (pid : Preid.t) =
-    create pid.pid_str ~attrs:pid.pid_attrs ~loc:pid.pid_loc
+  let of_preid ?(path = []) (pid : Preid.t) =
+    create pid.pid_str ~path ~attrs:pid.pid_attrs ~loc:pid.pid_loc
 
   let set_loc t loc = { t with id_loc = loc }
   let add_attr t attr = { t with id_attrs = attr :: t.id_attrs }

--- a/src/identifier.ml
+++ b/src/identifier.ml
@@ -48,9 +48,13 @@ module Ident = struct
         let str =
           if x = 0 then id.id_str else id.id_str ^ "_" ^ string_of_int x
         in
+        let str =
+          if path then
+            List.fold_right (fun e acc -> e ^ "." ^ acc) id.id_path str
+          else str
+        in
         Hashtbl.replace output id.id_tag str;
-        if path then List.fold_right (fun e acc -> e ^ "." ^ acc) id.id_path str
-        else str
+        str
     in
     fun path ppf t ->
       Format.fprintf ppf "%s%a" (str_of_id path t) pp_attrs t.id_attrs

--- a/src/identifier.mli
+++ b/src/identifier.mli
@@ -41,6 +41,7 @@ module Ident : sig
   type t = private {
     id_str : string;  (** The identifier name. *)
     id_attrs : string list;  (** The attributes of the identifier. *)
+    id_path : string list;  (** The full path of the identifier *)
     id_loc : Location.t;  (** The location of the identifier. *)
     id_tag : int;  (** The unique tag of the identifier. *)
   }
@@ -51,15 +52,19 @@ module Ident : sig
   val hash : t -> int
 
   val pp : Format.formatter -> t -> unit
+  (** Pretty printer for identifiers with their fully qualified names *)
+
+  val pp_simpl : Format.formatter -> t -> unit
   (** Pretty printer for identifiers. *)
 
-  val create : ?attrs:string list -> loc:Location.t -> string -> t
+  val create :
+    ?attrs:string list -> ?path:string list -> loc:Location.t -> string -> t
   (** [create ~attrs ~loc id] is a new pre-identifier identified with [id] with
       attributes [attrs] and location [loc]. A unique tag is automatically
       affected to the new identifier Default attributes are empty, and default
       location is [Location.none]. *)
 
-  val of_preid : Preid.t -> t
+  val of_preid : ?path:string list -> Preid.t -> t
   (** [of_preid pid] is a fresh identifier using the same name, attributes and
       location as [pid]. A unique tag is automatically affected to the new
       identifier *)

--- a/src/identifier.mli
+++ b/src/identifier.mli
@@ -51,23 +51,23 @@ module Ident : sig
   val equal : t -> t -> bool
   val hash : t -> int
 
-  val pp : Format.formatter -> t -> unit
-  (** Pretty printer for identifiers with their fully qualified names *)
-
   val pp_simpl : Format.formatter -> t -> unit
-  (** Pretty printer for identifiers. *)
+  (** [pp fmt id] pretty prints [id] *)
+
+  val pp : Format.formatter -> t -> unit
+  (** [pp fmt id] pretty prints [id] with their fully qualified name *)
 
   val create :
     ?attrs:string list -> ?path:string list -> loc:Location.t -> string -> t
-  (** [create ~attrs ~loc id] is a new pre-identifier identified with [id] with
-      attributes [attrs] and location [loc]. A unique tag is automatically
-      affected to the new identifier Default attributes are empty, and default
-      location is [Location.none]. *)
+  (** [create ~attrs ~path ~loc id] is a new pre-identifier identified with [id]
+      with attributes [attrs], path [path] and location [loc]. A unique tag is
+      automatically affected to the new identifier Default attributes are empty,
+      and default location is [Location.none]. *)
 
   val of_preid : ?path:string list -> Preid.t -> t
-  (** [of_preid pid] is a fresh identifier using the same name, attributes and
-      location as [pid]. A unique tag is automatically affected to the new
-      identifier *)
+  (** [of_preid ~path pid] is a fresh identifier using the same name, attributes
+      and location as [pid]. If necessary, a [path] may also be supplied. A
+      unique tag is automatically affected to the new identifier *)
 
   val set_loc : t -> Location.t -> t
   (** [set_loc t loc] is [t] with [loc] as its location. *)

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -15,7 +15,8 @@ module Ident = Identifier.Ident
 (* Variable Symbols *)
 type vsymbol = { vs_name : Ident.t; vs_ty : ty } [@@deriving show]
 
-let create_vsymbol pid ty = { vs_name = Ident.of_preid pid; vs_ty = ty }
+let create_vsymbol ?(path = []) pid ty =
+  { vs_name = Ident.of_preid ~path pid; vs_ty = ty }
 
 module Vs = struct
   type t = vsymbol

--- a/src/tast_printer.ml
+++ b/src/tast_printer.ml
@@ -12,12 +12,12 @@ module Option = Stdlib.Option
 let print_variant_field fmt ld =
   pp fmt "%s%a:%a"
     (if ld.ld_mut = Mutable then "mutable " else "")
-    Ident.pp (fst ld.ld_field) print_ty (snd ld.ld_field)
+    Ident.pp_simpl (fst ld.ld_field) print_ty (snd ld.ld_field)
 
 let print_rec_field fmt ld =
   pp fmt "%s%a:%a"
     (if ld.ld_mut = Mutable then "mutable " else "")
-    Ident.pp ld.ld_field.ls_name print_ty
+    Ident.pp_simpl ld.ld_field.ls_name print_ty
     (Stdlib.Option.get ld.ld_field.ls_value)
 
 let print_label_decl_list print_field fmt fields =
@@ -31,7 +31,7 @@ let print_type_kind fmt = function
         | ld -> print_label_decl_list print_variant_field fmt ld
       in
       let print_constructor fmt { cd_cs; cd_ld; _ } =
-        pp fmt "@[%a of %a@\n@[<h 2>%a@]@]" Ident.pp cd_cs.ls_name
+        pp fmt "@[%a of %a@\n@[<h 2>%a@]@]" Ident.pp_simpl cd_cs.ls_name
           (print_args cd_cs) cd_ld print_ls_decl cd_cs
       in
       pp fmt "@[ = %a@]"
@@ -88,7 +88,7 @@ let print_type_declaration fmt td =
   let print_constraint fmt (ty1, ty2, _) =
     pp fmt "%a = %a" print_ty ty1 print_ty ty2
   in
-  pp fmt "@[%a%a%a%a%s%a@]@\n@[%a@]" print_params td.td_params Ident.pp
+  pp fmt "@[%a%a%a%a%s%a@]@\n@[%a@]" print_params td.td_params Ident.pp_simpl
     (ts_ident td.td_ts) print_manifest td.td_manifest print_type_kind td.td_kind
     (if td.td_cstrs = [] then "" else " constraint ")
     (list ~sep:(const string " constraint ") print_constraint)
@@ -128,7 +128,7 @@ let print_vd_spec val_id fmt spec =
         (list ~sep:comma print_lb_arg)
         vs.sp_ret
         (if vs.sp_ret = [] then "" else " =")
-        Ident.pp val_id
+        Ident.pp_simpl val_id
         (list ~sep:sp print_lb_arg)
         vs.sp_args print_diverges vs.sp_diverge
         (list
@@ -162,7 +162,7 @@ let print_vd_spec val_id fmt spec =
            constant_string)
         vs.sp_equiv
 
-let print_param f p = pp f "(%a:%a)" Ident.pp p.vs_name print_ty p.vs_ty
+let print_param f p = pp f "(%a:%a)" Ident.pp_simpl p.vs_name print_ty p.vs_ty
 
 let print_function f x =
   let func_pred =
@@ -193,7 +193,7 @@ let print_function f x =
   let func f x =
     pp f "@[%s %s%a %a%a%a%a@]" func_pred
       (if x.fun_rec then "rec " else "")
-      Ident.pp x.fun_ls.ls_name (list ~sep:sp print_param) x.fun_params
+      Ident.pp_simpl x.fun_ls.ls_name (list ~sep:sp print_param) x.fun_params
       (option (fun f -> pp f ": %a" print_ty))
       x.fun_ls.ls_value
       (option (fun f -> pp f " =@\n@[<hov2>@[%a@]@]" print_term))
@@ -206,7 +206,7 @@ let print_extension_constructor ctxt f x =
   match x.ext_kind with
   | Pext_decl (_, _, _) -> print_xs f x.ext_xs
   | Pext_rebind li ->
-      pp f "%a%a@;=@;%a" Ident.pp x.ext_xs.xs_ident (attributes ctxt)
+      pp f "%a%a@;=@;%a" Ident.pp_simpl x.ext_xs.xs_ident (attributes ctxt)
         x.ext_attributes longident_loc li
 
 let exception_declaration ctxt f x =
@@ -217,7 +217,7 @@ let exception_declaration ctxt f x =
 let rec print_signature_item f x =
   let print_val f vd =
     let intro = if vd.vd_prim = [] then "val" else "external" in
-    pp f "@[%s@ %a@ :@ %a%a%a@]@\n@[<h4>%a@]" intro Ident.pp vd.vd_name
+    pp f "@[%s@ %a@ :@ %a%a%a@]@\n@[<h4>%a@]" intro Ident.pp_simpl vd.vd_name
       core_type vd.vd_type
       (fun f x ->
         if x.vd_prim <> [] then pp f "@ =@ %a" (list constant_string) x.vd_prim)
@@ -256,14 +256,14 @@ let rec print_signature_item f x =
   | Sig_module
       ({ md_type = { mt_desc = Mod_alias alias; mt_attrs = []; _ }; _ } as pmd)
     ->
-      pp f "@[<hov>module@ %a@ =@ %a@]%a" Ident.pp pmd.md_name
+      pp f "@[<hov>module@ %a@ =@ %a@]%a" Ident.pp_simpl pmd.md_name
         (list ~sep:full Format.pp_print_string)
         alias
         (item_attributes reset_ctxt)
         pmd.md_attrs
   | Sig_module pmd ->
-      pp f "@[<hov>module@ %a@ :@ %a@]%a" Ident.pp pmd.md_name print_module_type
-        pmd.md_type
+      pp f "@[<hov>module@ %a@ :@ %a@]%a" Ident.pp_simpl pmd.md_name
+        print_module_type pmd.md_type
         (item_attributes reset_ctxt)
         pmd.md_attrs
   | Sig_open (od, ghost) ->
@@ -280,7 +280,7 @@ let rec print_signature_item f x =
         (item_attributes reset_ctxt)
         incl.pincl_attributes
   | Sig_modtype { mtd_name = s; mtd_type = md; mtd_attrs = attrs; _ } ->
-      pp f "@[<hov2>module@ type@ %a%a@]%a" Ident.pp s
+      pp f "@[<hov2>module@ type@ %a%a@]%a" Ident.pp_simpl s
         (fun f md ->
           match md with
           | None -> ()
@@ -297,11 +297,11 @@ let rec print_signature_item f x =
    *       | [] -> () ;
    *       | pmd :: tl ->
    *           if not first then
-   *             pp f "@ @[<hov2>and@ %a:@ %a@]%a" Ident.pp pmd.mdname
+   *             pp f "@ @[<hov2>and@ %a:@ %a@]%a" Ident.pp_simpl pmd.mdname
    *               print_modyle_type1 pmd.mdtype
    *               (item_attributes reset_ctxt) pmd.mdattributes
    *           else
-   *             pp f "@[<hov2>module@ rec@ %a:@ %a@]%a" Ident.pp pmd.mdname
+   *             pp f "@[<hov2>module@ rec@ %a:@ %a@]%a" Ident.pp_simpl pmd.mdname
    *               print_modyle_type1 pmd.mdtype
    *               (item_attributes reset_ctxt) pmd.mdattributes;
    *           string_x_module_type_list f ~first:false tl
@@ -313,7 +313,7 @@ let rec print_signature_item f x =
       item_attributes reset_ctxt f a
   | Sig_function x -> print_function f x
   | Sig_axiom x ->
-      pp f "(*@@ axiom %a: %a *)" Ident.pp x.ax_name print_term x.ax_term
+      pp f "(*@@ axiom %a: %a *)" Ident.pp_simpl x.ax_name print_term x.ax_term
   | Sig_use s -> pp f "(*@@ use %s *)" s
   | _ -> assert false
 
@@ -333,7 +333,7 @@ and print_module_type f x =
           pp f "@[<hov2>%a@ ->@ %a@]" print_modyle_type1 mt1 print_module_type
             mt2
         else
-          pp f "@[<hov2>functor@ (%a@ :@ %a)@ ->@ %a@]" Ident.pp s
+          pp f "@[<hov2>functor@ (%a@ :@ %a)@ ->@ %a@]" Ident.pp_simpl s
             print_module_type mt1 print_module_type mt2
     | Mod_with (mt, []) -> print_module_type f mt
     | Mod_with (mt, l) ->
@@ -345,18 +345,19 @@ and print_module_type f x =
               let td = { td with td_ts = ts } in
               pp f "type@ %a"
                 (* (list print_tv ~sep:comma ~first:lparens ~last:rparens) ls
-                 * Ident.pp li *)
+                 * Ident.pp_simpl li *)
                 print_type_declaration td
-          | Wmod (li, li2) -> pp f "module %a =@ %a" Ident.pp li Ident.pp li2
+          | Wmod (li, li2) ->
+              pp f "module %a =@ %a" Ident.pp_simpl li Ident.pp_simpl li2
           | Wtysubs (li, ({ td_params = ls; _ } as td)) ->
               let ls = List.map fst ls in
               let ts = { td.td_ts with ts_ident = li } in
               let td = { td with td_ts = ts } in
               pp f "type@ %a %a :=@ %a"
                 (list print_tv ~sep:comma ~first:lparens ~last:rparens)
-                ls Ident.pp li print_type_declaration td
+                ls Ident.pp_simpl li print_type_declaration td
           | Wmodsubs (li, li2) ->
-              pp f "module %a :=@ %a" Ident.pp li Ident.pp li2
+              pp f "module %a :=@ %a" Ident.pp_simpl li Ident.pp_simpl li2
         in
         pp f "@[<hov2>%a@ with@ %a@]" print_modyle_type1 mt
           (list with_constraint ~sep:(any " and@ "))

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -604,8 +604,9 @@ and print_ns nm fmt { ns_ts; ns_ls; ns_fd; ns_xs; ns_ns; ns_tns } =
  * (tree_ns (fun ns -> ns.ns_tns)) ns_tns *)
 
 let print_file fmt { fl_nm; fl_sigs; fl_export } =
-  pp fmt "@[module %a@\n@[<h2>@\n%a@\n@[<hv2>Signatures@\n%a@]@]@]@." Ident.pp
-    fl_nm (print_ns fl_nm.id_str) fl_export print_signature fl_sigs
+  pp fmt "@[module %a@\n@[<h2>@\n%a@\n@[<hv2>Signatures@\n%a@]@]@]@."
+    Ident.pp_simpl fl_nm (print_ns fl_nm.id_str) fl_export print_signature
+    fl_sigs
 
 let write_gospel_file md =
   let filename =

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -294,6 +294,7 @@ type file = { fl_nm : Ident.t; fl_sigs : signature; fl_export : namespace }
 
 type module_uc = {
   muc_nm : Ident.t;
+  muc_file : string;
   muc_sigs : signature list;
   muc_prefix : string list;
   (* essential when closing namespaces *)
@@ -539,12 +540,15 @@ let add_sig_contents muc sig_ =
 (* TODO *)
 
 (** Module under construction with primitive types and functions *)
+let path2module p =
+  Filename.basename p |> Filename.chop_extension |> String.capitalize_ascii
 
-let init_muc s =
+let init_muc file =
   {
-    muc_nm = Ident.create ~loc:Location.none s;
+    muc_nm = Ident.create ~loc:Location.none (path2module file);
+    muc_file = file;
     muc_sigs = [ [] ];
-    muc_prefix = [ s ];
+    muc_prefix = [ file ];
     muc_import = [ ns_with_primitives ];
     muc_export = [ empty_ns ];
     muc_files = Mstr.empty;
@@ -609,9 +613,7 @@ let print_file fmt { fl_nm; fl_sigs; fl_export } =
     fl_sigs
 
 let write_gospel_file md =
-  let filename =
-    Filename.chop_extension (Fmt.str "%a" Ident.pp md.muc_nm) ^ ".gospel"
-  in
+  let filename = Filename.chop_extension md.muc_file ^ ".gospel" in
   let oc = open_out filename in
   Marshal.to_channel oc md [];
   close_out oc

--- a/src/tterm_printer.ml
+++ b/src/tterm_printer.ml
@@ -15,20 +15,20 @@ open Utils
 open Fmt
 
 let print_vs fmt { vs_name; vs_ty } =
-  pp fmt "@[%a:%a@]" Ident.pp vs_name print_ty vs_ty
+  pp fmt "@[%a:%a@]" Ident.pp_simpl vs_name print_ty vs_ty
 
 let print_ls_decl fmt { ls_name; ls_args; ls_value; _ } =
   let is_func = Option.is_some ls_value in
   let print_unnamed_arg fmt ty = pp fmt "(_:%a)" print_ty ty in
   pp fmt "%s %a %a%s%a"
     (if is_func then "function" else "predicate")
-    Ident.pp ls_name
+    Ident.pp_simpl ls_name
     (list ~sep:sp print_unnamed_arg)
     ls_args
     (if is_func then " : " else "")
     (option print_ty) ls_value
 
-let print_ls_nm fmt { ls_name; _ } = pp fmt "%a" Ident.pp ls_name
+let print_ls_nm fmt { ls_name; _ } = pp fmt "%a" Ident.pp_simpl ls_name
 let protect_on x s = if x then "(" ^^ s ^^ ")" else s
 
 let rec print_pat_node pri fmt p =
@@ -85,10 +85,10 @@ let rec print_term fmt { t_node; t_ty; t_attrs; _ } =
         in
         pp fmt "(%a %s %a)%a" print_term x1 op_nm print_term x2 print_ty t_ty
     | Tapp (ls, tl) ->
-        pp fmt "(%a %a)%a" Ident.pp ls.ls_name
+        pp fmt "(%a %a)%a" Ident.pp_simpl ls.ls_name
           (list ~first:sp ~sep:sp print_term)
           tl print_ty t_ty
-    | Tfield (t, ls) -> pp fmt "(%a).%a" print_term t Ident.pp ls.ls_name
+    | Tfield (t, ls) -> pp fmt "(%a).%a" print_term t Ident.pp_simpl ls.ls_name
     | Tnot t -> pp fmt "not %a" print_term t
     | Tif (t1, t2, t3) ->
         pp fmt "if %a then %a else %a" print_term t1 print_term t2 print_term t3

--- a/src/ttypes.ml
+++ b/src/ttypes.ml
@@ -313,9 +313,11 @@ let xs_subst_ty old_ts new_ts new_ty xs =
 open Fmt
 
 let print_tv fmt tv =
-  pp fmt (if tv.tv_name.id_str = "_" then "%a" else "'%a") Ident.pp tv.tv_name
+  pp fmt
+    (if tv.tv_name.id_str = "_" then "%a" else "'%a")
+    Ident.pp_simpl tv.tv_name
 
-let print_ts_name fmt ts = pp fmt "@[%a@]" Ident.pp (ts_ident ts)
+let print_ts_name fmt ts = pp fmt "@[%a@]" Ident.pp_simpl (ts_ident ts)
 
 let rec print_ty fmt { ty_node } = print_ty_node fmt ty_node
 and print_arrow_ty fmt = list ~sep:arrow print_ty fmt
@@ -333,7 +335,7 @@ and print_ty_node fmt = function
 let print_ts fmt ts =
   pp fmt "@[%a %a%a@]"
     (list ~sep:comma ~first:lparens ~last:rparens print_tv)
-    ts.ts_args Ident.pp (ts_ident ts)
+    ts.ts_args Ident.pp_simpl (ts_ident ts)
     (fun fmt alias ->
       match alias with None -> () | Some ty -> pp fmt " [=%a]" print_ty ty)
     ts.ts_alias
@@ -341,7 +343,7 @@ let print_ts fmt ts =
 let print_exn_type f = function
   | Exn_tuple tyl -> list ~sep:star print_ty f tyl
   | Exn_record args ->
-      let print_arg f (id, ty) = pp f "%a:%a" Ident.pp id print_ty ty in
+      let print_arg f (id, ty) = pp f "%a:%a" Ident.pp_simpl id print_ty ty in
       list ~sep:semi ~first:rbrace ~last:lbrace print_arg f args
 
-let print_xs f x = pp f "%a" Ident.pp x.xs_ident
+let print_xs f x = pp f "%a" Ident.pp_simpl x.xs_ident

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -575,7 +575,7 @@ let process_type_spec kid crcm ns ty spec =
   type_spec spec.ty_ephemeral fields invariants spec.ty_text spec.ty_loc
 
 (* TODO compare manifest with td_kind *)
-let type_type_declaration kid crcm ns r tdl =
+let type_type_declaration path kid crcm ns r tdl =
   let add_new tdm td =
     if Mstr.mem td.tname.txt tdm then
       W.error ~loc:td.tname.loc (W.Name_clash td.tname.txt)
@@ -638,17 +638,19 @@ let type_type_declaration kid crcm ns r tdl =
       in
       Option.map (parse_core alias tvl) td.tmanifest
     in
-    let td_ts = mk_ts (Ident.create ~loc:td.tname.loc s) params manifest in
+    let td_ts =
+      mk_ts (Ident.create ~path ~loc:td.tname.loc s) params manifest
+    in
     Hashtbl.add hts s td_ts;
 
     let process_record ty alias ldl =
-      let cs_id = Ident.create ~loc:Location.none ("constr#" ^ s) in
+      let cs_id = Ident.create ~path ~loc:Location.none ("constr#" ^ s) in
       let fields_ty =
         List.map (fun ld -> parse_core alias tvl ld.pld_type) ldl
       in
       let rd_cs = fsymbol ~constr:true ~field:false cs_id fields_ty ty in
       let mk_ld ld (ldl, ns) =
-        let id = Ident.create ~loc:ld.pld_loc ld.pld_name.txt in
+        let id = Ident.create ~path ~loc:ld.pld_loc ld.pld_name.txt in
         let ty_res = parse_core alias tvl ld.pld_type in
         let field = fsymbol ~field:true id [ ty ] ty_res in
         let mut = mutable_flag ld.pld_mutable in
@@ -663,7 +665,7 @@ let type_type_declaration kid crcm ns r tdl =
       let loc = cd.pcd_loc in
       if cd.pcd_res != None then
         W.error ~loc (W.Unsupported "type in constructors");
-      let cs_id = Ident.create ~loc cd.pcd_name.txt in
+      let cs_id = Ident.create ~path ~loc cd.pcd_name.txt in
       let cd_cs, cd_ld, ns =
         match cd.pcd_args with
         | Pcstr_tuple ctl ->
@@ -672,7 +674,7 @@ let type_type_declaration kid crcm ns r tdl =
             (ls, [], ns_add_ls ~allow_duplicate:true ns cs_id.id_str ls)
         | Pcstr_record ldl ->
             let add ld (ldl, tyl, ns) =
-              let id = Ident.create ~loc:ld.pld_loc ld.pld_name.txt in
+              let id = Ident.create ~path ~loc:ld.pld_loc ld.pld_name.txt in
               let ty = parse_core alias tvl ld.pld_type in
               let mut = mutable_flag ld.pld_mutable in
               let field = fsymbol ~constr:false ~field:true id [ ty_res ] ty in
@@ -746,9 +748,9 @@ let type_type_declaration kid crcm ns r tdl =
   List.iter (fun td -> Hts.replace type_declarations td.td_ts td) tdl;
   tdl
 
-let process_sig_type ~loc ?(ghost = Nonghost) kid crcm ns r tdl =
+let process_sig_type path ~loc ?(ghost = Nonghost) kid crcm ns r tdl =
   let r = rec_flag r in
-  let tdl = type_type_declaration kid crcm ns r tdl in
+  let tdl = type_type_declaration path kid crcm ns r tdl in
   let sig_desc = Sig_type (r, tdl, ghost) in
   mk_sig_item sig_desc loc
 
@@ -974,8 +976,8 @@ let mk_dummy_var i (ty, arg) =
   | Labelled s -> Uast.Lnamed (Preid.create ~loc s)
   | Optional s -> Uast.Loptional (Preid.create ~loc s)
 
-let process_val ~loc ?(ghost = Nonghost) kid crcm ns vd =
-  let id = Ident.create ~loc:vd.vloc vd.vname.txt in
+let process_val path ~loc ?(ghost = Nonghost) kid crcm ns vd =
+  let id = Ident.create ~path ~loc:vd.vloc vd.vname.txt in
   let args, ret = val_parse_core_type ns vd.vtype in
   let spec =
     match vd.vspec with
@@ -1025,7 +1027,7 @@ let process_val ~loc ?(ghost = Nonghost) kid crcm ns vd =
 
 (* Currently checking:
    1 - arguments have different names *)
-let process_function kid crcm ns f =
+let process_function path kid crcm ns f =
   let f_ty = Option.map (ty_of_pty ns) f.fun_type in
 
   let params =
@@ -1035,7 +1037,7 @@ let process_function kid crcm ns f =
   in
   let tyl = List.map (fun vs -> vs.vs_ty) params in
 
-  let ls = lsymbol ~field:false (Ident.of_preid f.fun_name) tyl f_ty in
+  let ls = lsymbol ~field:false (Ident.of_preid ~path f.fun_name) tyl f_ty in
   let ns =
     if f.fun_rec then ns_add_ls ~allow_duplicate:true ns f.fun_name.pid_str ls
     else ns
@@ -1089,15 +1091,15 @@ let process_function kid crcm ns f =
   in
   mk_sig_item (Sig_function f) f.fun_loc
 
-let process_axiom loc kid crcm ns a =
-  let id = Ident.of_preid a.Uast.ax_name in
+let process_axiom path loc kid crcm ns a =
+  let id = Ident.of_preid ~path a.Uast.ax_name in
   let t = fmla Axiom kid crcm ns Mstr.empty a.Uast.ax_term in
   let ax = mk_axiom id t a.ax_loc a.ax_text in
   mk_sig_item (Sig_axiom ax) loc
 
-let process_exception_sig loc ns te =
+let process_exception_sig path loc ns te =
   let ec = te.ptyexn_constructor in
-  let id = Ident.create ~loc:ec.pext_loc ec.pext_name.txt in
+  let id = Ident.create ~path ~loc:ec.pext_loc ec.pext_name.txt in
   let xs =
     match ec.pext_kind with
     | Pext_rebind lid -> find_xs ~loc:lid.loc ns (Longident.flatten_exn lid.txt)
@@ -1145,7 +1147,7 @@ let rec open_file ~loc penv muc nm =
     in
     let muc = open_empty_module muc nm in
     let penv = { penv with parsing = Sstr.add nm penv.parsing } in
-    let muc = List.fold_left (type_sig_item penv) muc sl in
+    let muc = List.fold_left (type_sig_item [ nm ] penv) muc sl in
     let muc = close_module_file muc in
     muc
 
@@ -1172,10 +1174,10 @@ and process_open ~loc ?(ghost = Nonghost) penv muc od =
   (muc, mk_sig_item (Sig_open (od, ghost)) loc)
 
 (* assumes that a new namespace has been opened *)
-and process_modtype penv muc umty =
+and process_modtype path penv muc umty =
   match umty.mdesc with
   | Mod_signature usig ->
-      let muc = List.fold_left (type_sig_item penv) muc usig in
+      let muc = List.fold_left (type_sig_item path penv) muc usig in
       let tsig = Mod_signature (get_top_sigs muc) in
       let tmty =
         { mt_desc = tsig; mt_loc = umty.mloc; mt_attrs = umty.mattributes }
@@ -1208,16 +1210,15 @@ and process_modtype penv muc umty =
   | Mod_with (umty2, cl) ->
       let ns_init = get_top_import muc in
       (* required to type type decls in constraints *)
-      let muc, tmty2 = process_modtype penv muc umty2 in
+      let muc, tmty2 = process_modtype path penv muc umty2 in
       let process_constraint (muc, cl) c =
         match c with
         | Wtype (li, tyd) ->
             let tdl =
-              type_type_declaration muc.muc_kid muc.muc_crcm ns_init
+              type_type_declaration path muc.muc_kid muc.muc_crcm ns_init
                 Nonrecursive [ tyd ]
             in
             let td = match tdl with [ td ] -> td | _ -> assert false in
-
             let q = Longident.flatten_exn li.txt in
             let ns = get_top_import muc in
             let ts = find_ts ~loc:li.loc ns q in
@@ -1239,7 +1240,7 @@ and process_modtype penv muc umty =
             (muc, Wty (ts.ts_ident, td) :: cl)
         | Wtypesubst (li, tyd) ->
             let tdl =
-              type_type_declaration muc.muc_kid muc.muc_crcm ns_init
+              type_type_declaration path muc.muc_kid muc.muc_crcm ns_init
                 Nonrecursive [ tyd ]
             in
             let td = match tdl with [ td ] -> td | _ -> assert false in
@@ -1290,9 +1291,9 @@ and process_modtype penv muc umty =
         | Named ({ txt; loc }, mt) -> (Option.value ~default:"_" txt, mt, loc)
       in
       let muc = open_module muc nm in
-      let muc, tmty_arg = process_modtype penv muc mty_arg in
+      let muc, tmty_arg = process_modtype path penv muc mty_arg in
       let muc = close_module_functor muc in
-      let muc, tmty = process_modtype penv muc mt in
+      let muc, tmty = process_modtype path penv muc mt in
       let tmty =
         {
           mt_desc = Mod_functor (Ident.create ~loc nm, Some tmty_arg, tmty);
@@ -1304,13 +1305,13 @@ and process_modtype penv muc umty =
   | Mod_typeof _ -> W.error ~loc:umty.mloc (W.Unsupported "module type of")
   | Mod_extension _ -> W.error ~loc:umty.mloc (W.Unsupported "module extension")
 
-and process_mod penv loc m muc =
+and process_mod path penv loc m muc =
   let nm = Option.value ~default:"_" m.mdname.txt in
   let muc = open_module muc nm in
-  let muc, mty = process_modtype penv muc m.mdtype in
+  let muc, mty = process_modtype (path @ [ nm ]) penv muc m.mdtype in
   let decl =
     {
-      md_name = Ident.create ~loc:m.mdname.loc nm;
+      md_name = Ident.create ~loc:m.mdname.loc ~path nm;
       md_type = mty;
       md_attrs = m.mdattributes;
       md_loc = m.mdloc;
@@ -1318,16 +1319,16 @@ and process_mod penv loc m muc =
   in
   (close_module muc, mk_sig_item (Sig_module decl) loc)
 
-and process_modtype_decl penv loc decl muc =
+and process_modtype_decl path penv loc decl muc =
   let nm = decl.mtdname.txt in
   let muc = open_module muc nm in
-  let md_mty = Option.map (process_modtype penv muc) decl.mtdtype in
+  let md_mty = Option.map (process_modtype path penv muc) decl.mtdtype in
   let muc, mty =
     match md_mty with None -> (muc, None) | Some (muc, mty) -> (muc, Some mty)
   in
   let decl =
     {
-      mtd_name = Ident.create ~loc:decl.mtdname.loc nm;
+      mtd_name = Ident.create ~path ~loc:decl.mtdname.loc nm;
       mtd_type = mty;
       mtd_attrs = decl.mtdattributes;
       mtd_loc = decl.mtdloc;
@@ -1335,32 +1336,33 @@ and process_modtype_decl penv loc decl muc =
   in
   (close_module_type muc, mk_sig_item (Sig_modtype decl) loc)
 
-and process_sig_item penv muc { sdesc; sloc } =
+and process_sig_item path penv muc { sdesc; sloc } =
   let process_sig_item si muc =
     let kid, ns, crcm = (muc.muc_kid, get_top_import muc, muc.muc_crcm) in
     match si with
     | Uast.Sig_type (r, tdl) ->
-        (muc, process_sig_type ~loc:sloc kid crcm ns r tdl)
-    | Uast.Sig_val vd -> (muc, process_val ~loc:sloc kid crcm ns vd)
+        (muc, process_sig_type path ~loc:sloc kid crcm ns r tdl)
+    | Uast.Sig_val vd -> (muc, process_val path ~loc:sloc kid crcm ns vd)
     | Uast.Sig_typext te -> (muc, mk_sig_item (Sig_typext te) sloc)
-    | Uast.Sig_module m -> process_mod penv sloc m muc
+    | Uast.Sig_module m -> process_mod path penv sloc m muc
     | Uast.Sig_recmodule _ -> W.error ~loc:sloc (W.Unsupported "module rec")
     | Uast.Sig_modsubst _ | Uast.Sig_modtypesubst _ | Uast.Sig_typesubst _ ->
         W.error ~loc:sloc (W.Unsupported "type substitution")
-    | Uast.Sig_modtype mty_decl -> process_modtype_decl penv sloc mty_decl muc
-    | Uast.Sig_exception te -> (muc, process_exception_sig sloc ns te)
+    | Uast.Sig_modtype mty_decl ->
+        process_modtype_decl path penv sloc mty_decl muc
+    | Uast.Sig_exception te -> (muc, process_exception_sig path sloc ns te)
     | Uast.Sig_open od -> process_open ~loc:sloc ~ghost:Nonghost penv muc od
     | Uast.Sig_include id -> (muc, mk_sig_item (Sig_include id) sloc)
     | Uast.Sig_class cdl -> (muc, mk_sig_item (Sig_class cdl) sloc)
     | Uast.Sig_class_type ctdl -> (muc, mk_sig_item (Sig_class_type ctdl) sloc)
     | Uast.Sig_attribute a -> (muc, mk_sig_item (Sig_attribute a) sloc)
     | Uast.Sig_extension (e, a) -> (muc, mk_sig_item (Sig_extension (e, a)) sloc)
-    | Uast.Sig_function f -> (muc, process_function kid crcm ns f)
-    | Uast.Sig_axiom a -> (muc, process_axiom sloc kid crcm ns a)
+    | Uast.Sig_function f -> (muc, process_function path kid crcm ns f)
+    | Uast.Sig_axiom a -> (muc, process_axiom path sloc kid crcm ns a)
     | Uast.Sig_ghost_type (r, tdl) ->
-        (muc, process_sig_type ~loc:sloc ~ghost:Ghost kid crcm ns r tdl)
+        (muc, process_sig_type path ~loc:sloc ~ghost:Ghost kid crcm ns r tdl)
     | Uast.Sig_ghost_val vd ->
-        (muc, process_val ~loc:sloc ~ghost:Ghost kid crcm ns vd)
+        (muc, process_val path ~loc:sloc ~ghost:Ghost kid crcm ns vd)
     | Uast.Sig_ghost_open od -> process_open ~loc:sloc ~ghost:Ghost penv muc od
   in
   let rec process_and_import si muc =
@@ -1377,6 +1379,9 @@ and process_sig_item penv muc { sdesc; sloc } =
   let muc = add_sig_contents muc signature in
   (muc, signature)
 
-and type_sig_item penv muc sig_item =
-  let muc, _ = process_sig_item penv muc sig_item in
+and type_sig_item path penv muc sig_item =
+  let muc, _ = process_sig_item path penv muc sig_item in
   muc
+
+let type_sig_item penv muc sig_item =
+  type_sig_item [ muc.muc_nm.id_str ] penv muc sig_item

--- a/src/typing.mli
+++ b/src/typing.mli
@@ -9,7 +9,6 @@
 (*                                                                  *)
 (********************************************************************)
 
-open Tast
 open Tmodule
 
 type parse_env
@@ -19,11 +18,6 @@ val penv : string list -> Utils.Sstr.t -> parse_env
 (** `penv load_paths module_nm` creates a `parse_env` for typing a module with
     name `module_nm`. The paths in `load_paths` are to be used when searching
     for modules dependencies. *)
-
-val process_sig_item :
-  parse_env -> module_uc -> Uast.s_signature_item -> module_uc * signature_item
-(** `process_sig_item penv muc s` returns a new module under construction after
-    type checking `s` and the typed signature obtained from `s` and `muc`. *)
 
 val type_sig_item : parse_env -> module_uc -> Uast.s_signature_item -> module_uc
 (** the same as above but it drops the typed signature *)

--- a/src/typing.mli
+++ b/src/typing.mli
@@ -20,4 +20,5 @@ val penv : string list -> Utils.Sstr.t -> parse_env
     for modules dependencies. *)
 
 val type_sig_item : parse_env -> module_uc -> Uast.s_signature_item -> module_uc
-(** the same as above but it drops the typed signature *)
+(** `type_sig_item penv muc s` returns a new module under construction after
+    type checking `s`. *)

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -124,7 +124,7 @@ First, create a test artifact:
       sig_loc = foo.mli:3:0 };
     { Tast.sig_desc =
       (Tast.Sig_val (
-         { Tast.vd_name = create; vd_type = int -> 'a t; vd_prim = [];
+         { Tast.vd_name = Foo.create; vd_type = int -> 'a t; vd_prim = [];
            vd_attrs = <attributes>;
            vd_args =
            [(Tast.Lnone
@@ -185,7 +185,7 @@ First, create a test artifact:
                    sp_checks =
                    [{ Tterm.t_node =
                       (Tterm.Tapp (
-                         { Symbols.ls_name = infix >=;
+                         { Symbols.ls_name = Gospelstdlib.infix >=;
                            ls_args =
                            [{ Ttypes.ty_node =
                               (Ttypes.Tyapp (
@@ -204,7 +204,7 @@ First, create a test artifact:
                            },
                          [{ Tterm.t_node =
                             (Tterm.Tapp (
-                               { Symbols.ls_name = integer_of_int;
+                               { Symbols.ls_name = Gospelstdlib.integer_of_int;
                                  ls_args =
                                  [{ Ttypes.ty_node =
                                     (Ttypes.Tyapp (
@@ -497,7 +497,7 @@ First, create a test artifact:
       sig_loc = foo.mli:8:0 };
     { Tast.sig_desc =
       (Tast.Sig_axiom
-         { Tast.ax_name = a_3;
+         { Tast.ax_name = Foo.a_3;
            ax_term =
            { Tterm.t_node = Tterm.Ttrue; t_ty = None; t_attrs = [];
              t_loc = foo.mli:16:14 };
@@ -506,7 +506,7 @@ First, create a test artifact:
     { Tast.sig_desc =
       (Tast.Sig_function
          { Tast.fun_ls =
-           { Symbols.ls_name = is_full;
+           { Symbols.ls_name = Foo.is_full;
              ls_args =
              [{ Ttypes.ty_node =
                 (Ttypes.Tyapp (
@@ -568,7 +568,7 @@ First, create a test artifact:
                              ls_field = false },
                            [{ Tterm.t_node =
                               (Tterm.Tapp (
-                                 { Symbols.ls_name = length;
+                                 { Symbols.ls_name = Gospelstdlib.List.length;
                                    ls_args =
                                    [{ Ttypes.ty_node =
                                       (Ttypes.Tyapp (
@@ -713,7 +713,7 @@ First, create a test artifact:
     { Tast.sig_desc =
       (Tast.Sig_function
          { Tast.fun_ls =
-           { Symbols.ls_name = with_spec;
+           { Symbols.ls_name = Foo.with_spec;
              ls_args =
              [{ Ttypes.ty_node =
                 (Ttypes.Tyapp (
@@ -784,7 +784,7 @@ First, create a test artifact:
                       (Tterm.Tnot
                          { Tterm.t_node =
                            (Tterm.Tapp (
-                              { Symbols.ls_name = mem;
+                              { Symbols.ls_name = Gospelstdlib.List.mem;
                                 ls_args =
                                 [{ Ttypes.ty_node =
                                    (Ttypes.Tyvar { Ttypes.tv_name = a }) };
@@ -880,7 +880,7 @@ First, create a test artifact:
     { Tast.sig_desc =
       (Tast.Sig_function
          { Tast.fun_ls =
-           { Symbols.ls_name = is_sorted_list;
+           { Symbols.ls_name = Foo.is_sorted_list;
              ls_args =
              [{ Ttypes.ty_node =
                 (Ttypes.Tyapp (
@@ -1395,7 +1395,8 @@ First, create a test artifact:
                                       (Tterm.Tbinop (Tterm.Tand,
                                          { Tterm.t_node =
                                            (Tterm.Tapp (
-                                              { Symbols.ls_name = infix <=;
+                                              { Symbols.ls_name =
+                                                Gospelstdlib.infix <=;
                                                 ls_args =
                                                 [{ Ttypes.ty_node =
                                                    (Ttypes.Tyapp (
@@ -1737,7 +1738,7 @@ First, create a test artifact:
       sig_loc = foo.mli:24:4 };
     { Tast.sig_desc =
       (Tast.Sig_val (
-         { Tast.vd_name = add; vd_type = 'a -> 'a t -> unit; vd_prim = [];
+         { Tast.vd_name = Foo.add; vd_type = 'a -> 'a t -> unit; vd_prim = [];
            vd_attrs = <attributes>;
            vd_args =
            [(Tast.Lnone

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -1419,7 +1419,7 @@ First, create a test artifact:
                                               [{ Tterm.t_node =
                                                  (Tterm.Tapp (
                                                     { Symbols.ls_name =
-                                                      integer_of_int;
+                                                      Gospelstdlib.integer_of_int;
                                                       ls_args =
                                                       [{ Ttypes.ty_node =
                                                          (Ttypes.Tyapp (
@@ -1485,7 +1485,7 @@ First, create a test artifact:
                                                 { Tterm.t_node =
                                                   (Tterm.Tapp (
                                                      { Symbols.ls_name =
-                                                       integer_of_int;
+                                                       Gospelstdlib.integer_of_int;
                                                        ls_args =
                                                        [{ Ttypes.ty_node =
                                                           (Ttypes.Tyapp (
@@ -1560,7 +1560,7 @@ First, create a test artifact:
                                          { Tterm.t_node =
                                            (Tterm.Tapp (
                                               { Symbols.ls_name =
-                                                is_sorted_list;
+                                                Foo.is_sorted_list;
                                                 ls_args =
                                                 [{ Ttypes.ty_node =
                                                    (Ttypes.Tyapp (
@@ -1892,7 +1892,7 @@ First, create a test artifact:
                                        ls_field = false },
                                      [{ Tterm.t_node =
                                         (Tterm.Tapp (
-                                           { Symbols.ls_name = is_full;
+                                           { Symbols.ls_name = Foo.is_full;
                                              ls_args =
                                              [{ Ttypes.ty_node =
                                                 (Ttypes.Tyapp (
@@ -2035,7 +2035,7 @@ First, create a test artifact:
                                              { Tterm.t_node =
                                                (Tterm.Tapp (
                                                   { Symbols.ls_name =
-                                                    integer_of_int;
+                                                    Gospelstdlib.integer_of_int;
                                                     ls_args =
                                                     [{ Ttypes.ty_node =
                                                        (Ttypes.Tyapp (

--- a/test/path/dune
+++ b/test/path/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:gospel}))

--- a/test/path/path_test.t
+++ b/test/path/path_test.t
@@ -1,0 +1,90 @@
+Testing the paths of typed identifiers by `gospel dumpast`, 
+
+First, create a test artifact:
+
+  $ cat > path_test.mli << EOF
+  > val x : int
+  > val y : int ->  int
+  > 
+  > type t
+  > 
+  > val w : t
+  > 
+  > val z : t ->  t
+  > (*@ r = z arg
+  >     ensures arg = r *)
+  > 
+  > module M : sig
+  > 
+  >   val x : int
+  >   val y : int ->  int
+  > 
+  >  (*@ function f (n : int) : int *)
+  >  (*@ axiom a : forall n. f n = n + 1 *)
+  > 
+  >   module Nested : sig
+  >     val x : int
+  >     val y : int ->  int
+  >   end
+  > end
+  > 
+  > module N : sig
+  >   
+  >   val x : int
+  >   val y : int ->  int
+  >   
+  > end
+  > EOF
+  $ gospel dumpast path_test.mli | grep '_name.*'
+         { Tast.vd_name = Path_test.x; vd_type = int; vd_prim = [];
+               { Symbols.vs_name = x_1;
+         { Tast.vd_name = Path_test.y; vd_type = int -> int; vd_prim = [];
+               { Symbols.vs_name = __arg0;
+               { Symbols.vs_name = result;
+         { Tast.vd_name = Path_test.w; vd_type = t; vd_prim = [];
+               { Symbols.vs_name = w_1;
+         { Tast.vd_name = Path_test.z; vd_type = t -> t; vd_prim = [];
+               { Symbols.vs_name = arg;
+               { Symbols.vs_name = r;
+                       { Symbols.vs_name = arg;
+                       { Symbols.vs_name = r;
+                         { Symbols.ls_name = infix =;
+                              (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) };
+                               (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) }
+                               { Symbols.vs_name = arg;
+                                { Symbols.vs_name = r;
+         { Tast.md_name = Path_test.M;
+                      { Tast.vd_name = Path_test.M.x_2; vd_type = int;
+                            { Symbols.vs_name = x_3;
+                       { Tast.vd_name = Path_test.M.y_1; vd_type = int -> int;
+                             { Symbols.vs_name = __arg0_1;
+                             { Symbols.vs_name = result_1;
+                         { Symbols.ls_name = Path_test.M.f;
+                         [{ Symbols.vs_name = n;
+                       { Tast.ax_name = Path_test.M.a_2;
+                              [{ Symbols.vs_name = n_1;
+                                   { Symbols.ls_name = infix =;
+                                        (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
+                                         (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
+                                         { Symbols.ls_name =
+                                               { Symbols.ls_name = f;
+                                                     { Symbols.vs_name = n_1;
+                                          { Symbols.ls_name =
+                                                { Symbols.ls_name =
+                                                      { Symbols.vs_name = n_1;
+                       { Tast.md_name = Path_test.M.Nested;
+                                    { Tast.vd_name = Path_test.M.Nested.x_4;
+                                          { Symbols.vs_name = x_5;
+                                     { Tast.vd_name = Path_test.M.Nested.y_2;
+                                           { Symbols.vs_name = __arg0_2;
+                                           { Symbols.vs_name = result_2;
+         { Tast.md_name = Path_test.N;
+                      { Tast.vd_name = Path_test.N.x_6; vd_type = int;
+                            { Symbols.vs_name = x_7;
+                       { Tast.vd_name = Path_test.N.y_3; vd_type = int -> int;
+                             { Symbols.vs_name = __arg0_3;
+                             { Symbols.vs_name = result_3;
+
+Clean up:
+
+  $ rm path_test.mli

--- a/test/path/path_test.t
+++ b/test/path/path_test.t
@@ -35,56 +35,55 @@ First, create a test artifact:
   >   
   > end
   > EOF
-  $ gospel dumpast path_test.mli | grep '_name.*'
-         { Tast.vd_name = Path_test.x; vd_type = int; vd_prim = [];
-               { Symbols.vs_name = x_1;
-         { Tast.vd_name = Path_test.y; vd_type = int -> int; vd_prim = [];
-               { Symbols.vs_name = __arg0;
-               { Symbols.vs_name = result;
-         { Tast.vd_name = Path_test.w; vd_type = t; vd_prim = [];
-               { Symbols.vs_name = w_1;
-         { Tast.vd_name = Path_test.z; vd_type = t -> t; vd_prim = [];
-               { Symbols.vs_name = arg;
-               { Symbols.vs_name = r;
-                       { Symbols.vs_name = arg;
-                       { Symbols.vs_name = r;
-                         { Symbols.ls_name = infix =;
-                              (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) };
-                               (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) }
-                               { Symbols.vs_name = arg;
-                                { Symbols.vs_name = r;
-         { Tast.md_name = Path_test.M;
-                      { Tast.vd_name = Path_test.M.x_2; vd_type = int;
-                            { Symbols.vs_name = x_3;
-                       { Tast.vd_name = Path_test.M.y_1; vd_type = int -> int;
-                             { Symbols.vs_name = __arg0_1;
-                             { Symbols.vs_name = result_1;
-                         { Symbols.ls_name = Path_test.M.f;
-                         [{ Symbols.vs_name = n;
-                       { Tast.ax_name = Path_test.M.a_2;
-                              [{ Symbols.vs_name = n_1;
-                                   { Symbols.ls_name = infix =;
-                                        (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
-                                         (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
-                                         { Symbols.ls_name =
-                                               { Symbols.ls_name = f;
-                                                     { Symbols.vs_name = n_1;
-                                          { Symbols.ls_name =
-                                                { Symbols.ls_name =
-                                                      { Symbols.vs_name = n_1;
-                       { Tast.md_name = Path_test.M.Nested;
-                                    { Tast.vd_name = Path_test.M.Nested.x_4;
-                                          { Symbols.vs_name = x_5;
-                                     { Tast.vd_name = Path_test.M.Nested.y_2;
-                                           { Symbols.vs_name = __arg0_2;
-                                           { Symbols.vs_name = result_2;
-         { Tast.md_name = Path_test.N;
-                      { Tast.vd_name = Path_test.N.x_6; vd_type = int;
-                            { Symbols.vs_name = x_7;
-                       { Tast.vd_name = Path_test.N.y_3; vd_type = int -> int;
-                             { Symbols.vs_name = __arg0_3;
-                             { Symbols.vs_name = result_3;
-
+  $ gospel dumpast path_test.mli | tr '\n' ' ' | tr ';}' '\n' | grep -Eo '_name = .*'  | awk '{$1=$1};1' | sed 's/_name = \(\)/\1/'
+  Path_test.x
+  x_1
+  Path_test.y
+  __arg0
+  result
+  Path_test.w
+  w_1
+  Path_test.z
+  arg
+  r
+  arg
+  r
+  infix =
+  a_1
+  a_1
+  arg
+  r
+  Path_test.M
+  Path_test.M.x_2
+  x_3
+  Path_test.M.y_1
+  __arg0_1
+  result_1
+  Path_test.M.f
+  n
+  Path_test.M.a_2
+  n_1
+  infix =
+  a_1
+  a_1
+  Gospelstdlib.integer_of_int
+  Path_test.M.f
+  n_1
+  Gospelstdlib.infix +
+  Gospelstdlib.integer_of_int
+  n_1
+  Path_test.M.Nested
+  Path_test.M.Nested.x_4
+  x_5
+  Path_test.M.Nested.y_2
+  __arg0_2
+  result_2
+  Path_test.N
+  Path_test.N.x_6
+  x_7
+  Path_test.N.y_3
+  __arg0_3
+  result_3
 Clean up:
 
   $ rm path_test.mli

--- a/test/utils/dune_gen.ml
+++ b/test/utils/dune_gen.ml
@@ -46,6 +46,7 @@ let print_rule file =
       | None -> ("", "")
       | Some prd -> ("(with-accepted-exit-codes " ^ prd ^ "\n    ", ")")
     in
+
     Printf.printf
       {|(rule
  (deps

--- a/test/utils/dune_gen.ml
+++ b/test/utils/dune_gen.ml
@@ -46,7 +46,6 @@ let print_rule file =
       | None -> ("", "")
       | Some prd -> ("(with-accepted-exit-codes " ^ prd ^ "\n    ", ")")
     in
-
     Printf.printf
       {|(rule
  (deps


### PR DESCRIPTION
Hello again :)

As I said previously, I was trying to change the commit history so that the previous commits were well formatted, but I guess something broke. All the previous commits are now well formatted. I also merged the commits that added tests and identifiers into one. I also added a field to module records with the name of the module (not just the path of the file) for convinience's sake.