### PR TITLE
fix examples tests

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version = 0.26.1
+version = 0.26.2
 parse-docstrings = true
 break-infix = fit-or-vertical
 module-item-spacing = compact

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.3
 
 ## Added
 

--- a/examples/Stack.mli
+++ b/examples/Stack.mli
@@ -37,6 +37,3 @@ module type S = sig
         ensures s2.view = Sequence.empty *)
 end
 
-(* {gospel_expected|
-   [0] OK
-   |gospel_expected} *)

--- a/examples/Stack.mli
+++ b/examples/Stack.mli
@@ -36,4 +36,3 @@ module type S = sig
         ensures s1.view = (old s1.view ++ old s2.view)
         ensures s2.view = Sequence.empty *)
 end
-

--- a/examples/dune.inc
+++ b/examples/dune.inc
@@ -2,6 +2,7 @@
  (deps
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets Stack.gospel)
  (action
   (with-outputs-to Stack.mli.output
    (run %{checker} %{dep:Stack.mli}))))


### PR DESCRIPTION
This is mainly a clean-up PR as it:

- Update examples tests which doesn't print `OK` anymore
- Revert "Open an “Unreleased” section in the changelog" because 0.3.0 has been released (sorry to not have checked that before merging)
- Update to ocamlformat.0.26.2
