### PR TITLE
AST node for application of arbitrary terms

### DIFF
--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -113,7 +113,8 @@ and dterm_node =
   | DTattr of dterm * string list
   | DTvar of Preid.t
   | DTconst of constant
-  | DTapp of lsymbol * dterm list
+  | DTapply of dterm * dterm list
+  | DTidapp of lsymbol * dterm list
   | DTif of dterm * dterm * dterm
   | DTlet of Preid.t * dterm * dterm
   | DTcase of dterm * (dpattern * dterm option * dterm) list
@@ -231,7 +232,7 @@ let apply_coercion l dt =
   let apply dt ls =
     let dtyl, dty = specialize_ls ls in
     dterm_unify dt (List.hd dtyl);
-    { dt_node = DTapp (ls, [ dt ]); dt_dty = Some dty; dt_loc = dt.dt_loc }
+    { dt_node = DTidapp (ls, [ dt ]); dt_dty = Some dty; dt_loc = dt.dt_loc }
   in
   List.fold_left apply dt l
 
@@ -339,15 +340,20 @@ and term_node ~loc env dty dterm_node =
       (* TODO should I match vs.vs_ty with dty? *)
       t_var vs loc
   | DTconst c -> t_const c (ty_of_dty (Option.get dty)) loc
-  | DTapp (ls, []) when ls_equal ls fs_bool_true -> t_true loc
-  | DTapp (ls, []) when ls_equal ls fs_bool_false -> t_false loc
-  | DTapp ((Field_symbol _ as ls), [ dt1 ]) ->
+  | DTidapp (ls, []) when ls_equal ls fs_bool_true -> t_true loc
+  | DTidapp (ls, []) when ls_equal ls fs_bool_false -> t_false loc
+  | DTidapp ((Field_symbol _ as ls), [ dt1 ]) ->
       t_field (term env dt1) ls
         (Option.fold ~some:ty_of_dty ~none:ty_bool dty)
         loc
-  | DTapp (ls, dtl) ->
+  | DTidapp (ls, dtl) ->
       t_ls ls
         (List.map (term env) dtl)
+        (Option.fold ~some:ty_of_dty ~none:ty_bool dty)
+        loc
+  | DTapply (t, tl) ->
+      t_app (term env t)
+        (List.map (term env) tl)
         (Option.fold ~some:ty_of_dty ~none:ty_bool dty)
         loc
   | DTif (dt1, dt2, dt3) ->

--- a/src/dterm.ml
+++ b/src/dterm.ml
@@ -346,7 +346,7 @@ and term_node ~loc env dty dterm_node =
         (Option.fold ~some:ty_of_dty ~none:ty_bool dty)
         loc
   | DTapp (ls, dtl) ->
-      t_app ls
+      t_ls ls
         (List.map (term env) dtl)
         (Option.fold ~some:ty_of_dty ~none:ty_bool dty)
         loc

--- a/src/dterm.mli
+++ b/src/dterm.mli
@@ -34,7 +34,8 @@ and dterm_node =
   | DTattr of dterm * string list
   | DTvar of Preid.t
   | DTconst of constant
-  | DTapp of lsymbol * dterm list
+  | DTapply of dterm * dterm list
+  | DTidapp of lsymbol * dterm list
   | DTif of dterm * dterm * dterm
   | DTlet of Preid.t * dterm * dterm
   | DTcase of dterm * (dpattern * dterm option * dterm) list

--- a/src/tterm.ml
+++ b/src/tterm.ml
@@ -57,7 +57,8 @@ type term = {
 and term_node =
   | Tvar of vsymbol
   | Tconst of constant [@printer fun fmt _ -> fprintf fmt "<constant>"]
-  | Tapp of lsymbol * term list
+  | Tapply of term * term list
+  | Tidapp of lsymbol * term list
   | Tfield of term * lsymbol
   | Tif of term * term * term
   | Tlet of vsymbol * term * term

--- a/src/tterm_helper.ml
+++ b/src/tterm_helper.ml
@@ -126,7 +126,7 @@ let t_var vs = mk_term (Tvar vs) vs.vs_ty
 let t_const c ty = mk_term (Tconst c) ty
 
 let t_app t tl ty loc =
-  let args, v = args_value ty in
+  let args, v = args_value t.t_ty in
   ignore (app_inst args v tl ty : ty Mtv.t);
   mk_term (Tapply (t, tl)) ty loc
 

--- a/src/tterm_helper.ml
+++ b/src/tterm_helper.ml
@@ -16,15 +16,13 @@ open Symbols
 module Ident = Identifier.Ident
 
 (** type checking *)
-let ls_arg_inst ls tl =
+let arg_inst args tl =
   let rec short_fold_left2 f accu l1 l2 =
     match (l1, l2) with
     | a1 :: l1, a2 :: l2 -> short_fold_left2 f (f accu a1 a2) l1 l2
     | _, _ -> accu
   in
-  short_fold_left2
-    (fun tvm ty t -> ty_match tvm ty t.t_ty)
-    Mtv.empty (get_args ls) tl
+  short_fold_left2 (fun tvm ty t -> ty_match tvm ty t.t_ty) Mtv.empty args tl
 
 let drop n xs =
   let rec aux n xs =
@@ -35,18 +33,23 @@ let drop n xs =
   in
   if n < 0 then invalid_arg "drop" else aux n xs
 
-let ls_app_inst ls tl ty =
-  let s = ls_arg_inst ls tl in
-  let vty = get_value ls in
+let rec args_value ty =
+  match ty.ty_node with
+  | Tyapp (ts, [ arg; t ]) when ts_equal ts ts_arrow ->
+      let args, v = args_value t in
+      (arg :: args, v)
+  | _ -> ([], ty)
+
+let app_inst args vty tl ty =
+  let s = arg_inst args tl in
   let vty =
     let ntl = List.length tl in
-    if ntl >= List.length (get_args ls) then vty
+    if ntl >= List.length args then vty
     else
       (* build the result type in case of a partial application *)
       List.fold_right
         (fun t1 t2 -> { ty_node = Tyapp (ts_arrow, [ t1; t2 ]) })
-        (drop ntl (get_args ls))
-        vty
+        (drop ntl args) vty
   in
   ty_match s vty ty
 
@@ -63,7 +66,11 @@ let rec t_free_vars t =
   match t.t_node with
   | Tvar vs -> Svs.singleton vs
   | Tconst _ -> Svs.empty
-  | Tapp (_, tl) ->
+  | Tapply (t, tl) ->
+      List.fold_left
+        (fun fvs t -> Svs.union (t_free_vars t) fvs)
+        (t_free_vars t) tl
+  | Tidapp (_, tl) ->
       List.fold_left (fun fvs t -> Svs.union (t_free_vars t) fvs) Svs.empty tl
   | Tfield (t, _) -> t_free_vars t
   | Tif (t1, t2, t3) ->
@@ -118,12 +125,17 @@ let mk_term t_node t_ty t_loc = { t_node; t_ty; t_attrs = []; t_loc }
 let t_var vs = mk_term (Tvar vs) vs.vs_ty
 let t_const c ty = mk_term (Tconst c) ty
 
-let t_app ls tl ty loc =
-  ignore (ls_app_inst ls tl ty : ty Mtv.t);
-  mk_term (Tapp (ls, tl)) ty loc
+let t_app t tl ty loc =
+  let args, v = args_value ty in
+  ignore (app_inst args v tl ty : ty Mtv.t);
+  mk_term (Tapply (t, tl)) ty loc
+
+let t_ls ls tl ty loc =
+  ignore (app_inst (get_args ls) (get_value ls) tl ty : ty Mtv.t);
+  mk_term (Tidapp (ls, tl)) ty loc
 
 let t_field t ls ty loc =
-  ignore (ls_app_inst ls [ t ] ty : ty Mtv.t);
+  ignore (app_inst (get_args ls) (get_value ls) [ t ] ty : ty Mtv.t);
   mk_term (Tfield (t, ls)) ty loc
 
 let t_if t1 t2 t3 = mk_term (Tif (t1, t2, t3)) t2.t_ty
@@ -142,9 +154,9 @@ let t_old t = mk_term (Told t) t.t_ty
 let t_true = mk_term Ttrue ty_bool
 let t_false = mk_term Tfalse ty_bool
 let t_attr_set attr t = { t with t_attrs = attr }
-let t_bool_true = mk_term (Tapp (fs_bool_true, [])) ty_bool
-let t_bool_false = mk_term (Tapp (fs_bool_false, [])) ty_bool
-let t_equ t1 t2 = t_app ps_equ [ t1; t2 ] ty_bool
+let t_bool_true = mk_term (Tidapp (fs_bool_true, [])) ty_bool
+let t_bool_false = mk_term (Tidapp (fs_bool_false, [])) ty_bool
+let t_equ t1 t2 = t_ls ps_equ [ t1; t2 ] ty_bool
 let t_neq t1 t2 loc = t_not (t_equ t1 t2 loc)
 let f_binop op f1 f2 = t_binop op f1 f2
 let f_not f = t_not f

--- a/src/tterm_helper.mli
+++ b/src/tterm_helper.mli
@@ -15,8 +15,8 @@ open Ttypes
 open Symbols
 
 val t_free_vars : Tterm.term -> Svs.t
-val ls_arg_inst : lsymbol -> term list -> ty Mtv.t
-val ls_app_inst : lsymbol -> term list -> ty -> ty Mtv.t
+val arg_inst : ty list -> term list -> ty Mtv.t
+val app_inst : ty list -> ty -> term list -> ty -> ty Mtv.t
 val mk_pattern : pattern_node -> ty -> Location.t -> pattern
 val p_wild : ty -> Location.t -> pattern
 val p_var : vsymbol -> Location.t -> pattern
@@ -28,7 +28,8 @@ val p_const : Parsetree.constant -> Location.t -> pattern
 val mk_term : term_node -> ty -> Location.t -> term
 val t_var : vsymbol -> Location.t -> term
 val t_const : constant -> ty -> Location.t -> term
-val t_app : lsymbol -> term list -> ty -> Location.t -> term
+val t_app : term -> term list -> ty -> Location.t -> term
+val t_ls : lsymbol -> term list -> ty -> Location.t -> term
 val t_field : term -> lsymbol -> ty -> Location.t -> term
 val t_if : term -> term -> term -> Location.t -> term
 val t_let : vsymbol -> term -> term -> Location.t -> term

--- a/src/tterm_printer.ml
+++ b/src/tterm_printer.ml
@@ -76,15 +76,19 @@ let rec print_term fmt { t_node; t_ty; t_attrs; _ } =
     | Tvar vs ->
         pp fmt "%a" print_vs vs;
         assert (vs.vs_ty = t_ty) (* TODO remove this *)
-    | Tapp (ls, [ x1; x2 ]) when Identifier.is_infix (get_name ls).id_str ->
+    | Tidapp (ls, [ x1; x2 ]) when Identifier.is_infix (get_name ls).id_str ->
         let op_nm =
           match String.split_on_char ' ' (get_name ls).id_str with
           | [ x ] | [ _; x ] -> x
           | _ -> assert false
         in
         pp fmt "(%a %s %a)%a" print_term x1 op_nm print_term x2 print_ty t_ty
-    | Tapp (ls, tl) ->
+    | Tidapp (ls, tl) ->
         pp fmt "(%a %a)%a" Ident.pp_simpl (get_name ls)
+          (list ~first:sp ~sep:sp print_term)
+          tl print_ty t_ty
+    | Tapply (t, tl) ->
+        pp fmt "(%a %a)%a" print_term t
           (list ~first:sp ~sep:sp print_term)
           tl print_ty t_ty
     | Tfield (t, ls) ->

--- a/test/locations/test_location.t
+++ b/test/locations/test_location.t
@@ -182,7 +182,7 @@ First, create a test artifact:
                    sp_pre = [];
                    sp_checks =
                    [{ Tterm.t_node =
-                      (Tterm.Tapp (
+                      (Tterm.Tidapp (
                          Symbols.Function_symbol {
                            ls_name = Gospelstdlib.infix >=;
                            ls_args =
@@ -207,7 +207,7 @@ First, create a test artifact:
                                 []))
                              }},
                          [{ Tterm.t_node =
-                            (Tterm.Tapp (
+                            (Tterm.Tidapp (
                                Symbols.Function_symbol {
                                  ls_name = Gospelstdlib.integer_of_int;
                                  ls_args =
@@ -276,7 +276,7 @@ First, create a test artifact:
                      ];
                    sp_post =
                    [{ Tterm.t_node =
-                      (Tterm.Tapp (
+                      (Tterm.Tidapp (
                          Symbols.Function_symbol {ls_name = infix =;
                            ls_args =
                            [{ Ttypes.ty_node =
@@ -363,7 +363,7 @@ First, create a test artifact:
                               };
                             t_attrs = []; t_loc = foo.mli:11:12 };
                            { Tterm.t_node =
-                             (Tterm.Tapp (
+                             (Tterm.Tidapp (
                                 Symbols.Constructor_symbol {ls_name = [];
                                   ls_args = (Symbols.Cstr_tuple []);
                                   ls_value =
@@ -403,7 +403,7 @@ First, create a test artifact:
                         };
                       t_attrs = []; t_loc = foo.mli:11:12 };
                      { Tterm.t_node =
-                       (Tterm.Tapp (
+                       (Tterm.Tidapp (
                           Symbols.Function_symbol {ls_name = infix =;
                             ls_args =
                             [{ Ttypes.ty_node =
@@ -582,7 +582,7 @@ First, create a test artifact:
              ];
            fun_def =
            (Some { Tterm.t_node =
-                   (Tterm.Tapp (
+                   (Tterm.Tidapp (
                       Symbols.Function_symbol {ls_name = infix =;
                         ls_args =
                         [{ Ttypes.ty_node =
@@ -598,7 +598,7 @@ First, create a test artifact:
                              []))
                           }},
                       [{ Tterm.t_node =
-                         (Tterm.Tapp (
+                         (Tterm.Tidapp (
                             Symbols.Function_symbol {
                               ls_name = Gospelstdlib.Sequence.length;
                               ls_args =
@@ -621,7 +621,7 @@ First, create a test artifact:
                                    []))
                                 }},
                             [{ Tterm.t_node =
-                               (Tterm.Tapp (
+                               (Tterm.Tidapp (
                                   Symbols.Function_symbol {
                                     ls_name = Gospelstdlib.of_list;
                                     ls_args =
@@ -814,7 +814,7 @@ First, create a test artifact:
                    [{ Tterm.t_node =
                       (Tterm.Tnot
                          { Tterm.t_node =
-                           (Tterm.Tapp (
+                           (Tterm.Tidapp (
                               Symbols.Function_symbol {
                                 ls_name = Gospelstdlib.Sequence.mem;
                                 ls_args =
@@ -859,7 +859,7 @@ First, create a test artifact:
                                    };
                                  t_attrs = []; t_loc = foo.mli:21:31 };
                                 { Tterm.t_node =
-                                  (Tterm.Tapp (
+                                  (Tterm.Tidapp (
                                      Symbols.Function_symbol {
                                        ls_name = Gospelstdlib.of_list;
                                        ls_args =
@@ -1447,7 +1447,7 @@ First, create a test artifact:
                          { Tterm.t_node =
                            (Tterm.Tbinop (Tterm.Tand,
                               { Tterm.t_node =
-                                (Tterm.Tapp (
+                                (Tterm.Tidapp (
                                    Symbols.Function_symbol {
                                      ls_name = Gospelstdlib.infix <=;
                                      ls_args =
@@ -1472,7 +1472,7 @@ First, create a test artifact:
                                           []))
                                        }},
                                    [{ Tterm.t_node =
-                                      (Tterm.Tapp (
+                                      (Tterm.Tidapp (
                                          Symbols.Function_symbol {
                                            ls_name =
                                            Gospelstdlib.integer_of_int;
@@ -1526,7 +1526,7 @@ First, create a test artifact:
                                         };
                                       t_attrs = []; t_loc = foo.mli:26:30 };
                                      { Tterm.t_node =
-                                       (Tterm.Tapp (
+                                       (Tterm.Tidapp (
                                           Symbols.Function_symbol {
                                             ls_name =
                                             Gospelstdlib.integer_of_int;
@@ -1590,7 +1590,7 @@ First, create a test artifact:
                                   };
                                 t_attrs = []; t_loc = foo.mli:26:30 },
                               { Tterm.t_node =
-                                (Tterm.Tapp (
+                                (Tterm.Tidapp (
                                    Symbols.Function_symbol {
                                      ls_name = Foo.is_sorted_list;
                                      ls_args =
@@ -1741,7 +1741,7 @@ First, create a test artifact:
                    sp_ret = []; sp_pre = []; sp_checks = [];
                    sp_post =
                    [{ Tterm.t_node =
-                      (Tterm.Tapp (
+                      (Tterm.Tidapp (
                          Symbols.Function_symbol {ls_name = infix =;
                            ls_args =
                            [{ Ttypes.ty_node =
@@ -1830,7 +1830,7 @@ First, create a test artifact:
                            { Tterm.t_node =
                              (Tterm.Tif (
                                 { Tterm.t_node =
-                                  (Tterm.Tapp (
+                                  (Tterm.Tidapp (
                                      Symbols.Function_symbol {
                                        ls_name = Foo.is_full;
                                        ls_args =
@@ -1948,7 +1948,7 @@ First, create a test artifact:
                                           };
                                         t_attrs = []; t_loc = foo.mli:32:36 };
                                        { Tterm.t_node =
-                                         (Tterm.Tapp (
+                                         (Tterm.Tidapp (
                                             Symbols.Function_symbol {
                                               ls_name =
                                               Gospelstdlib.integer_of_int;
@@ -2173,7 +2173,7 @@ First, create a test artifact:
                                     };
                                   t_attrs = []; t_loc = foo.mli:33:30 },
                                 { Tterm.t_node =
-                                  (Tterm.Tapp (
+                                  (Tterm.Tidapp (
                                      Symbols.Constructor_symbol {
                                        ls_name = infix ::;
                                        ls_args =


### PR DESCRIPTION
Hello

As mentioned in [#430](https://github.com/ocaml-gospel/gospel/issues/430), Gospel injects `fs_apply` when applying function
terms that are not simple names. This pull request adds a dedicated
AST node `Tapply` for arbitrary function terms and changes the name of
the current AST node for named function application to `Tidapp`.
