### PR TITLE
Improve error message for unbound record fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Improved
 
+- Improve error message for unbound record fields
+  [#419] (https://github.com/ocaml-gospel/gospel/pull/419)
 - Collect all the missing fields in a record definition and don't accept
   incomplete record pattern syntax that OCaml consider incorrect
   [#418] (https://github.com/ocaml-gospel/gospel/pull/418)

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -136,7 +136,16 @@ let find_constructors kid ts =
   | _ -> assert false
 
 let parse_record ~loc kid ns fll =
-  let fll = List.map (fun (q, v) -> (find_q_fd ns q, v)) fll in
+  let find q =
+    try find_q_fd ns q
+    with W.(Error (_, Symbol_not_found _)) ->
+      let label =
+        let open Uast in
+        match q with Qpreid pid | Qdot (_, pid) -> pid.pid_str
+      in
+      W.(error ~loc (Unbound_label label))
+  in
+  let fll = List.map (fun (q, v) -> (find q, v)) fll in
   let fs =
     match fll with
     | [] -> assert false (* foridden at parsing *)

--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -41,8 +41,8 @@ type kind =
   | Syntax_error
   | Term_expected
   | Type_checking_error of string
+  | Unbound_label of string
   | Unbound_variable of string
-  | Unknown_record_field of string
   | Unsupported of string
   | Unterminated_comment
 
@@ -154,9 +154,9 @@ let pp_kind ppf = function
   | Syntax_error -> pf ppf "Syntax error"
   | Term_expected -> pf ppf "A term was expected"
   | Type_checking_error msg -> pf ppf "Type checking error: %a" text msg
+  | Unbound_label s -> pf ppf "Unbound record field: %s" s
   | Unbound_variable s ->
       pf ppf "The variable %s does not appear in this pattern" s
-  | Unknown_record_field s -> pf ppf "The field %s is unknown" s
   | Unsupported s -> pf ppf "Not yet supported: %s" s
   | Unterminated_comment -> pf ppf "Unterminated comment"
 

--- a/test/patterns/dune.inc
+++ b/test/patterns/dune.inc
@@ -754,3 +754,24 @@
    ; Syntax sanity check
    (run ocamlc -c %{dep:redundant3.mli}))))
 
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets unbound_record_field.gospel)
+ (action
+  (with-outputs-to unbound_record_field.mli.output
+   (run %{checker} %{dep:unbound_record_field.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff unbound_record_field.mli unbound_record_field.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:unbound_record_field.mli}))))
+

--- a/test/patterns/unbound_record_field.mli
+++ b/test/patterns/unbound_record_field.mli
@@ -6,9 +6,8 @@
 *)
 
 (* {gospel_expected|
-   [125] File "unbound_record_field.mli", line 5, characters 9-10:
+   [125] File "unbound_record_field.mli", line 5, characters 4-12:
          5 |   | { a; b } -> true
-                      ^
-         Error: Symbol b not found in scope
-                (see "Symbols in scope" documentation page).
+                 ^^^^^^^^
+         Error: Unbound record field: b.
    |gospel_expected} *)

--- a/test/patterns/unbound_record_field.mli
+++ b/test/patterns/unbound_record_field.mli
@@ -1,0 +1,14 @@
+(*@ type t = { a : bool } *)
+
+(*@ predicate p (x : t) =
+  match x with
+  | { a; b } -> true
+*)
+
+(* {gospel_expected|
+   [125] File "unbound_record_field.mli", line 5, characters 9-10:
+         5 |   | { a; b } -> true
+                      ^
+         Error: Symbol b not found in scope
+                (see "Symbols in scope" documentation page).
+   |gospel_expected} *)

--- a/test/syntax/record_pattern2.mli
+++ b/test/syntax/record_pattern2.mli
@@ -18,9 +18,8 @@ type t = { x : int }
 (* TODO better error message: "unknown field name" *)
 
 (* {gospel_expected|
-   [125] File "record_pattern2.mli", line 15, characters 7-8:
+   [125] File "record_pattern2.mli", line 15, characters 6-9:
          15 |     | {y} -> y
-                     ^
-         Error: Symbol y not found in scope
-                (see "Symbols in scope" documentation page).
+                    ^^^
+         Error: Unbound record field: y.
    |gospel_expected} *)

--- a/test/syntax/record_pattern3.mli
+++ b/test/syntax/record_pattern3.mli
@@ -16,9 +16,8 @@ type t = { x : int }
 *)
 
 (* {gospel_expected|
-   [125] File "record_pattern3.mli", line 15, characters 11-12:
+   [125] File "record_pattern3.mli", line 15, characters 6-14:
          15 |     | { x; z } -> x
-                         ^
-         Error: Symbol z not found in scope
-                (see "Symbols in scope" documentation page).
+                    ^^^^^^^^
+         Error: Unbound record field: z.
    |gospel_expected} *)

--- a/test/typechecker/dune.inc
+++ b/test/typechecker/dune.inc
@@ -972,6 +972,27 @@
  (deps
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets value_unbound_record_field.gospel)
+ (action
+  (with-outputs-to value_unbound_record_field.mli.output
+   (run %{checker} %{dep:value_unbound_record_field.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff value_unbound_record_field.mli value_unbound_record_field.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:value_unbound_record_field.mli}))))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
  (targets variant_integer.gospel)
  (action
   (with-outputs-to variant_integer.mli.output

--- a/test/typechecker/value_unbound_record_field.mli
+++ b/test/typechecker/value_unbound_record_field.mli
@@ -1,0 +1,13 @@
+(*@ type t = { a : bool } *)
+
+(*@ predicate p (x : t) =
+  let y = { a = true ; b = 42 } in true
+*)
+
+(* {gospel_expected|
+   [125] File "value_unbound_record_field.mli", line 4, characters 23-24:
+         4 |   let y = { a = true ; b = 42 } in true
+                                    ^
+         Error: Symbol b not found in scope
+                (see "Symbols in scope" documentation page).
+   |gospel_expected} *)

--- a/test/typechecker/value_unbound_record_field.mli
+++ b/test/typechecker/value_unbound_record_field.mli
@@ -5,9 +5,8 @@
 *)
 
 (* {gospel_expected|
-   [125] File "value_unbound_record_field.mli", line 4, characters 23-24:
+   [125] File "value_unbound_record_field.mli", line 4, characters 10-31:
          4 |   let y = { a = true ; b = 42 } in true
-                                    ^
-         Error: Symbol b not found in scope
-                (see "Symbols in scope" documentation page).
+                       ^^^^^^^^^^^^^^^^^^^^^
+         Error: Unbound record field: b.
    |gospel_expected} *)


### PR DESCRIPTION
This PR proposes to use the same error message as the OCaml compiler for unbound record fields, both in values and in patterns.

It is based on #418, please consider only the last five commits.