### PR TITLE
Fix typing of expression with inlined records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Improved
 
+- Fix typing of expression with inlined record
+  [#420] (https://github.com/ocaml-gospel/gospel/pull/420)
 - Improve error message for unbound record fields
   [#419] (https://github.com/ocaml-gospel/gospel/pull/419)
 - Collect all the missing fields in a record definition and don't accept
@@ -9,7 +11,7 @@
   [#418] (https://github.com/ocaml-gospel/gospel/pull/418)
 - Display proper error message for a number of unsupported construction
   [#406] (https://github.com/ocaml-gospel/gospel/pull/406)
-- Display an error message when encoutering a Functor application
+- Display an error message when encountering a Functor application
   [#404] (https://github.com/ocaml-gospel/gospel/pull/404)
 - Changed the gospel typechecker to use bool as the type of logical formulae
   [\#391](https://github.com/ocaml-gospel/gospel/pull/391)

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -53,13 +53,11 @@ end
 module Sls = Set.Make (LS)
 module Mls = Map.Make (LS)
 
-let lsymbol ?(constr = false) ~field ls_name ls_args ls_value =
+let lsymbol ~constr ~field ls_name ls_args ls_value =
   { ls_name; ls_args; ls_value; ls_constr = constr; ls_field = field }
 
-let fsymbol ?(constr = false) ~field nm tyl ty =
-  lsymbol ~constr ~field nm tyl ty
-
-let psymbol nm ty = lsymbol ~field:false nm ty ty_bool
+let fsymbol ~constr ~field nm tyl ty = lsymbol ~constr ~field nm tyl ty
+let psymbol nm ty = lsymbol ~constr:false ~field:false nm ty ty_bool
 
 let ls_subst_ts old_ts new_ts ({ ls_name; ls_constr; ls_field; _ } as ls) =
   let ls_args = List.map (ty_subst_ts old_ts new_ts) ls.ls_args in
@@ -96,7 +94,7 @@ let fs_bool_false =
 let fs_apply =
   let ty_a, ty_b = (fresh_ty_var "a", fresh_ty_var "b") in
   let ty_a_to_b = ty_app ts_arrow [ ty_a; ty_b ] in
-  fsymbol ~field:false
+  fsymbol ~constr:false ~field:false
     (Ident.create ~loc:Location.none "apply")
     [ ty_a_to_b; ty_a ] ty_b
 

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -56,9 +56,6 @@ module Mls = Map.Make (LS)
 let lsymbol ~constr ~field ls_name ls_args ls_value =
   { ls_name; ls_args; ls_value; ls_constr = constr; ls_field = field }
 
-let fsymbol ~constr ~field nm tyl ty = lsymbol ~constr ~field nm tyl ty
-let psymbol nm ty = lsymbol ~constr:false ~field:false nm ty ty_bool
-
 let ls_subst_ts old_ts new_ts ({ ls_name; ls_constr; ls_field; _ } as ls) =
   let ls_args = List.map (ty_subst_ts old_ts new_ts) ls.ls_args in
   let ls_value = ty_subst_ts old_ts new_ts ls.ls_value in
@@ -74,27 +71,27 @@ let ls_subst_ty old_ts new_ts new_ty ls =
 
 let ps_equ =
   let tv = fresh_ty_var "a" in
-  psymbol Identifier.eq [ tv; tv ]
+  lsymbol ~constr:false ~field:false Identifier.eq [ tv; tv ] ty_bool
 
 let fs_unit =
-  fsymbol ~constr:true ~field:false
+  lsymbol ~constr:true ~field:false
     (Ident.create ~loc:Location.none "()")
     [] ty_unit
 
 let fs_bool_true =
-  fsymbol ~constr:true ~field:false
+  lsymbol ~constr:true ~field:false
     (Ident.create ~loc:Location.none "true")
     [] ty_bool
 
 let fs_bool_false =
-  fsymbol ~constr:true ~field:false
+  lsymbol ~constr:true ~field:false
     (Ident.create ~loc:Location.none "false")
     [] ty_bool
 
 let fs_apply =
   let ty_a, ty_b = (fresh_ty_var "a", fresh_ty_var "b") in
   let ty_a_to_b = ty_app ts_arrow [ ty_a; ty_b ] in
-  fsymbol ~constr:false ~field:false
+  lsymbol ~constr:false ~field:false
     (Ident.create ~loc:Location.none "apply")
     [ ty_a_to_b; ty_a ] ty_b
 
@@ -104,17 +101,17 @@ let tv_option = { Ttypes.ty_node = Ttypes.Tyvar { Ttypes.tv_name = tvo } }
 let tv_list = { Ttypes.ty_node = Ttypes.Tyvar { Ttypes.tv_name = tvl } }
 
 let fs_option_none =
-  fsymbol ~constr:true ~field:false Identifier.none [] (ty_option tv_option)
+  lsymbol ~constr:true ~field:false Identifier.none [] (ty_option tv_option)
 
 let fs_option_some =
-  fsymbol ~constr:true ~field:false Identifier.some [ tv_option ]
+  lsymbol ~constr:true ~field:false Identifier.some [ tv_option ]
     (ty_option tv_option)
 
 let fs_list_nil =
-  fsymbol ~constr:true ~field:false Identifier.nil [] (ty_list tv_list)
+  lsymbol ~constr:true ~field:false Identifier.nil [] (ty_list tv_list)
 
 let fs_list_cons =
-  fsymbol ~constr:true ~field:false Identifier.cons
+  lsymbol ~constr:true ~field:false Identifier.cons
     [ tv_list; ty_list tv_list ]
     (ty_list tv_list)
 
@@ -130,7 +127,7 @@ let fs_tuple =
       let ts = ts_tuple n in
       let tyl = List.map ty_of_var ts.ts_args in
       let ty = ty_app (ts_tuple n) tyl in
-      let ls = fsymbol ~constr:true ~field:false id tyl ty in
+      let ls = lsymbol ~constr:true ~field:false id tyl ty in
       Hashtbl.add fs_tuple_ids id ls;
       Hashtbl.add ls_tuples n ls;
       ls

--- a/src/symbols.ml
+++ b/src/symbols.ml
@@ -27,20 +27,69 @@ end
 module Svs = Set.Make (Vs)
 module Mvs = Map.Make (Vs)
 
-(* Function and predicate symbols *)
+(* Function, field and constructor symbols *)
 
-type lsymbol = {
-  ls_name : Ident.t;
-  ls_args : ty list;
-  ls_value : ty;
-  ls_constr : bool;
-  (* true if it is a construct, false otherwise*)
-  ls_field : bool; (* true if it is a record/model field *)
-}
+type lsymbol =
+  | Function_symbol of { ls_name : Ident.t; ls_args : ty list; ls_value : ty }
+  | Constructor_symbol of {
+      ls_name : Ident.t;
+      ls_args : ty list;
+      ls_value : ty;
+    }
+  | Field_symbol of { ls_name : Ident.t; ls_args : ty list; ls_value : ty }
 [@@deriving show]
 
+let function_symbol ls_name ls_args ls_value =
+  Function_symbol { ls_name; ls_args; ls_value }
+
+let constructor_symbol ls_name ls_args ls_value =
+  Constructor_symbol { ls_name; ls_args; ls_value }
+
+let field_symbol ls_name ls_args ls_value =
+  Field_symbol { ls_name; ls_args; ls_value }
+
+let get_name = function
+  | Constructor_symbol { ls_name; _ }
+  | Field_symbol { ls_name; _ }
+  | Function_symbol { ls_name; _ } ->
+      ls_name
+
+let get_args = function
+  | Constructor_symbol { ls_args; _ }
+  | Field_symbol { ls_args; _ }
+  | Function_symbol { ls_args; _ } ->
+      ls_args
+
+let get_value = function
+  | Constructor_symbol { ls_value; _ }
+  | Field_symbol { ls_value; _ }
+  | Function_symbol { ls_value; _ } ->
+      ls_value
+
+(* We won't want to change the name of a symbol *)
+let fmap f = function
+  | Constructor_symbol { ls_name; ls_args; ls_value } ->
+      let ls_args = List.map f ls_args and ls_value = f ls_value in
+      Constructor_symbol { ls_name; ls_args; ls_value }
+  | Field_symbol { ls_name; ls_args; ls_value } ->
+      let ls_args = List.map f ls_args and ls_value = f ls_value in
+      Field_symbol { ls_name; ls_args; ls_value }
+  | Function_symbol { ls_name; ls_args; ls_value } ->
+      let ls_args = List.map f ls_args and ls_value = f ls_value in
+      Function_symbol { ls_name; ls_args; ls_value }
+
+let ls_subst_ts old_ts new_ts symbol =
+  let subst = ty_subst_ts old_ts new_ts in
+  fmap subst symbol
+
+let ls_subst_ty old_ts new_ts new_ty symbol =
+  let subst ty = ty_subst_ty old_ts new_ts new_ty ty in
+  fmap subst symbol
+
 (* CHECK *)
-let ls_equal l r = Ident.equal l.ls_name r.ls_name
+let ls_equal l r =
+  let l = get_name l and r = get_name r in
+  Ident.equal l r
 
 module LS = struct
   type t = lsymbol
@@ -53,45 +102,25 @@ end
 module Sls = Set.Make (LS)
 module Mls = Map.Make (LS)
 
-let lsymbol ~constr ~field ls_name ls_args ls_value =
-  { ls_name; ls_args; ls_value; ls_constr = constr; ls_field = field }
-
-let ls_subst_ts old_ts new_ts ({ ls_name; ls_constr; ls_field; _ } as ls) =
-  let ls_args = List.map (ty_subst_ts old_ts new_ts) ls.ls_args in
-  let ls_value = ty_subst_ts old_ts new_ts ls.ls_value in
-  lsymbol ls_name ls_args ls_value ~constr:ls_constr ~field:ls_field
-
-let ls_subst_ty old_ts new_ts new_ty ls =
-  let subst ty = ty_subst_ty old_ts new_ts new_ty ty in
-  let ls_args = List.map subst ls.ls_args in
-  let ls_value = subst ls.ls_value in
-  lsymbol ls.ls_name ls_args ls_value ~constr:ls.ls_constr ~field:ls.ls_field
-
-(** buil-in lsymbols *)
+(** built-in lsymbols *)
 
 let ps_equ =
   let tv = fresh_ty_var "a" in
-  lsymbol ~constr:false ~field:false Identifier.eq [ tv; tv ] ty_bool
+  function_symbol Identifier.eq [ tv; tv ] ty_bool
 
 let fs_unit =
-  lsymbol ~constr:true ~field:false
-    (Ident.create ~loc:Location.none "()")
-    [] ty_unit
+  constructor_symbol (Ident.create ~loc:Location.none "()") [] ty_unit
 
 let fs_bool_true =
-  lsymbol ~constr:true ~field:false
-    (Ident.create ~loc:Location.none "true")
-    [] ty_bool
+  constructor_symbol (Ident.create ~loc:Location.none "true") [] ty_bool
 
 let fs_bool_false =
-  lsymbol ~constr:true ~field:false
-    (Ident.create ~loc:Location.none "false")
-    [] ty_bool
+  constructor_symbol (Ident.create ~loc:Location.none "false") [] ty_bool
 
 let fs_apply =
   let ty_a, ty_b = (fresh_ty_var "a", fresh_ty_var "b") in
   let ty_a_to_b = ty_app ts_arrow [ ty_a; ty_b ] in
-  lsymbol ~constr:false ~field:false
+  function_symbol
     (Ident.create ~loc:Location.none "apply")
     [ ty_a_to_b; ty_a ] ty_b
 
@@ -99,19 +128,15 @@ let tvo = ts_option.ts_args |> function [ v ] -> v.tv_name | _ -> assert false
 let tvl = ts_list.ts_args |> function [ v ] -> v.tv_name | _ -> assert false
 let tv_option = { Ttypes.ty_node = Ttypes.Tyvar { Ttypes.tv_name = tvo } }
 let tv_list = { Ttypes.ty_node = Ttypes.Tyvar { Ttypes.tv_name = tvl } }
-
-let fs_option_none =
-  lsymbol ~constr:true ~field:false Identifier.none [] (ty_option tv_option)
+let fs_option_none = constructor_symbol Identifier.none [] (ty_option tv_option)
 
 let fs_option_some =
-  lsymbol ~constr:true ~field:false Identifier.some [ tv_option ]
-    (ty_option tv_option)
+  constructor_symbol Identifier.some [ tv_option ] (ty_option tv_option)
 
-let fs_list_nil =
-  lsymbol ~constr:true ~field:false Identifier.nil [] (ty_list tv_list)
+let fs_list_nil = constructor_symbol Identifier.nil [] (ty_list tv_list)
 
 let fs_list_cons =
-  lsymbol ~constr:true ~field:false Identifier.cons
+  constructor_symbol Identifier.cons
     [ tv_list; ty_list tv_list ]
     (ty_list tv_list)
 
@@ -127,9 +152,11 @@ let fs_tuple =
       let ts = ts_tuple n in
       let tyl = List.map ty_of_var ts.ts_args in
       let ty = ty_app (ts_tuple n) tyl in
-      let ls = lsymbol ~constr:true ~field:false id tyl ty in
+      let ls = constructor_symbol id tyl ty in
       Hashtbl.add fs_tuple_ids id ls;
       Hashtbl.add ls_tuples n ls;
       ls
 
-let is_fs_tuple fs = fs.ls_constr && Hashtbl.mem fs_tuple_ids fs.ls_name
+let is_fs_tuple = function
+  | Constructor_symbol { ls_name; _ } -> Hashtbl.mem fs_tuple_ids ls_name
+  | _ -> false

--- a/src/tast_printer.ml
+++ b/src/tast_printer.ml
@@ -17,7 +17,7 @@ let print_variant_field fmt ld =
 let print_rec_field fmt ld =
   pp fmt "%s%a:%a"
     (if ld.ld_mut = Mutable then "mutable " else "")
-    Ident.pp_simpl ld.ld_field.ls_name print_ty ld.ld_field.ls_value
+    Ident.pp_simpl (get_name ld.ld_field) print_ty (get_value ld.ld_field)
 
 let print_label_decl_list print_field fmt fields =
   pp fmt "{%a}" (list ~sep:semi print_field) fields
@@ -26,11 +26,11 @@ let print_type_kind fmt = function
   | Pty_abstract -> ()
   | Pty_variant cpl ->
       let print_args cs fmt = function
-        | [] -> list ~sep:star print_ty fmt cs.ls_args
+        | [] -> list ~sep:star print_ty fmt (get_args cs)
         | ld -> print_label_decl_list print_variant_field fmt ld
       in
       let print_constructor fmt { cd_cs; cd_ld; _ } =
-        pp fmt "@[%a of %a@\n@[<h 2>%a@]@]" Ident.pp_simpl cd_cs.ls_name
+        pp fmt "@[%a of %a@\n@[<h 2>%a@]@]" Ident.pp_simpl (get_name cd_cs)
           (print_args cd_cs) cd_ld print_ls_decl cd_cs
       in
       pp fmt "@[ = %a@]"
@@ -53,7 +53,7 @@ let print_type_spec fmt { ty_ephemeral; ty_fields; ty_invariants; _ } =
     let print_field f (ls, mut) =
       pp f "@[%s%a : %a@]"
         (if mut then "mutable model " else "model ")
-        print_ls_nm ls print_ty ls.ls_value
+        print_ls_nm ls print_ty (get_value ls)
     in
     let print_invariants ppf i =
       pf ppf "with %a@;%a" print_vs (fst i)
@@ -164,7 +164,7 @@ let print_param f p = pp f "(%a:%a)" Ident.pp_simpl p.vs_name print_ty p.vs_ty
 
 let print_function f x =
   let func_pred =
-    if ty_equal x.fun_ls.ls_value ty_bool then "predicate" else "function"
+    if ty_equal (get_value x.fun_ls) ty_bool then "predicate" else "function"
   in
   let print_term f t = pp f "@[%a@]" print_term t in
   let print_term f t = pp f "@[%a@]" print_term t in
@@ -191,9 +191,9 @@ let print_function f x =
   let func f x =
     pp f "@[%s %s%a %a%a%a%a@]" func_pred
       (if x.fun_rec then "rec " else "")
-      Ident.pp_simpl x.fun_ls.ls_name (list ~sep:sp print_param) x.fun_params
+      Ident.pp_simpl (get_name x.fun_ls) (list ~sep:sp print_param) x.fun_params
       (fun f -> pp f ": %a" print_ty)
-      x.fun_ls.ls_value
+      (get_value x.fun_ls)
       (option (fun f -> pp f " =@\n@[<hov2>@[%a@]@]" print_term))
       x.fun_def (option func_spec) x.fun_spec
   in

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -481,7 +481,7 @@ let add_sig_contents muc sig_ =
   | Sig_val (({ vd_spec = Some { sp_pure = true; _ }; _ } as v), _) ->
       let tyl = List.map ty_of_lb_arg v.vd_args in
       let ty = ty_tuple (List.map ty_of_lb_arg v.vd_ret) in
-      let ls = lsymbol ~field:false v.vd_name tyl ty in
+      let ls = lsymbol ~constr:false ~field:false v.vd_name tyl ty in
       let muc = add_ls ~export:true muc ls.ls_name.id_str ls in
       add_kid muc ls.ls_name sig_
   | Sig_function f ->

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -57,15 +57,15 @@ let ns_add_ts ~allow_duplicate ns s ts =
 
 let ns_add_ls ~allow_duplicate:_ ns s ls =
   let ns_ls =
-    add ~allow_duplicate:true ~equal:ls_equal ~loc:ls.ls_name.id_loc ns.ns_ls s
-      ls
+    add ~allow_duplicate:true ~equal:ls_equal ~loc:(get_name ls).id_loc ns.ns_ls
+      s ls
   in
   { ns with ns_ls }
 
 let ns_add_fd ~allow_duplicate:_ ns s fd =
   let ns_fd =
-    add ~allow_duplicate:true ~equal:ls_equal ~loc:fd.ls_name.id_loc ns.ns_fd s
-      fd
+    add ~allow_duplicate:true ~equal:ls_equal ~loc:(get_name fd).id_loc ns.ns_fd
+      s fd
   in
   { ns with ns_fd }
 
@@ -266,7 +266,7 @@ let ns_with_primitives =
   Hts.add type_declarations ts_option td_option;
   Hts.add type_declarations ts_list td_list;
 
-  let primitive_ps = [ (ps_equ.ls_name.id_str, ps_equ) ] in
+  let primitive_ps = [ ((get_name ps_equ).id_str, ps_equ) ] in
   let primitive_ls =
     [
       (none.id_str, fs_option_none);
@@ -481,41 +481,37 @@ let add_sig_contents muc sig_ =
   | Sig_val (({ vd_spec = Some { sp_pure = true; _ }; _ } as v), _) ->
       let tyl = List.map ty_of_lb_arg v.vd_args in
       let ty = ty_tuple (List.map ty_of_lb_arg v.vd_ret) in
-      let ls = lsymbol ~constr:false ~field:false v.vd_name tyl ty in
-      let muc = add_ls ~export:true muc ls.ls_name.id_str ls in
-      add_kid muc ls.ls_name sig_
+      let ls = function_symbol v.vd_name tyl ty in
+      let muc = add_ls ~export:true muc (get_name ls).id_str ls in
+      add_kid muc (get_name ls) sig_
   | Sig_function f ->
-      let muc = add_ls ~export:true muc f.fun_ls.ls_name.id_str f.fun_ls in
+      let muc = add_ls ~export:true muc (get_name f.fun_ls).id_str f.fun_ls in
       let muc =
         match f.fun_spec with
         | Some spec when spec.fun_coer -> add_coer muc f.fun_ls
         | _ -> muc
       in
-      add_kid muc f.fun_ls.ls_name sig_
+      add_kid muc (get_name f.fun_ls) sig_
   | Sig_type (_, tdl, _) ->
       let add_td muc td =
         let s = (ts_ident td.td_ts).id_str in
         let muc = add_ts ~export:true muc s td.td_ts in
         let csl = get_cs_pjs td.td_kind in
-        let muc =
-          List.fold_left
-            (fun muc cs ->
-              (if cs.ls_field then add_fd else add_ls)
-                ~export:true muc cs.ls_name.id_str cs)
-            muc csl
+        let add muc x =
+          match x with
+          | Field_symbol { ls_name; _ } ->
+              add_fd ~export:true muc ls_name.id_str x
+          | Constructor_symbol { ls_name; _ } | Function_symbol { ls_name; _ }
+            ->
+              add_ls ~export:true muc ls_name.id_str x
         in
+        let muc = List.fold_left add muc csl in
         let fields =
           Option.fold ~none:[]
             ~some:(fun spec -> List.map fst spec.ty_fields)
             td.td_spec
         in
-        let muc =
-          List.fold_left
-            (fun muc ls ->
-              (if ls.ls_field then add_fd else add_ls)
-                ~export:true muc ls.ls_name.id_str ls)
-            muc fields
-        in
+        let muc = List.fold_left add muc fields in
         add_kid muc td.td_ts.ts_ident sig_
       in
       List.fold_left add_td muc tdl

--- a/src/tterm_helper.ml
+++ b/src/tterm_helper.ml
@@ -24,7 +24,7 @@ let ls_arg_inst ls tl =
   in
   short_fold_left2
     (fun tvm ty t -> ty_match tvm ty t.t_ty)
-    Mtv.empty ls.ls_args tl
+    Mtv.empty (get_args ls) tl
 
 let drop n xs =
   let rec aux n xs =
@@ -37,15 +37,16 @@ let drop n xs =
 
 let ls_app_inst ls tl ty =
   let s = ls_arg_inst ls tl in
-  let vty = ls.ls_value in
+  let vty = get_value ls in
   let vty =
     let ntl = List.length tl in
-    if ntl >= List.length ls.ls_args then vty
+    if ntl >= List.length (get_args ls) then vty
     else
       (* build the result type in case of a partial application *)
       List.fold_right
         (fun t1 t2 -> { ty_node = Tyapp (ts_arrow, [ t1; t2 ]) })
-        (drop ntl ls.ls_args) vty
+        (drop ntl (get_args ls))
+        vty
   in
   ty_match s vty ty
 

--- a/src/tterm_printer.ml
+++ b/src/tterm_printer.ml
@@ -17,7 +17,10 @@ open Fmt
 let print_vs fmt { vs_name; vs_ty } =
   pp fmt "@[%a:%a@]" Ident.pp_simpl vs_name print_ty vs_ty
 
-let print_ls_decl fmt { ls_name; ls_args; ls_value; _ } =
+let print_ls_decl fmt ls =
+  let ls_name = get_name ls
+  and ls_args = get_args ls
+  and ls_value = get_value ls in
   let is_pred = ty_equal ls_value ty_bool in
   let print_unnamed_arg fmt ty = pp fmt "(_:%a)" print_ty ty in
   pp fmt "%s %a %a:%a"
@@ -26,7 +29,7 @@ let print_ls_decl fmt { ls_name; ls_args; ls_value; _ } =
     (list ~sep:sp print_unnamed_arg)
     ls_args print_ty ls_value
 
-let print_ls_nm fmt { ls_name; _ } = pp fmt "%a" Ident.pp_simpl ls_name
+let print_ls_nm fmt ls = pp fmt "%a" Ident.pp_simpl (get_name ls)
 let protect_on x s = if x then "(" ^^ s ^^ ")" else s
 
 let rec print_pat_node pri fmt p =
@@ -73,18 +76,19 @@ let rec print_term fmt { t_node; t_ty; t_attrs; _ } =
     | Tvar vs ->
         pp fmt "%a" print_vs vs;
         assert (vs.vs_ty = t_ty) (* TODO remove this *)
-    | Tapp (ls, [ x1; x2 ]) when Identifier.is_infix ls.ls_name.id_str ->
+    | Tapp (ls, [ x1; x2 ]) when Identifier.is_infix (get_name ls).id_str ->
         let op_nm =
-          match String.split_on_char ' ' ls.ls_name.id_str with
+          match String.split_on_char ' ' (get_name ls).id_str with
           | [ x ] | [ _; x ] -> x
           | _ -> assert false
         in
         pp fmt "(%a %s %a)%a" print_term x1 op_nm print_term x2 print_ty t_ty
     | Tapp (ls, tl) ->
-        pp fmt "(%a %a)%a" Ident.pp_simpl ls.ls_name
+        pp fmt "(%a %a)%a" Ident.pp_simpl (get_name ls)
           (list ~first:sp ~sep:sp print_term)
           tl print_ty t_ty
-    | Tfield (t, ls) -> pp fmt "(%a).%a" print_term t Ident.pp_simpl ls.ls_name
+    | Tfield (t, ls) ->
+        pp fmt "(%a).%a" print_term t Ident.pp_simpl (get_name ls)
     | Tnot t -> pp fmt "not %a" print_term t
     | Tif (t1, t2, t3) ->
         pp fmt "if %a then %a else %a" print_term t1 print_term t2 print_term t3

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -585,7 +585,9 @@ let mutable_flag = function
 let process_type_spec kid crcm ns ty spec =
   let field (ns, fields) f =
     let f_ty = ty_of_pty ns f.f_pty in
-    let ls = fsymbol ~field:true (Ident.of_preid f.f_preid) [ ty ] f_ty in
+    let ls =
+      fsymbol ~constr:false ~field:true (Ident.of_preid f.f_preid) [ ty ] f_ty
+    in
     ( ns_add_fd ~allow_duplicate:true ns f.f_preid.pid_str ls,
       (ls, f.f_mutable) :: fields )
   in
@@ -683,7 +685,7 @@ let type_type_declaration path kid crcm ns r tdl =
       let mk_ld ld (ldl, ns) =
         let id = Ident.create ~path ~loc:ld.pld_loc ld.pld_name.txt in
         let ty_res = parse_core alias tvl ld.pld_type in
-        let field = fsymbol ~field:true id [ ty ] ty_res in
+        let field = fsymbol ~constr:false ~field:true id [ ty ] ty_res in
         let mut = mutable_flag ld.pld_mutable in
         let ld = label_declaration field mut ld.pld_loc ld.pld_attributes in
         (ld :: ldl, ns_add_fd ~allow_duplicate:true ns id.id_str field)
@@ -1068,7 +1070,11 @@ let process_function path kid crcm ns f =
   in
   let tyl = List.map (fun vs -> vs.vs_ty) params in
 
-  let ls = lsymbol ~field:false (Ident.of_preid ~path f.fun_name) tyl f_ty in
+  let ls =
+    lsymbol ~constr:false ~field:false
+      (Ident.of_preid ~path f.fun_name)
+      tyl f_ty
+  in
   let ns =
     if f.fun_rec then ns_add_ls ~allow_duplicate:true ns f.fun_name.pid_str ls
     else ns

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -586,7 +586,7 @@ let process_type_spec kid crcm ns ty spec =
   let field (ns, fields) f =
     let f_ty = ty_of_pty ns f.f_pty in
     let ls =
-      fsymbol ~constr:false ~field:true (Ident.of_preid f.f_preid) [ ty ] f_ty
+      lsymbol ~constr:false ~field:true (Ident.of_preid f.f_preid) [ ty ] f_ty
     in
     ( ns_add_fd ~allow_duplicate:true ns f.f_preid.pid_str ls,
       (ls, f.f_mutable) :: fields )
@@ -681,11 +681,11 @@ let type_type_declaration path kid crcm ns r tdl =
       let fields_ty =
         List.map (fun ld -> parse_core alias tvl ld.pld_type) ldl
       in
-      let rd_cs = fsymbol ~constr:true ~field:false cs_id fields_ty ty in
+      let rd_cs = lsymbol ~constr:true ~field:false cs_id fields_ty ty in
       let mk_ld ld (ldl, ns) =
         let id = Ident.create ~path ~loc:ld.pld_loc ld.pld_name.txt in
         let ty_res = parse_core alias tvl ld.pld_type in
-        let field = fsymbol ~constr:false ~field:true id [ ty ] ty_res in
+        let field = lsymbol ~constr:false ~field:true id [ ty ] ty_res in
         let mut = mutable_flag ld.pld_mutable in
         let ld = label_declaration field mut ld.pld_loc ld.pld_attributes in
         (ld :: ldl, ns_add_fd ~allow_duplicate:true ns id.id_str field)
@@ -703,14 +703,14 @@ let type_type_declaration path kid crcm ns r tdl =
         match cd.pcd_args with
         | Pcstr_tuple ctl ->
             let tyl = List.map (parse_core alias tvl) ctl in
-            let ls = fsymbol ~constr:true ~field:false cs_id tyl ty_res in
+            let ls = lsymbol ~constr:true ~field:false cs_id tyl ty_res in
             (ls, [], ns_add_ls ~allow_duplicate:true ns cs_id.id_str ls)
         | Pcstr_record ldl ->
             let add ld (ldl, tyl, ns) =
               let id = Ident.create ~path ~loc:ld.pld_loc ld.pld_name.txt in
               let ty = parse_core alias tvl ld.pld_type in
               let mut = mutable_flag ld.pld_mutable in
-              let field = fsymbol ~constr:false ~field:true id [ ty_res ] ty in
+              let field = lsymbol ~constr:false ~field:true id [ ty_res ] ty in
               let ld =
                 label_declaration (id, ty) mut ld.pld_loc ld.pld_attributes
               in
@@ -719,7 +719,7 @@ let type_type_declaration path kid crcm ns r tdl =
                 ns_add_fd ~allow_duplicate:true ns id.id_str field )
             in
             let ldl, tyl, ns = List.fold_right add ldl ([], [], ns) in
-            let cs = fsymbol ~constr:true ~field:false cs_id tyl ty_res in
+            let cs = lsymbol ~constr:true ~field:false cs_id tyl ty_res in
             let ns = ns_add_ls ~allow_duplicate:true ns cs_id.id_str cs in
             (cs, ldl, ns)
       in

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -152,9 +152,9 @@ let parse_record ~loc kid ns fll =
     | (fs, _) :: _ -> fs
   in
   let ts =
-    match fs.ls_args with
+    match get_args fs with
     | [ { ty_node = Tyapp (ts, _) } ] -> ts
-    | _ -> W.error ~loc (W.Bad_record_field fs.ls_name.id_str)
+    | _ -> W.error ~loc (W.Bad_record_field (get_name fs).id_str)
   in
   let cs, pjl = find_constructors kid ts in
   let pjs = Sls.of_list pjl in
@@ -162,9 +162,9 @@ let parse_record ~loc kid ns fll =
     List.fold_left
       (fun m (pj, v) ->
         if not (Sls.mem pj pjs) then
-          W.error ~loc (W.Bad_record_field pj.ls_name.id_str)
+          W.error ~loc (W.Bad_record_field (get_name pj).id_str)
         else if Mls.mem pj m then
-          W.error ~loc (Duplicated_record_field pj.ls_name.id_str)
+          W.error ~loc (Duplicated_record_field (get_name pj).id_str)
         else Mls.add pj v m)
       Mls.empty fll
   in
@@ -177,7 +177,7 @@ let rec dpattern kid ns { pat_desc; pat_loc = loc } =
   let mk_pwild loc dty = mk_dpattern ~loc DPwild dty Mstr.empty in
   let rec mk_papp ~loc cs dpl =
     let dtyl, dty = specialize_cs ~loc cs in
-    match (dpl, cs.ls_args) with
+    match (dpl, get_args cs) with
     (* allow pattern C (x,y) when the constructor C expects only one
        argument, which can be a tuple (such as ('a * 'b) option) *)
     | _ :: _ :: _, [ _ ] ->
@@ -249,7 +249,7 @@ let rec dpattern kid ns { pat_desc; pat_loc = loc } =
       let aux ls (patterns, missing) =
         match Mls.find_opt ls fields_pattern with
         | Some p -> (dpattern kid ns p :: patterns, missing)
-        | None -> (patterns, ls.ls_name.id_str :: missing)
+        | None -> (patterns, (get_name ls).id_str :: missing)
       in
       match List.fold_right aux fields_name ([], []) with
       | patterns, [] -> mk_papp ~loc cs patterns
@@ -298,7 +298,7 @@ let rec dterm whereami kid crcm ns denv { term_desc; term_loc = loc } : dterm =
     mk_dterm ~loc (DTapp (ls, dtl)) dty
   in
   let gen_app ~loc ls tl =
-    let nls = List.length ls.ls_args and ntl = List.length tl in
+    let nls = List.length (get_args ls) and ntl = List.length tl in
     let args, extra = split_at_i nls tl in
     let dtl = List.map (dterm whereami kid crcm ns denv) args in
     let dtyl, dty = specialize_ls ls in
@@ -320,23 +320,26 @@ let rec dterm whereami kid crcm ns denv { term_desc; term_loc = loc } : dterm =
     (* gen_app in two layers, to check that constructors are fully
        applied (and with the usual syntax) without enforcing this on
        functions *)
-    if ls.ls_constr then
-      let n = List.length ls.ls_args in
-      match tl with
-      | [ { term_desc = Ttuple tl; _ } ] when List.length tl = n ->
-          gen_app ~loc ls tl
-      | [ { term_desc = Ttuple tl; _ } ] when n > 1 ->
-          W.error ~loc (W.Bad_arity (ls.ls_name.id_str, n, List.length tl))
-      | _ when List.length tl < n ->
-          W.error ~loc (W.Partial_application ls.ls_name.id_str)
-      | _ :: _ :: _ when not (is_fs_tuple ls || ls_equal ls fs_list_cons) ->
-          W.error ~loc W.Syntax_error
-      | _ -> gen_app ~loc ls tl
-    else gen_app ~loc ls tl
+    match ls with
+    | Constructor_symbol { ls_name; ls_args; _ } -> (
+        let n = List.length ls_args in
+        match tl with
+        | [ { term_desc = Ttuple tl; _ } ] when List.length tl = n ->
+            gen_app ~loc ls tl
+        | [ { term_desc = Ttuple tl; _ } ] when n > 1 ->
+            W.error ~loc (W.Bad_arity (ls_name.id_str, n, List.length tl))
+        | _ when List.length tl < n ->
+            W.error ~loc (W.Partial_application ls_name.id_str)
+        | _ :: _ :: _ when not (is_fs_tuple ls || ls_equal ls fs_list_cons) ->
+            W.error ~loc W.Syntax_error
+        | _ -> gen_app ~loc ls tl)
+    | _ -> gen_app ~loc ls tl
   in
   let fun_app ~loc ls tl =
-    if ls.ls_field then W.error ~loc (W.Field_application ls.ls_name.id_str);
-    gen_app ~loc ls tl
+    match ls with
+    | Field_symbol { ls_name; _ } ->
+        W.error ~loc (W.Field_application ls_name.id_str)
+    | _ -> gen_app ~loc ls tl
   in
   let qualid_app q tl =
     match q with
@@ -377,17 +380,17 @@ let rec dterm whereami kid crcm ns denv { term_desc; term_loc = loc } : dterm =
   | Uast.Tpreid (Qpreid pid) when is_in_denv denv pid.pid_str ->
       let dty = denv_find ~loc:pid.pid_loc pid.pid_str denv in
       mk_dterm ~loc (DTvar pid) dty
-  | Uast.Tpreid q ->
+  | Uast.Tpreid q -> (
       (* in this case it must be a constant *)
-      let ls = find_q_ls ns q in
-      if ls.ls_field then
-        W.error ~loc (W.Symbol_not_found (string_list_of_qualid q));
-      gen_app ~loc ls []
-  | Uast.Tfield (t, q) ->
-      let ls = find_q_fd ns q in
-      if not ls.ls_field then
-        W.error ~loc (W.Bad_record_field ls.ls_name.id_str);
-      gen_app ~loc ls [ t ]
+      match find_q_ls ns q with
+      | Field_symbol _ ->
+          W.error ~loc (W.Symbol_not_found (string_list_of_qualid q))
+      | _ as ls -> gen_app ~loc ls [])
+  | Uast.Tfield (t, q) -> (
+      match find_q_fd ns q with
+      | Field_symbol _ as ls -> gen_app ~loc ls [ t ]
+      | Constructor_symbol { ls_name; _ } | Function_symbol { ls_name; _ } ->
+          W.error ~loc (W.Bad_record_field ls_name.id_str))
   | Uast.Tidapp (q, tl) -> qualid_app q tl
   | Uast.Tapply (t1, t2) -> unfold_app t1 t2 []
   | Uast.Tnot t ->
@@ -541,7 +544,7 @@ let rec dterm whereami kid crcm ns denv { term_desc; term_loc = loc } : dterm =
         | Some t ->
             let dt = dterm whereami kid crcm ns denv t in
             (dterm_expected crcm dt dty :: fields, missing)
-        | None -> (fields, ls.ls_name.id_str :: missing)
+        | None -> (fields, (get_name ls).id_str :: missing)
       in
       (* Uses [List.fold_right2] to keep fields in their order as records are
          transformed into applications. *)
@@ -585,9 +588,7 @@ let mutable_flag = function
 let process_type_spec kid crcm ns ty spec =
   let field (ns, fields) f =
     let f_ty = ty_of_pty ns f.f_pty in
-    let ls =
-      lsymbol ~constr:false ~field:true (Ident.of_preid f.f_preid) [ ty ] f_ty
-    in
+    let ls = field_symbol (Ident.of_preid f.f_preid) [ ty ] f_ty in
     ( ns_add_fd ~allow_duplicate:true ns f.f_preid.pid_str ls,
       (ls, f.f_mutable) :: fields )
   in
@@ -681,11 +682,11 @@ let type_type_declaration path kid crcm ns r tdl =
       let fields_ty =
         List.map (fun ld -> parse_core alias tvl ld.pld_type) ldl
       in
-      let rd_cs = lsymbol ~constr:true ~field:false cs_id fields_ty ty in
+      let rd_cs = constructor_symbol cs_id fields_ty ty in
       let mk_ld ld (ldl, ns) =
         let id = Ident.create ~path ~loc:ld.pld_loc ld.pld_name.txt in
         let ty_res = parse_core alias tvl ld.pld_type in
-        let field = lsymbol ~constr:false ~field:true id [ ty ] ty_res in
+        let field = field_symbol id [ ty ] ty_res in
         let mut = mutable_flag ld.pld_mutable in
         let ld = label_declaration field mut ld.pld_loc ld.pld_attributes in
         (ld :: ldl, ns_add_fd ~allow_duplicate:true ns id.id_str field)
@@ -703,14 +704,14 @@ let type_type_declaration path kid crcm ns r tdl =
         match cd.pcd_args with
         | Pcstr_tuple ctl ->
             let tyl = List.map (parse_core alias tvl) ctl in
-            let ls = lsymbol ~constr:true ~field:false cs_id tyl ty_res in
+            let ls = constructor_symbol cs_id tyl ty_res in
             (ls, [], ns_add_ls ~allow_duplicate:true ns cs_id.id_str ls)
         | Pcstr_record ldl ->
             let add ld (ldl, tyl, ns) =
               let id = Ident.create ~path ~loc:ld.pld_loc ld.pld_name.txt in
               let ty = parse_core alias tvl ld.pld_type in
               let mut = mutable_flag ld.pld_mutable in
-              let field = lsymbol ~constr:false ~field:true id [ ty_res ] ty in
+              let field = field_symbol id [ ty_res ] ty in
               let ld =
                 label_declaration (id, ty) mut ld.pld_loc ld.pld_attributes
               in
@@ -719,7 +720,7 @@ let type_type_declaration path kid crcm ns r tdl =
                 ns_add_fd ~allow_duplicate:true ns id.id_str field )
             in
             let ldl, tyl, ns = List.fold_right add ldl ([], [], ns) in
-            let cs = lsymbol ~constr:true ~field:false cs_id tyl ty_res in
+            let cs = constructor_symbol cs_id tyl ty_res in
             let ns = ns_add_ls ~allow_duplicate:true ns cs_id.id_str cs in
             (cs, ldl, ns)
       in
@@ -1070,11 +1071,7 @@ let process_function path kid crcm ns f =
   in
   let tyl = List.map (fun vs -> vs.vs_ty) params in
 
-  let ls =
-    lsymbol ~constr:false ~field:false
-      (Ident.of_preid ~path f.fun_name)
-      tyl f_ty
-  in
+  let ls = function_symbol (Ident.of_preid ~path f.fun_name) tyl f_ty in
   let ns =
     if f.fun_rec then ns_add_ls ~allow_duplicate:true ns f.fun_name.pid_str ls
     else ns

--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -21,6 +21,7 @@ type kind =
   | Functor_application of string
   | Illegal_character of char
   | Illegal_escape of string * string option
+  | Inlined_record_expected
   | Invalid_coercion_type of string
   | Invalid_int_literal of string * char option
   | Label_missing of string list
@@ -102,6 +103,8 @@ let pp_kind ppf = function
       pf ppf "Illegal backslash escape in string or character (%s)%a" s
         (option (fmt ": %s"))
         explanation
+  | Inlined_record_expected ->
+      pf ppf "This constructor expects an inlined record argument"
   | Invalid_coercion_type f ->
       pf ppf "The function %s does not have a valid coercion type" f
   | Invalid_int_literal (s, c) ->

--- a/src/warnings.ml
+++ b/src/warnings.ml
@@ -46,6 +46,7 @@ type kind =
   | Unbound_variable of string
   | Unsupported of string
   | Unterminated_comment
+  | Wrong_name of string * string
 
 type error = location * kind
 
@@ -162,6 +163,10 @@ let pp_kind ppf = function
       pf ppf "The variable %s does not appear in this pattern" s
   | Unsupported s -> pf ppf "Not yet supported: %s" s
   | Unterminated_comment -> pf ppf "Unterminated comment"
+  | Wrong_name (field, constr) ->
+      pf ppf
+        "The field %s is not part of the record argument for the constructor %s"
+        field constr
 
 let styled_list l pp = List.fold_left (fun acc x -> styled x acc) pp l
 

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -65,7 +65,7 @@ First, create a test artifact:
             td_spec =
             (Some { Tast.ty_ephemeral = true;
                     ty_fields =
-                    [({ Symbols.ls_name = contents;
+                    [(Symbols.Field_symbol {ls_name = contents;
                         ls_args =
                         [{ Ttypes.ty_node =
                            (Ttypes.Tyapp (
@@ -88,10 +88,9 @@ First, create a test artifact:
                                 (Ttypes.Tyvar { Ttypes.tv_name = a }) }
                                ]
                              ))
-                          };
-                        ls_constr = false; ls_field = true },
+                          }},
                       true);
-                      ({ Symbols.ls_name = size;
+                      (Symbols.Field_symbol {ls_name = size;
                          ls_args =
                          [{ Ttypes.ty_node =
                             (Ttypes.Tyapp (
@@ -110,8 +109,7 @@ First, create a test artifact:
                               { Ttypes.ts_ident = int; ts_args = [];
                                 ts_alias = None },
                               []))
-                           };
-                         ls_constr = false; ls_field = true },
+                           }},
                        false)
                       ];
                     ty_invariants = None;
@@ -185,7 +183,8 @@ First, create a test artifact:
                    sp_checks =
                    [{ Tterm.t_node =
                       (Tterm.Tapp (
-                         { Symbols.ls_name = Gospelstdlib.infix >=;
+                         Symbols.Function_symbol {
+                           ls_name = Gospelstdlib.infix >=;
                            ls_args =
                            [{ Ttypes.ty_node =
                               (Ttypes.Tyapp (
@@ -206,11 +205,11 @@ First, create a test artifact:
                                 { Ttypes.ts_ident = bool; ts_args = [];
                                   ts_alias = None },
                                 []))
-                             };
-                           ls_constr = false; ls_field = false },
+                             }},
                          [{ Tterm.t_node =
                             (Tterm.Tapp (
-                               { Symbols.ls_name = Gospelstdlib.integer_of_int;
+                               Symbols.Function_symbol {
+                                 ls_name = Gospelstdlib.integer_of_int;
                                  ls_args =
                                  [{ Ttypes.ty_node =
                                     (Ttypes.Tyapp (
@@ -225,8 +224,7 @@ First, create a test artifact:
                                       { Ttypes.ts_ident = integer;
                                         ts_args = []; ts_alias = None },
                                       []))
-                                   };
-                                 ls_constr = false; ls_field = false },
+                                   }},
                                [{ Tterm.t_node =
                                   (Tterm.Tvar
                                      { Symbols.vs_name = i;
@@ -279,7 +277,7 @@ First, create a test artifact:
                    sp_post =
                    [{ Tterm.t_node =
                       (Tterm.Tapp (
-                         { Symbols.ls_name = infix =;
+                         Symbols.Function_symbol {ls_name = infix =;
                            ls_args =
                            [{ Ttypes.ty_node =
                               (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) };
@@ -292,8 +290,7 @@ First, create a test artifact:
                                 { Ttypes.ts_ident = bool; ts_args = [];
                                   ts_alias = None },
                                 []))
-                             };
-                           ls_constr = false; ls_field = false },
+                             }},
                          [{ Tterm.t_node =
                             (Tterm.Tfield (
                                { Tterm.t_node =
@@ -326,7 +323,7 @@ First, create a test artifact:
                                       ))
                                    };
                                  t_attrs = []; t_loc = foo.mli:11:12 },
-                               { Symbols.ls_name = contents;
+                               Symbols.Field_symbol {ls_name = contents;
                                  ls_args =
                                  [{ Ttypes.ty_node =
                                     (Ttypes.Tyapp (
@@ -351,8 +348,7 @@ First, create a test artifact:
                                          }
                                         ]
                                       ))
-                                   };
-                                 ls_constr = false; ls_field = true }
+                                   }}
                                ));
                             t_ty =
                             { Ttypes.ty_node =
@@ -368,7 +364,8 @@ First, create a test artifact:
                             t_attrs = []; t_loc = foo.mli:11:12 };
                            { Tterm.t_node =
                              (Tterm.Tapp (
-                                { Symbols.ls_name = []; ls_args = [];
+                                Symbols.Constructor_symbol {ls_name = [];
+                                  ls_args = [];
                                   ls_value =
                                   { Ttypes.ty_node =
                                     (Ttypes.Tyapp (
@@ -381,8 +378,7 @@ First, create a test artifact:
                                           }
                                          ]
                                        ))
-                                    };
-                                  ls_constr = true; ls_field = false },
+                                    }},
                                 []));
                              t_ty =
                              { Ttypes.ty_node =
@@ -408,7 +404,7 @@ First, create a test artifact:
                       t_attrs = []; t_loc = foo.mli:11:12 };
                      { Tterm.t_node =
                        (Tterm.Tapp (
-                          { Symbols.ls_name = infix =;
+                          Symbols.Function_symbol {ls_name = infix =;
                             ls_args =
                             [{ Ttypes.ty_node =
                                (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) };
@@ -421,8 +417,7 @@ First, create a test artifact:
                                  { Ttypes.ts_ident = bool; ts_args = [];
                                    ts_alias = None },
                                  []))
-                              };
-                            ls_constr = false; ls_field = false },
+                              }},
                           [{ Tterm.t_node =
                              (Tterm.Tfield (
                                 { Tterm.t_node =
@@ -456,7 +451,7 @@ First, create a test artifact:
                                        ))
                                     };
                                   t_attrs = []; t_loc = foo.mli:12:12 },
-                                { Symbols.ls_name = size;
+                                Symbols.Field_symbol {ls_name = size;
                                   ls_args =
                                   [{ Ttypes.ty_node =
                                      (Ttypes.Tyapp (
@@ -476,8 +471,7 @@ First, create a test artifact:
                                        { Ttypes.ts_ident = int; ts_args = [];
                                          ts_alias = None },
                                        []))
-                                    };
-                                  ls_constr = false; ls_field = true }
+                                    }}
                                 ));
                              t_ty =
                              { Ttypes.ty_node =
@@ -542,7 +536,7 @@ First, create a test artifact:
     { Tast.sig_desc =
       (Tast.Sig_function
          { Tast.fun_ls =
-           { Symbols.ls_name = Foo.is_full;
+           Symbols.Function_symbol {ls_name = Foo.is_full;
              ls_args =
              [{ Ttypes.ty_node =
                 (Ttypes.Tyapp (
@@ -563,8 +557,7 @@ First, create a test artifact:
                (Ttypes.Tyapp (
                   { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None }, 
                   []))
-               };
-             ls_constr = false; ls_field = false };
+               }};
            fun_rec = false;
            fun_params =
            [{ Symbols.vs_name = xs;
@@ -590,7 +583,7 @@ First, create a test artifact:
            fun_def =
            (Some { Tterm.t_node =
                    (Tterm.Tapp (
-                      { Symbols.ls_name = infix =;
+                      Symbols.Function_symbol {ls_name = infix =;
                         ls_args =
                         [{ Ttypes.ty_node =
                            (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) };
@@ -603,11 +596,11 @@ First, create a test artifact:
                              { Ttypes.ts_ident = bool; ts_args = [];
                                ts_alias = None },
                              []))
-                          };
-                        ls_constr = false; ls_field = false },
+                          }},
                       [{ Tterm.t_node =
                          (Tterm.Tapp (
-                            { Symbols.ls_name = Gospelstdlib.List.length;
+                            Symbols.Function_symbol {
+                              ls_name = Gospelstdlib.List.length;
                               ls_args =
                               [{ Ttypes.ty_node =
                                  (Ttypes.Tyapp (
@@ -626,8 +619,7 @@ First, create a test artifact:
                                    { Ttypes.ts_ident = integer; ts_args = [];
                                      ts_alias = None },
                                    []))
-                                };
-                              ls_constr = false; ls_field = false },
+                                }},
                             [{ Tterm.t_node =
                                (Tterm.Tvar
                                   { Symbols.vs_name = xs;
@@ -704,7 +696,7 @@ First, create a test artifact:
     { Tast.sig_desc =
       (Tast.Sig_function
          { Tast.fun_ls =
-           { Symbols.ls_name = Foo.with_spec;
+           Symbols.Function_symbol {ls_name = Foo.with_spec;
              ls_args =
              [{ Ttypes.ty_node =
                 (Ttypes.Tyapp (
@@ -738,8 +730,7 @@ First, create a test artifact:
                      }
                     ]
                   ))
-               };
-             ls_constr = false; ls_field = false };
+               }};
            fun_rec = false;
            fun_params =
            [{ Symbols.vs_name = x_1;
@@ -774,7 +765,8 @@ First, create a test artifact:
                       (Tterm.Tnot
                          { Tterm.t_node =
                            (Tterm.Tapp (
-                              { Symbols.ls_name = Gospelstdlib.List.mem;
+                              Symbols.Function_symbol {
+                                ls_name = Gospelstdlib.List.mem;
                                 ls_args =
                                 [{ Ttypes.ty_node =
                                    (Ttypes.Tyvar { Ttypes.tv_name = a }) };
@@ -796,8 +788,7 @@ First, create a test artifact:
                                      { Ttypes.ts_ident = bool; ts_args = [];
                                        ts_alias = None },
                                      []))
-                                  };
-                                ls_constr = false; ls_field = false },
+                                  }},
                               [{ Tterm.t_node =
                                  (Tterm.Tvar
                                     { Symbols.vs_name = x_1;
@@ -895,7 +886,7 @@ First, create a test artifact:
     { Tast.sig_desc =
       (Tast.Sig_function
          { Tast.fun_ls =
-           { Symbols.ls_name = Foo.is_sorted_list;
+           Symbols.Function_symbol {ls_name = Foo.is_sorted_list;
              ls_args =
              [{ Ttypes.ty_node =
                 (Ttypes.Tyapp (
@@ -916,8 +907,7 @@ First, create a test artifact:
                (Ttypes.Tyapp (
                   { Ttypes.ts_ident = bool; ts_args = []; ts_alias = None }, 
                   []))
-               };
-             ls_constr = false; ls_field = false };
+               }};
            fun_rec = true;
            fun_params =
            [{ Symbols.vs_name = l;
@@ -979,7 +969,8 @@ First, create a test artifact:
                           (Tterm.Por (
                              { Tterm.p_node =
                                (Tterm.Papp (
-                                  { Symbols.ls_name = []; ls_args = [];
+                                  Symbols.Constructor_symbol {ls_name = [];
+                                    ls_args = [];
                                     ls_value =
                                     { Ttypes.ty_node =
                                       (Ttypes.Tyapp (
@@ -992,8 +983,7 @@ First, create a test artifact:
                                             }
                                            ]
                                          ))
-                                      };
-                                    ls_constr = true; ls_field = false },
+                                      }},
                                   []));
                                p_ty =
                                { Ttypes.ty_node =
@@ -1013,7 +1003,8 @@ First, create a test artifact:
                                p_loc = foo.mli:25:8 },
                              { Tterm.p_node =
                                (Tterm.Papp (
-                                  { Symbols.ls_name = infix ::;
+                                  Symbols.Constructor_symbol {
+                                    ls_name = infix ::;
                                     ls_args =
                                     [{ Ttypes.ty_node =
                                        (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
@@ -1044,8 +1035,7 @@ First, create a test artifact:
                                             }
                                            ]
                                          ))
-                                      };
-                                    ls_constr = true; ls_field = false },
+                                      }},
                                   [{ Tterm.p_node = Tterm.Pwild;
                                      p_ty =
                                      { Ttypes.ty_node =
@@ -1057,7 +1047,8 @@ First, create a test artifact:
                                      p_loc = foo.mli:25:13 };
                                     { Tterm.p_node =
                                       (Tterm.Papp (
-                                         { Symbols.ls_name = []; ls_args = [];
+                                         Symbols.Constructor_symbol {
+                                           ls_name = []; ls_args = [];
                                            ls_value =
                                            { Ttypes.ty_node =
                                              (Ttypes.Tyapp (
@@ -1071,8 +1062,7 @@ First, create a test artifact:
                                                    }
                                                   ]
                                                 ))
-                                             };
-                                           ls_constr = true; ls_field = false },
+                                             }},
                                          []));
                                       p_ty =
                                       { Ttypes.ty_node =
@@ -1139,7 +1129,7 @@ First, create a test artifact:
                           t_attrs = []; t_loc = foo.mli:25:24 });
                         ({ Tterm.p_node =
                            (Tterm.Papp (
-                              { Symbols.ls_name = infix ::;
+                              Symbols.Constructor_symbol {ls_name = infix ::;
                                 ls_args =
                                 [{ Ttypes.ty_node =
                                    (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) };
@@ -1167,8 +1157,7 @@ First, create a test artifact:
                                         }
                                        ]
                                      ))
-                                  };
-                                ls_constr = true; ls_field = false },
+                                  }},
                               [{ Tterm.p_node =
                                  (Tterm.Pvar
                                     { Symbols.vs_name = h;
@@ -1192,7 +1181,8 @@ First, create a test artifact:
                                   (Tterm.Pas (
                                      { Tterm.p_node =
                                        (Tterm.Papp (
-                                          { Symbols.ls_name = infix ::;
+                                          Symbols.Constructor_symbol {
+                                            ls_name = infix ::;
                                             ls_args =
                                             [{ Ttypes.ty_node =
                                                (Ttypes.Tyvar
@@ -1226,9 +1216,7 @@ First, create a test artifact:
                                                     }
                                                    ]
                                                  ))
-                                              };
-                                            ls_constr = true; ls_field = false
-                                            },
+                                              }},
                                           [{ Tterm.p_node =
                                              (Tterm.Pvar
                                                 { Symbols.vs_name = y;
@@ -1348,7 +1336,8 @@ First, create a test artifact:
                            (Tterm.Tbinop (Tterm.Tand,
                               { Tterm.t_node =
                                 (Tterm.Tapp (
-                                   { Symbols.ls_name = Gospelstdlib.infix <=;
+                                   Symbols.Function_symbol {
+                                     ls_name = Gospelstdlib.infix <=;
                                      ls_args =
                                      [{ Ttypes.ty_node =
                                         (Ttypes.Tyapp (
@@ -1369,11 +1358,11 @@ First, create a test artifact:
                                           { Ttypes.ts_ident = bool;
                                             ts_args = []; ts_alias = None },
                                           []))
-                                       };
-                                     ls_constr = false; ls_field = false },
+                                       }},
                                    [{ Tterm.t_node =
                                       (Tterm.Tapp (
-                                         { Symbols.ls_name =
+                                         Symbols.Function_symbol {
+                                           ls_name =
                                            Gospelstdlib.integer_of_int;
                                            ls_args =
                                            [{ Ttypes.ty_node =
@@ -1391,9 +1380,7 @@ First, create a test artifact:
                                                   ts_args = []; ts_alias = None
                                                   },
                                                 []))
-                                             };
-                                           ls_constr = false; ls_field = false
-                                           },
+                                             }},
                                          [{ Tterm.t_node =
                                             (Tterm.Tvar
                                                { Symbols.vs_name = h;
@@ -1428,7 +1415,8 @@ First, create a test artifact:
                                       t_attrs = []; t_loc = foo.mli:26:30 };
                                      { Tterm.t_node =
                                        (Tterm.Tapp (
-                                          { Symbols.ls_name =
+                                          Symbols.Function_symbol {
+                                            ls_name =
                                             Gospelstdlib.integer_of_int;
                                             ls_args =
                                             [{ Ttypes.ty_node =
@@ -1446,9 +1434,7 @@ First, create a test artifact:
                                                    ts_args = [];
                                                    ts_alias = None },
                                                  []))
-                                              };
-                                            ls_constr = false; ls_field = false
-                                            },
+                                              }},
                                           [{ Tterm.t_node =
                                              (Tterm.Tvar
                                                 { Symbols.vs_name = y;
@@ -1493,7 +1479,8 @@ First, create a test artifact:
                                 t_attrs = []; t_loc = foo.mli:26:30 },
                               { Tterm.t_node =
                                 (Tterm.Tapp (
-                                   { Symbols.ls_name = Foo.is_sorted_list;
+                                   Symbols.Function_symbol {
+                                     ls_name = Foo.is_sorted_list;
                                      ls_args =
                                      [{ Ttypes.ty_node =
                                         (Ttypes.Tyapp (
@@ -1518,8 +1505,7 @@ First, create a test artifact:
                                           { Ttypes.ts_ident = bool;
                                             ts_args = []; ts_alias = None },
                                           []))
-                                       };
-                                     ls_constr = false; ls_field = false },
+                                       }},
                                    [{ Tterm.t_node =
                                       (Tterm.Tvar
                                          { Symbols.vs_name = t_2;
@@ -1644,7 +1630,7 @@ First, create a test artifact:
                    sp_post =
                    [{ Tterm.t_node =
                       (Tterm.Tapp (
-                         { Symbols.ls_name = infix =;
+                         Symbols.Function_symbol {ls_name = infix =;
                            ls_args =
                            [{ Ttypes.ty_node =
                               (Ttypes.Tyvar { Ttypes.tv_name = a_2 }) };
@@ -1657,8 +1643,7 @@ First, create a test artifact:
                                 { Ttypes.ts_ident = bool; ts_args = [];
                                   ts_alias = None },
                                 []))
-                             };
-                           ls_constr = false; ls_field = false },
+                             }},
                          [{ Tterm.t_node =
                             (Tterm.Tfield (
                                { Tterm.t_node =
@@ -1691,7 +1676,7 @@ First, create a test artifact:
                                       ))
                                    };
                                  t_attrs = []; t_loc = foo.mli:32:12 },
-                               { Symbols.ls_name = contents;
+                               Symbols.Field_symbol {ls_name = contents;
                                  ls_args =
                                  [{ Ttypes.ty_node =
                                     (Ttypes.Tyapp (
@@ -1716,8 +1701,7 @@ First, create a test artifact:
                                          }
                                         ]
                                       ))
-                                   };
-                                 ls_constr = false; ls_field = true }
+                                   }}
                                ));
                             t_ty =
                             { Ttypes.ty_node =
@@ -1735,7 +1719,8 @@ First, create a test artifact:
                              (Tterm.Tif (
                                 { Tterm.t_node =
                                   (Tterm.Tapp (
-                                     { Symbols.ls_name = Foo.is_full;
+                                     Symbols.Function_symbol {
+                                       ls_name = Foo.is_full;
                                        ls_args =
                                        [{ Ttypes.ty_node =
                                           (Ttypes.Tyapp (
@@ -1763,8 +1748,7 @@ First, create a test artifact:
                                             { Ttypes.ts_ident = bool;
                                               ts_args = []; ts_alias = None },
                                             []))
-                                         };
-                                       ls_constr = false; ls_field = false },
+                                         }},
                                      [{ Tterm.t_node =
                                         (Tterm.Tfield (
                                            { Tterm.t_node =
@@ -1804,7 +1788,8 @@ First, create a test artifact:
                                                };
                                              t_attrs = [];
                                              t_loc = foo.mli:32:36 },
-                                           { Symbols.ls_name = contents;
+                                           Symbols.Field_symbol {
+                                             ls_name = contents;
                                              ls_args =
                                              [{ Ttypes.ty_node =
                                                 (Ttypes.Tyapp (
@@ -1833,9 +1818,7 @@ First, create a test artifact:
                                                      }
                                                     ]
                                                   ))
-                                               };
-                                             ls_constr = false; ls_field = true
-                                             }
+                                               }}
                                            ));
                                         t_ty =
                                         { Ttypes.ty_node =
@@ -1854,7 +1837,8 @@ First, create a test artifact:
                                         t_attrs = []; t_loc = foo.mli:32:36 };
                                        { Tterm.t_node =
                                          (Tterm.Tapp (
-                                            { Symbols.ls_name =
+                                            Symbols.Function_symbol {
+                                              ls_name =
                                               Gospelstdlib.integer_of_int;
                                               ls_args =
                                               [{ Ttypes.ty_node =
@@ -1872,9 +1856,7 @@ First, create a test artifact:
                                                      ts_args = [];
                                                      ts_alias = None },
                                                    []))
-                                                };
-                                              ls_constr = false;
-                                              ls_field = false },
+                                                }},
                                             [{ Tterm.t_node =
                                                (Tterm.Tfield (
                                                   { Tterm.t_node =
@@ -1919,7 +1901,8 @@ First, create a test artifact:
                                                       };
                                                     t_attrs = [];
                                                     t_loc = foo.mli:32:47 },
-                                                  { Symbols.ls_name = size;
+                                                  Symbols.Field_symbol {
+                                                    ls_name = size;
                                                     ls_args =
                                                     [{ Ttypes.ty_node =
                                                        (Ttypes.Tyapp (
@@ -1945,9 +1928,7 @@ First, create a test artifact:
                                                            int; ts_args = [];
                                                            ts_alias = None },
                                                          []))
-                                                      };
-                                                    ls_constr = false;
-                                                    ls_field = true }
+                                                      }}
                                                   ));
                                                t_ty =
                                                { Ttypes.ty_node =
@@ -2019,7 +2000,8 @@ First, create a test artifact:
                                               };
                                             t_attrs = []; t_loc = foo.mli:33:34
                                             },
-                                          { Symbols.ls_name = contents;
+                                          Symbols.Field_symbol {
+                                            ls_name = contents;
                                             ls_args =
                                             [{ Ttypes.ty_node =
                                                (Ttypes.Tyapp (
@@ -2048,9 +2030,7 @@ First, create a test artifact:
                                                     }
                                                    ]
                                                  ))
-                                              };
-                                            ls_constr = false; ls_field = true
-                                            }
+                                              }}
                                           ));
                                        t_ty =
                                        { Ttypes.ty_node =
@@ -2082,7 +2062,8 @@ First, create a test artifact:
                                   t_attrs = []; t_loc = foo.mli:33:30 },
                                 { Tterm.t_node =
                                   (Tterm.Tapp (
-                                     { Symbols.ls_name = infix ::;
+                                     Symbols.Constructor_symbol {
+                                       ls_name = infix ::;
                                        ls_args =
                                        [{ Ttypes.ty_node =
                                           (Ttypes.Tyvar
@@ -2115,8 +2096,7 @@ First, create a test artifact:
                                                }
                                               ]
                                             ))
-                                         };
-                                       ls_constr = true; ls_field = false },
+                                         }},
                                      [{ Tterm.t_node =
                                         (Tterm.Tvar
                                            { Symbols.vs_name = a_4;
@@ -2177,7 +2157,8 @@ First, create a test artifact:
                                                      };
                                                    t_attrs = [];
                                                    t_loc = foo.mli:34:40 },
-                                                 { Symbols.ls_name = contents;
+                                                 Symbols.Field_symbol {
+                                                   ls_name = contents;
                                                    ls_args =
                                                    [{ Ttypes.ty_node =
                                                       (Ttypes.Tyapp (
@@ -2213,9 +2194,7 @@ First, create a test artifact:
                                                            }
                                                           ]
                                                         ))
-                                                     };
-                                                   ls_constr = false;
-                                                   ls_field = true }
+                                                     }}
                                                  ));
                                               t_ty =
                                               { Ttypes.ty_node =
@@ -2318,7 +2297,7 @@ First, create a test artifact:
                                 ))
                              };
                            t_attrs = []; t_loc = foo.mli:30:13 },
-                         { Symbols.ls_name = contents;
+                         Symbols.Field_symbol {ls_name = contents;
                            ls_args =
                            [{ Ttypes.ty_node =
                               (Ttypes.Tyapp (
@@ -2341,8 +2320,7 @@ First, create a test artifact:
                                    (Ttypes.Tyvar { Ttypes.tv_name = a }) }
                                   ]
                                 ))
-                             };
-                           ls_constr = false; ls_field = true }
+                             }}
                          ));
                       t_ty =
                       { Ttypes.ty_node =

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -365,7 +365,7 @@ First, create a test artifact:
                            { Tterm.t_node =
                              (Tterm.Tapp (
                                 Symbols.Constructor_symbol {ls_name = [];
-                                  ls_args = [];
+                                  ls_args = (Symbols.Cstr_tuple []);
                                   ls_value =
                                   { Ttypes.ty_node =
                                     (Ttypes.Tyapp (
@@ -970,7 +970,7 @@ First, create a test artifact:
                              { Tterm.p_node =
                                (Tterm.Papp (
                                   Symbols.Constructor_symbol {ls_name = [];
-                                    ls_args = [];
+                                    ls_args = (Symbols.Cstr_tuple []);
                                     ls_value =
                                     { Ttypes.ty_node =
                                       (Ttypes.Tyapp (
@@ -1006,23 +1006,25 @@ First, create a test artifact:
                                   Symbols.Constructor_symbol {
                                     ls_name = infix ::;
                                     ls_args =
-                                    [{ Ttypes.ty_node =
-                                       (Ttypes.Tyvar { Ttypes.tv_name = a_1 })
-                                       };
-                                      { Ttypes.ty_node =
-                                        (Ttypes.Tyapp (
-                                           { Ttypes.ts_ident = list;
-                                             ts_args =
-                                             [{ Ttypes.tv_name = a_1 }];
-                                             ts_alias = None },
-                                           [{ Ttypes.ty_node =
-                                              (Ttypes.Tyvar
-                                                 { Ttypes.tv_name = a_1 })
-                                              }
-                                             ]
-                                           ))
-                                        }
-                                      ];
+                                    (Symbols.Cstr_tuple
+                                       [{ Ttypes.ty_node =
+                                          (Ttypes.Tyvar
+                                             { Ttypes.tv_name = a_1 })
+                                          };
+                                         { Ttypes.ty_node =
+                                           (Ttypes.Tyapp (
+                                              { Ttypes.ts_ident = list;
+                                                ts_args =
+                                                [{ Ttypes.tv_name = a_1 }];
+                                                ts_alias = None },
+                                              [{ Ttypes.ty_node =
+                                                 (Ttypes.Tyvar
+                                                    { Ttypes.tv_name = a_1 })
+                                                 }
+                                                ]
+                                              ))
+                                           }
+                                         ]);
                                     ls_value =
                                     { Ttypes.ty_node =
                                       (Ttypes.Tyapp (
@@ -1048,7 +1050,8 @@ First, create a test artifact:
                                     { Tterm.p_node =
                                       (Tterm.Papp (
                                          Symbols.Constructor_symbol {
-                                           ls_name = []; ls_args = [];
+                                           ls_name = [];
+                                           ls_args = (Symbols.Cstr_tuple []);
                                            ls_value =
                                            { Ttypes.ty_node =
                                              (Ttypes.Tyapp (
@@ -1131,21 +1134,23 @@ First, create a test artifact:
                            (Tterm.Papp (
                               Symbols.Constructor_symbol {ls_name = infix ::;
                                 ls_args =
-                                [{ Ttypes.ty_node =
-                                   (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) };
-                                  { Ttypes.ty_node =
-                                    (Ttypes.Tyapp (
-                                       { Ttypes.ts_ident = list;
-                                         ts_args = [{ Ttypes.tv_name = a_1 }];
-                                         ts_alias = None },
-                                       [{ Ttypes.ty_node =
-                                          (Ttypes.Tyvar
-                                             { Ttypes.tv_name = a_1 })
-                                          }
-                                         ]
-                                       ))
-                                    }
-                                  ];
+                                (Symbols.Cstr_tuple
+                                   [{ Ttypes.ty_node =
+                                      (Ttypes.Tyvar { Ttypes.tv_name = a_1 }) };
+                                     { Ttypes.ty_node =
+                                       (Ttypes.Tyapp (
+                                          { Ttypes.ts_ident = list;
+                                            ts_args =
+                                            [{ Ttypes.tv_name = a_1 }];
+                                            ts_alias = None },
+                                          [{ Ttypes.ty_node =
+                                             (Ttypes.Tyvar
+                                                { Ttypes.tv_name = a_1 })
+                                             }
+                                            ]
+                                          ))
+                                       }
+                                     ]);
                                 ls_value =
                                 { Ttypes.ty_node =
                                   (Ttypes.Tyapp (
@@ -1184,25 +1189,28 @@ First, create a test artifact:
                                           Symbols.Constructor_symbol {
                                             ls_name = infix ::;
                                             ls_args =
-                                            [{ Ttypes.ty_node =
-                                               (Ttypes.Tyvar
-                                                  { Ttypes.tv_name = a_1 })
-                                               };
-                                              { Ttypes.ty_node =
-                                                (Ttypes.Tyapp (
-                                                   { Ttypes.ts_ident = list;
-                                                     ts_args =
-                                                     [{ Ttypes.tv_name = a_1 }];
-                                                     ts_alias = None },
-                                                   [{ Ttypes.ty_node =
-                                                      (Ttypes.Tyvar
-                                                         { Ttypes.tv_name = a_1
-                                                           })
-                                                      }
-                                                     ]
-                                                   ))
-                                                }
-                                              ];
+                                            (Symbols.Cstr_tuple
+                                               [{ Ttypes.ty_node =
+                                                  (Ttypes.Tyvar
+                                                     { Ttypes.tv_name = a_1 })
+                                                  };
+                                                 { Ttypes.ty_node =
+                                                   (Ttypes.Tyapp (
+                                                      { Ttypes.ts_ident = list;
+                                                        ts_args =
+                                                        [{ Ttypes.tv_name = a_1
+                                                           }
+                                                          ];
+                                                        ts_alias = None },
+                                                      [{ Ttypes.ty_node =
+                                                         (Ttypes.Tyvar
+                                                            { Ttypes.tv_name =
+                                                              a_1 })
+                                                         }
+                                                        ]
+                                                      ))
+                                                   }
+                                                 ]);
                                             ls_value =
                                             { Ttypes.ty_node =
                                               (Ttypes.Tyapp (
@@ -2065,24 +2073,25 @@ First, create a test artifact:
                                      Symbols.Constructor_symbol {
                                        ls_name = infix ::;
                                        ls_args =
-                                       [{ Ttypes.ty_node =
-                                          (Ttypes.Tyvar
-                                             { Ttypes.tv_name = a_1 })
-                                          };
-                                         { Ttypes.ty_node =
-                                           (Ttypes.Tyapp (
-                                              { Ttypes.ts_ident = list;
-                                                ts_args =
-                                                [{ Ttypes.tv_name = a_1 }];
-                                                ts_alias = None },
-                                              [{ Ttypes.ty_node =
-                                                 (Ttypes.Tyvar
-                                                    { Ttypes.tv_name = a_1 })
-                                                 }
-                                                ]
-                                              ))
-                                           }
-                                         ];
+                                       (Symbols.Cstr_tuple
+                                          [{ Ttypes.ty_node =
+                                             (Ttypes.Tyvar
+                                                { Ttypes.tv_name = a_1 })
+                                             };
+                                            { Ttypes.ty_node =
+                                              (Ttypes.Tyapp (
+                                                 { Ttypes.ts_ident = list;
+                                                   ts_args =
+                                                   [{ Ttypes.tv_name = a_1 }];
+                                                   ts_alias = None },
+                                                 [{ Ttypes.ty_node =
+                                                    (Ttypes.Tyvar
+                                                       { Ttypes.tv_name = a_1 })
+                                                    }
+                                                   ]
+                                                 ))
+                                              }
+                                            ]);
                                        ls_value =
                                        { Ttypes.ty_node =
                                          (Ttypes.Tyapp (

--- a/test/typechecker/dune.inc
+++ b/test/typechecker/dune.inc
@@ -359,6 +359,27 @@
  (deps
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets inlined_record_missing_field.gospel)
+ (action
+  (with-outputs-to inlined_record_missing_field.mli.output
+   (run %{checker} %{dep:inlined_record_missing_field.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff inlined_record_missing_field.mli inlined_record_missing_field.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:inlined_record_missing_field.mli}))))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
  (targets inlined_record_unbound_field.gospel)
  (action
   (with-outputs-to inlined_record_unbound_field.mli.output

--- a/test/typechecker/dune.inc
+++ b/test/typechecker/dune.inc
@@ -359,6 +359,27 @@
  (deps
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets inlined_record_ill_typed.gospel)
+ (action
+  (with-outputs-to inlined_record_ill_typed.mli.output
+   (run %{checker} %{dep:inlined_record_ill_typed.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff inlined_record_ill_typed.mli inlined_record_ill_typed.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:inlined_record_ill_typed.mli}))))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
  (targets inlined_record_missing_field.gospel)
  (action
   (with-outputs-to inlined_record_missing_field.mli.output

--- a/test/typechecker/dune.inc
+++ b/test/typechecker/dune.inc
@@ -338,6 +338,27 @@
  (deps
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets inlined_record_expected.gospel)
+ (action
+  (with-outputs-to inlined_record_expected.mli.output
+   (run %{checker} %{dep:inlined_record_expected.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff inlined_record_expected.mli inlined_record_expected.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:inlined_record_expected.mli}))))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
  (targets int_not_bool1.gospel)
  (action
   (with-outputs-to int_not_bool1.mli.output

--- a/test/typechecker/dune.inc
+++ b/test/typechecker/dune.inc
@@ -359,6 +359,27 @@
  (deps
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets inlined_record_unbound_field.gospel)
+ (action
+  (with-outputs-to inlined_record_unbound_field.mli.output
+   (run %{checker} %{dep:inlined_record_unbound_field.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff inlined_record_unbound_field.mli inlined_record_unbound_field.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:inlined_record_unbound_field.mli}))))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
  (targets int_not_bool1.gospel)
  (action
   (with-outputs-to int_not_bool1.mli.output

--- a/test/typechecker/inlined_record_expected.mli
+++ b/test/typechecker/inlined_record_expected.mli
@@ -1,0 +1,4 @@
+(*@ type t = A of { b : bool } *)
+
+(*@ function f (b : bool) : t = A b *)
+(* The type-checker is expected to fail here *)

--- a/test/typechecker/inlined_record_expected.mli
+++ b/test/typechecker/inlined_record_expected.mli
@@ -2,3 +2,9 @@
 
 (*@ function f (b : bool) : t = A b *)
 (* The type-checker is expected to fail here *)
+(* {gospel_expected|
+   [125] File "inlined_record_expected.mli", line 3, characters 32-35:
+         3 | (*@ function f (b : bool) : t = A b *)
+                                             ^^^
+         Error: This constructor expects an inlined record argument.
+   |gospel_expected} *)

--- a/test/typechecker/inlined_record_ill_typed.mli
+++ b/test/typechecker/inlined_record_ill_typed.mli
@@ -1,0 +1,11 @@
+(*@ type t = A of { b : bool } *)
+
+(*@ function f (i : integer) : t = A { b = i }
+*)
+
+(* {gospel_expected|
+   [125] File "inlined_record_ill_typed.mli", line 3, characters 37-46:
+         3 | (*@ function f (i : integer) : t = A { b = i }
+                                                  ^^^^^^^^^
+         Error: Unbound record field: b.
+   |gospel_expected} *)

--- a/test/typechecker/inlined_record_ill_typed.mli
+++ b/test/typechecker/inlined_record_ill_typed.mli
@@ -4,8 +4,8 @@
 *)
 
 (* {gospel_expected|
-   [125] File "inlined_record_ill_typed.mli", line 3, characters 37-46:
+   [125] File "inlined_record_ill_typed.mli", line 3, characters 43-44:
          3 | (*@ function f (i : integer) : t = A { b = i }
-                                                  ^^^^^^^^^
-         Error: Unbound record field: b.
+                                                        ^
+         Error: This term has type integer but a term was expected of type bool.
    |gospel_expected} *)

--- a/test/typechecker/inlined_record_missing_field.mli
+++ b/test/typechecker/inlined_record_missing_field.mli
@@ -1,0 +1,9 @@
+(*@ type t = A of { a: bool; b : bool } *)
+
+(*@ function f (b : bool) : t = A { b; } *)
+(* {gospel_expected|
+   [125] File "inlined_record_missing_field.mli", line 3, characters 32-33:
+         3 | (*@ function f (b : bool) : t = A { b; } *)
+                                             ^
+         Error: The symbol A cannot be partially applied.
+   |gospel_expected} *)

--- a/test/typechecker/inlined_record_missing_field.mli
+++ b/test/typechecker/inlined_record_missing_field.mli
@@ -2,8 +2,8 @@
 
 (*@ function f (b : bool) : t = A { b; } *)
 (* {gospel_expected|
-   [125] File "inlined_record_missing_field.mli", line 3, characters 32-33:
+   [125] File "inlined_record_missing_field.mli", line 3, characters 32-40:
          3 | (*@ function f (b : bool) : t = A { b; } *)
-                                             ^
-         Error: The symbol A cannot be partially applied.
+                                             ^^^^^^^^
+         Error: Some record fields are undefined: a.
    |gospel_expected} *)

--- a/test/typechecker/inlined_record_unbound_field.mli
+++ b/test/typechecker/inlined_record_unbound_field.mli
@@ -1,0 +1,9 @@
+(*@ type t = A of { b : bool } *)
+
+(*@ function f (b : bool) : t = A { b; i = 42 } *)
+(* {gospel_expected|
+   [125] File "inlined_record_unbound_field.mli", line 3, characters 34-47:
+         3 | (*@ function f (b : bool) : t = A { b; i = 42 } *)
+                                               ^^^^^^^^^^^^^
+         Error: Unbound record field: b.
+   |gospel_expected} *)

--- a/test/typechecker/inlined_record_unbound_field.mli
+++ b/test/typechecker/inlined_record_unbound_field.mli
@@ -2,8 +2,8 @@
 
 (*@ function f (b : bool) : t = A { b; i = 42 } *)
 (* {gospel_expected|
-   [125] File "inlined_record_unbound_field.mli", line 3, characters 34-47:
+   [125] File "inlined_record_unbound_field.mli", line 3, characters 39-40:
          3 | (*@ function f (b : bool) : t = A { b; i = 42 } *)
-                                               ^^^^^^^^^^^^^
-         Error: Unbound record field: b.
+                                                    ^
+         Error: The field i is not part of the record argument for the constructor t.A.
    |gospel_expected} *)


### PR DESCRIPTION

This PR proposes to improve the state of the type-checker regarding expressions involving inlined records.

This work is based on previous, not yet merged, PRs, please consider only the last 12 commits.

The PR is organised in four steps:

- the first four commits add test cases, demonstrating the behaviour we propose to improve
- the next two commits add errors, borrowed from the OCaml compiler so that error messages are closer to OCaml ones
- the next four commits refactor the encoding of symbols, proposing:
  1. to rely on types rather than on boolean encoding to distinguish between fields, functions and constructors
  2. to encode whether a constructor expect a record argument or a tuple one (inspired by how OCaml deals with inlined records)
- the penultimate commit uses the new encoding of symbols to raise the proper errors when needed and build the correct value when possible.