### PR TITLE
Fix bug on change log Github action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,9 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: git diff
       env:
         BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        ! git diff --exit-code origin/$BASE_REF -- CHANGES.md
+        ! git diff --exit-code remotes/origin/$BASE_REF -- CHANGES.md


### PR DESCRIPTION
Hello

This PR fixes the bug in the git action for the change log where
running git diff resulted in a "bad revision" error. This bug was
introduced in [bf39b4b](https://github.com/ocaml-gospel/gospel/commit/bf39b4b1824050409f4ad6b7b4e16b81845324d1) when the version of the `checkout` git hub action
was set to 4.
