### PR TITLE
Fix bug in creation of fresh type variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@
 
 ## Internals
 
+- Fix bug in creation of fresh type variables
+  [\#435](https://github.com/ocaml-gospel/gospel/pull/435)
 - Fix premature parsing of specification keywords in the preprocessor.
   [\#394](https://github.com/ocaml-gospel/gospel/pull/394)
 - Fix `ls_name` of `unit` logical symbol to be `()`

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -249,7 +249,7 @@ let ts_of_dty = function Some dt_dty -> ts_of_dty dt_dty | None -> ts_bool
 let rec ty_of_dty_raw = function
   | Tvar { dtv_def = Some (Tty ty); _ } -> ty
   | Tvar { dtv_def = Some dty; _ } -> ty_of_dty_raw dty
-  | Tvar _ -> fresh_ty_var ~loc:Location.none "xi"
+  | Tvar _ as ty -> ty_of_dty ty
   | Tapp (ts, dl) -> ty_app ts (List.map ty_of_dty_raw dl)
   | Tty ty -> ty
 

--- a/test/typechecker/dune.inc
+++ b/test/typechecker/dune.inc
@@ -1056,6 +1056,27 @@
  (deps
   %{bin:gospel}
   (:checker %{project_root}/test/utils/testchecker.exe))
+ (targets type_vars.gospel)
+ (action
+  (with-outputs-to type_vars.mli.output
+   (run %{checker} %{dep:type_vars.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff type_vars.mli type_vars.mli.output)))
+
+(rule
+ (alias test-cmis)
+ (action
+  (chdir %{project_root}
+   ; Syntax sanity check
+   (run ocamlc -c %{dep:type_vars.mli}))))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe))
  (targets value_incomplete_record.gospel)
  (action
   (with-outputs-to value_incomplete_record.mli.output

--- a/test/typechecker/type_vars.mli
+++ b/test/typechecker/type_vars.mli
@@ -1,0 +1,3 @@
+(*@ function f (f : 'a -> 'b) : 'a * 'b *)
+
+(*@ axiom test1 : forall x. f (fun _ -> x) = (x, x) *)


### PR DESCRIPTION
Happy Holidays!

I figured out the problem with the bug from [#431](https://github.com/ocaml-gospel/gospel/issues/431): when a fresh type
variable is created, it is "logged" into a hash table, using the
`ty_of_dty` function, that maps it into another type variable with a
unique name. However, there was one instance where we were creating
type variables without adding them to the hash table which was causing
problems when we ran the `ty_match` function (which I believe exists
only for integrity checking). This PR should fix this issue.
