### PR TITLE
Add documentation and refactor Tmodule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 
 - Check for repeated name of module and module types
   [\#444](https://github.com/ocaml-gospel/gospel/pull/444)
+- Add documentation and refactor Tmodule
+  [\#442](https://github.com/ocaml-gospel/gospel/pull/442)
 - Fix bug in creation of fresh type variables
   [\#435](https://github.com/ocaml-gospel/gospel/pull/435)
 - Fix typing of pattern with inlined record

--- a/bin/dumpast.ml
+++ b/bin/dumpast.ml
@@ -27,7 +27,7 @@ let run_file { load_path } file =
     let module_nm = path2module file in
     let sigs = parse_gospel ~filename:file ocaml module_nm in
     let file = type_check load_path file sigs in
-    Fmt.pf Fmt.stdout "%s\n" (Tast.show_signature file.fl_sigs);
+    Fmt.pf Fmt.stdout "%s\n" (Tast.show_signature (get_file_signature file));
     true
   with W.Error e ->
     Fmt.epr "%a@." W.pp e;

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -386,7 +386,7 @@ let open_empty_module muc s =
 
 let close_module_file muc =
   match (muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs) with
-  | _ :: i1 :: il, e0 :: e1 :: el, p0 :: pl, s0 :: sl ->
+  | _ :: i1 :: il, e0 :: el, p0 :: pl, s0 :: sl ->
       let file =
         {
           fl_nm = Ident.create ~loc:Location.none p0;
@@ -398,7 +398,7 @@ let close_module_file muc =
         muc with
         muc_prefix = pl;
         muc_import = ns_add_ns ~allow_duplicate:true i1 p0 e0 :: il;
-        muc_export = e1 :: el;
+        muc_export = el;
         muc_sigs = sl;
         muc_files = Mstr.add p0 file muc.muc_files;
       }
@@ -432,12 +432,12 @@ let close_module muc =
 (* for functor arguments *)
 let close_module_functor muc =
   match (muc.muc_import, muc.muc_export, muc.muc_prefix, muc.muc_sigs) with
-  | _ :: i1 :: il, e0 :: e1 :: el, p0 :: pl, _ :: sl ->
+  | _ :: i1 :: il, e0 :: el, p0 :: pl, _ :: sl ->
       {
         muc with
         muc_prefix = pl;
         muc_import = ns_add_ns ~allow_duplicate:true i1 p0 e0 :: il;
-        muc_export = e1 :: el;
+        muc_export = el;
         muc_sigs = sl;
       }
   | _ -> assert false
@@ -583,8 +583,6 @@ and print_ns nm fmt { ns_ts; ns_ls; ns_fd; ns_xs; ns_ns; ns_tns } =
     (print_mstr_vals print_ls_decl)
     ns_fd (print_mstr_vals print_xs) ns_xs print_nested_ns ns_ns print_nested_ns
     ns_tns
-(* (tree_ns (fun ns -> ns.ns_ns)) ns_ns
- * (tree_ns (fun ns -> ns.ns_tns)) ns_tns *)
 
 let print_file fmt { fl_nm; fl_sigs; fl_export } =
   pp fmt "@[module %a@\n@[<h2>@\n%a@\n@[<hv2>Signatures@\n%a@]@]@]@."

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -279,6 +279,9 @@ module Mid = Map.Make (Ident)
 type known_ids = signature_item Mid.t
 type file = { fl_nm : Ident.t; fl_sigs : signature; fl_export : namespace }
 
+let get_file_export file = file.fl_export
+let get_file_signature file = file.fl_sigs
+
 type module_uc = {
   muc_nm : Ident.t;
   muc_file : string;

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -81,18 +81,6 @@ let ns_add_ns ~allow_duplicate:_ ns s new_ns =
 let ns_add_tns ~allow_duplicate:_ ns s tns =
   { ns with ns_tns = Mstr.add s tns ns.ns_tns }
 
-let merge_ns from_ns to_ns =
-  let choose_fst _ x _ = Some x in
-  let union m1 m2 = Mstr.union choose_fst m1 m2 in
-  {
-    ns_ts = union from_ns.ns_ts to_ns.ns_ts;
-    ns_ls = union from_ns.ns_ls to_ns.ns_ls;
-    ns_fd = union from_ns.ns_fd to_ns.ns_fd;
-    ns_xs = union from_ns.ns_xs to_ns.ns_xs;
-    ns_ns = union from_ns.ns_ns to_ns.ns_ns;
-    ns_tns = union from_ns.ns_tns to_ns.ns_tns;
-  }
-
 let rec ns_find get_map ns = function
   | [] -> assert false
   | [ x ] -> Mstr.find x (get_map ns)
@@ -318,7 +306,6 @@ let add_fd ?(export = false) = muc_add ~export ns_add_fd
 let add_xs ?(export = false) = muc_add ~export ns_add_xs
 let add_ns ?(export = false) = muc_add ~export ns_add_ns
 let add_tns ?(export = false) = muc_add ~export ns_add_tns
-let add_file muc s file = { muc with muc_files = Mstr.add s file muc.muc_files }
 let get_file muc s = Mstr.find s muc.muc_files
 let add_kid muc id s = { muc with muc_kid = Mid.add id s muc.muc_kid }
 
@@ -465,9 +452,6 @@ let get_top_sigs muc =
 let get_top_import muc =
   match muc.muc_import with i0 :: _ -> i0 | _ -> assert false
 
-let get_top_export muc =
-  match muc.muc_export with e0 :: _ -> e0 | _ -> assert false
-
 let add_sig_contents muc sig_ =
   let muc = add_sig muc sig_ in
   let get_cs_pjs = function
@@ -560,15 +544,6 @@ let wrap_up_muc (muc : module_uc) =
 
 open Utils.Fmt
 open Tast_printer
-
-let rec tree_ns f fmt ns =
-  Mstr.iter
-    (fun s ns ->
-      if f ns = Mstr.empty then pp fmt "@[%s@\n@]" s
-      else pp fmt "@[%s:@\n@ @[%a@]@\n@]" s (tree_ns f) (f ns))
-    ns
-
-let ns_names nsm = List.map fst (Mstr.bindings nsm)
 
 let print_mstr_vals printer fmt m =
   let print_elem e = pp fmt "@[%a@]@\n" printer e in

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -292,6 +292,10 @@ type module_uc = {
   muc_crcm : Coercion.t;
 }
 
+let get_module_name muc = muc.muc_nm
+let get_known_ids muc = muc.muc_kid
+let get_coercions muc = muc.muc_crcm
+
 let muc_add ?(export = false) add muc s x =
   match (muc.muc_import, muc.muc_export) with
   | i0 :: il, e0 :: el ->

--- a/src/tmodule.ml
+++ b/src/tmodule.ml
@@ -24,12 +24,14 @@ let type_declarations : type_declaration Hts.t = Hts.create 0
 module Mstr = Map.Make (String)
 
 type namespace = {
-  ns_ts : tysymbol Mstr.t;
+  ns_ts : tysymbol Mstr.t; (* type symbol namespace *)
   ns_ls : lsymbol Mstr.t;
+      (* logical symbol - data constructors and functions - namespace *)
   ns_fd : lsymbol Mstr.t;
-  ns_xs : xsymbol Mstr.t;
-  ns_ns : namespace Mstr.t;
-  ns_tns : namespace Mstr.t;
+      (* logical symbal - records fields and logical model - namespace *)
+  ns_xs : xsymbol Mstr.t; (* exception symbols namespace *)
+  ns_ns : namespace Mstr.t; (* module declaration namespace *)
+  ns_tns : namespace Mstr.t; (* module type namespace *)
 }
 
 let empty_ns =

--- a/src/tmodule.mli
+++ b/src/tmodule.mli
@@ -1,0 +1,63 @@
+open Tast
+module Mid : Map.S with type key = Ident.t
+module Mstr : Map.S with type key = string
+
+type namespace
+type known_ids = signature_item Mid.t
+type file = { fl_nm : Ident.t; fl_sigs : signature; fl_export : namespace }
+
+type module_uc = {
+  muc_nm : Ident.t;
+  muc_file : string;
+  muc_sigs : signature list;
+  muc_prefix : string list;
+  (* essential when closing namespaces *)
+  muc_import : namespace list;
+  muc_export : namespace list;
+  muc_files : file Mstr.t;
+  muc_kid : known_ids;
+  muc_crcm : Coercion.t;
+}
+
+val empty_ns : namespace
+val type_declarations : type_declaration Ttypes.Hts.t
+val ns_exists_ns : namespace -> string -> bool
+val ns_exists_tns : namespace -> string -> bool
+val ns_find_ts : namespace -> string list -> Ttypes.tysymbol
+val ns_find_ls : namespace -> string list -> Symbols.lsymbol
+val ns_find_fd : namespace -> string list -> Symbols.lsymbol
+val ns_find_xs : namespace -> string list -> Ttypes.xsymbol
+val ns_find_ns : namespace -> string list -> namespace
+val ns_find_tns : namespace -> string list -> namespace
+
+val ns_add_ls :
+  allow_duplicate:bool -> namespace -> string -> Symbols.lsymbol -> namespace
+
+val ns_add_fd :
+  allow_duplicate:bool -> namespace -> string -> Symbols.lsymbol -> namespace
+
+val add_ns : ?export:bool -> module_uc -> string -> namespace -> module_uc
+val add_ns_top : ?export:bool -> module_uc -> namespace -> module_uc
+val init_muc : string -> module_uc
+val open_empty_module : module_uc -> string -> module_uc
+val close_module_file : module_uc -> module_uc
+val open_module : module_uc -> string -> module_uc
+val close_module_functor : module_uc -> module_uc
+val close_module : module_uc -> module_uc
+val close_module_type : module_uc -> module_uc
+val add_sig_contents : module_uc -> Tast.signature_item -> module_uc
+val get_top_import : module_uc -> namespace
+val get_top_sigs : module_uc -> signature
+val muc_replace_ts : module_uc -> Ttypes.tysymbol -> string list -> module_uc
+val muc_rm_ts : module_uc -> string list -> module_uc
+val muc_subst_ts : module_uc -> Ttypes.tysymbol -> Ttypes.tysymbol -> module_uc
+
+val muc_subst_ty :
+  module_uc -> Ttypes.tysymbol -> Ttypes.tysymbol -> Ttypes.ty -> module_uc
+
+val get_file : module_uc -> string -> file
+val wrap_up_muc : module_uc -> file
+val read_gospel_file : string -> module_uc
+val path2module : string -> string
+val print_file : file Fmt.t
+val write_gospel_file : module_uc -> unit

--- a/src/tmodule.mli
+++ b/src/tmodule.mli
@@ -4,7 +4,7 @@ module Mstr : Map.S with type key = string
 
 type namespace
 type known_ids = signature_item Mid.t
-type file = { fl_nm : Ident.t; fl_sigs : signature; fl_export : namespace }
+type file
 type module_uc
 
 val empty_ns : namespace
@@ -46,6 +46,8 @@ val muc_subst_ts : module_uc -> Ttypes.tysymbol -> Ttypes.tysymbol -> module_uc
 val muc_subst_ty :
   module_uc -> Ttypes.tysymbol -> Ttypes.tysymbol -> Ttypes.ty -> module_uc
 
+val get_file_export : file -> namespace
+val get_file_signature : file -> Tast.signature
 val get_file : module_uc -> string -> file
 val wrap_up_muc : module_uc -> file
 val read_gospel_file : string -> module_uc

--- a/src/tmodule.mli
+++ b/src/tmodule.mli
@@ -5,19 +5,7 @@ module Mstr : Map.S with type key = string
 type namespace
 type known_ids = signature_item Mid.t
 type file = { fl_nm : Ident.t; fl_sigs : signature; fl_export : namespace }
-
-type module_uc = {
-  muc_nm : Ident.t;
-  muc_file : string;
-  muc_sigs : signature list;
-  muc_prefix : string list;
-  (* essential when closing namespaces *)
-  muc_import : namespace list;
-  muc_export : namespace list;
-  muc_files : file Mstr.t;
-  muc_kid : known_ids;
-  muc_crcm : Coercion.t;
-}
+type module_uc
 
 val empty_ns : namespace
 val type_declarations : type_declaration Ttypes.Hts.t
@@ -48,6 +36,9 @@ val close_module_type : module_uc -> module_uc
 val add_sig_contents : module_uc -> Tast.signature_item -> module_uc
 val get_top_import : module_uc -> namespace
 val get_top_sigs : module_uc -> signature
+val get_module_name : module_uc -> Ident.t
+val get_known_ids : module_uc -> known_ids
+val get_coercions : module_uc -> Coercion.t
 val muc_replace_ts : module_uc -> Ttypes.tysymbol -> string list -> module_uc
 val muc_rm_ts : module_uc -> string list -> module_uc
 val muc_subst_ts : module_uc -> Ttypes.tysymbol -> Ttypes.tysymbol -> module_uc

--- a/src/tmodule.mli
+++ b/src/tmodule.mli
@@ -8,40 +8,121 @@ type file
 type module_uc
 
 val empty_ns : namespace
+(** The empty namespace *)
+
 val type_declarations : type_declaration Ttypes.Hts.t
 val ns_exists_ns : namespace -> string -> bool
 val ns_exists_tns : namespace -> string -> bool
+
 val ns_find_ts : namespace -> string list -> Ttypes.tysymbol
+(** [ns_find_ts ns path] find the type symbol mapped to [path].
+
+    @raise Not_found *)
+
 val ns_find_ls : namespace -> string list -> Symbols.lsymbol
+(** [ns_find_ls ns path] find the logical symbol representing a data constructor
+    or a function mapped to [path].
+
+    @raise Not_found *)
+
 val ns_find_fd : namespace -> string list -> Symbols.lsymbol
+(** [ns_find_fd ns path] find the logical symbol representing a record's field
+    or a logical model mapped to [path].
+
+    @raise Not_found *)
+
 val ns_find_xs : namespace -> string list -> Ttypes.xsymbol
+(** [ns_find_xs ns path] find the exception symbol mapped to [path].
+
+    @raise Not_found *)
+
 val ns_find_ns : namespace -> string list -> namespace
+(** [ns_find_ns ns path] find the namespace mapped to [path]. The namespace
+    corresponds to a module declaration.
+
+    @raise Not_found *)
+
 val ns_find_tns : namespace -> string list -> namespace
+(** [ns_find_tns ns path] find the namespace mapped to [path]. The namespace
+    corresponds to a module type definition.
+
+    @raise Not_found *)
 
 val ns_add_ls :
   allow_duplicate:bool -> namespace -> string -> Symbols.lsymbol -> namespace
+(** [ns_add_ls ~allow_duplicate ns id ls] adds a mapping from [id] to [ls] in
+    [nm]. This is used both for data constructors and functions. Note that
+    [allow_duplicate] is overrided to [true] allowing name shadowing for data
+    constructors and functions.*)
 
 val ns_add_fd :
   allow_duplicate:bool -> namespace -> string -> Symbols.lsymbol -> namespace
+(** [ns_add_fd ~allow_duplicate ns id ls] adds a mapping from [id] to [ls] in
+    [nm]. This is used for record's fields and logical models. Note that
+    [allow_duplicate] is overrided to [true] allowing name shadowing for records
+    fields and logical models. *)
 
 val add_ns : ?export:bool -> module_uc -> string -> namespace -> module_uc
+(** [add_ns ~export muc id ns] adds a mapping from [id] to [ns] in the import
+    list of [muc]. If [export] then it also adds the mapping to the export list.
+    Default value for [export] is [false].*)
+
 val add_ns_top : ?export:bool -> module_uc -> namespace -> module_uc
+(** [add_ns_top ~export muc ns] adds all the mapping from [ns] to the import
+    list of [muc]. If [export] then it also adds the mappings to the export
+    list. Default value for [export] is [false].*)
+
 val init_muc : string -> module_uc
-val open_empty_module : module_uc -> string -> module_uc
-val close_module_file : module_uc -> module_uc
+(** [init_muc name] creates a new module under construction containing only
+    built-ins elements. *)
+
 val open_module : module_uc -> string -> module_uc
-val close_module_functor : module_uc -> module_uc
+(** [open_module muc name] opens a sub-module [name] in [muc]. *)
+
+val open_empty_module : module_uc -> string -> module_uc
+(** [open_empty_module muc name] opens a new empty module [name] to be filled in
+    [muc]. *)
+
 val close_module : module_uc -> module_uc
+(** [close_module muc] closes the last opened module in [muc]. Adds the
+    namespace correponding to the closed module declaration to the import and
+    export lists. *)
+
+val close_module_functor : module_uc -> module_uc
+(** [close_module_functor muc] closes the last opened module in [muc]. Intended
+    to be used for functor arguments. Adds the namespace corresponding to the
+    closed module to the import list. *)
+
 val close_module_type : module_uc -> module_uc
+(** [close_module_type muc] closes the last opened module in [muc]. Adds the
+    namespace correponding to the closed module type to the import and export
+    lists. *)
+
+val close_module_file : module_uc -> module_uc
+(** [close_module_file muc] closes the last opened module in [muc] and add it as
+    a [file]. Adds the namespace corresponding to the closed module to the
+    import list. *)
+
 val add_sig_contents : module_uc -> Tast.signature_item -> module_uc
+(** [add_sig_contents muc item] adds [item] to [muc] *)
+
 val get_top_import : module_uc -> namespace
 val get_top_sigs : module_uc -> signature
 val get_module_name : module_uc -> Ident.t
 val get_known_ids : module_uc -> known_ids
 val get_coercions : module_uc -> Coercion.t
+
 val muc_replace_ts : module_uc -> Ttypes.tysymbol -> string list -> module_uc
+(** [muc_replace_ts muc new_ts path] replaces the [tysymbol] mapped to [path]
+    with [new_ts] in the tip of the import and export lists. *)
+
 val muc_rm_ts : module_uc -> string list -> module_uc
+(** [muc_rm_ts muc path] removes the mapping from [path] to a type symbol in the
+    top of the import and export lists. *)
+
 val muc_subst_ts : module_uc -> Ttypes.tysymbol -> Ttypes.tysymbol -> module_uc
+(** [muc_subst_ts old_ts new_ts] substitutes all the occurences of [old_ts] with
+    [new_ts] in the top of the import and export lists. *)
 
 val muc_subst_ty :
   module_uc -> Ttypes.tysymbol -> Ttypes.tysymbol -> Ttypes.ty -> module_uc

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -1377,8 +1377,8 @@ and process_modtype path penv muc umty =
         match c with
         | Wtype (lid, tyd) ->
             let tdl =
-              type_type_declaration path muc.muc_kid muc.muc_crcm ns_init
-                Nonrecursive [ tyd ]
+              type_type_declaration path (get_known_ids muc) (get_coercions muc)
+                ns_init Nonrecursive [ tyd ]
             in
             let td = match tdl with [ td ] -> td | _ -> assert false in
             let q = flatten_exn lid in
@@ -1402,8 +1402,8 @@ and process_modtype path penv muc umty =
             (muc, Wty (ts.ts_ident, td) :: cl)
         | Wtypesubst (lid, tyd) ->
             let tdl =
-              type_type_declaration path muc.muc_kid muc.muc_crcm ns_init
-                Nonrecursive [ tyd ]
+              type_type_declaration path (get_known_ids muc) (get_coercions muc)
+                ns_init Nonrecursive [ tyd ]
             in
             let td = match tdl with [ td ] -> td | _ -> assert false in
             let ty =
@@ -1504,7 +1504,9 @@ and process_modtype_decl path penv loc decl muc =
 
 and process_sig_item path penv muc { sdesc; sloc } =
   let process_sig_item si muc =
-    let kid, ns, crcm = (muc.muc_kid, get_top_import muc, muc.muc_crcm) in
+    let kid, ns, crcm =
+      (get_known_ids muc, get_top_import muc, get_coercions muc)
+    in
     match si with
     | Uast.Sig_type (r, tdl) ->
         (muc, process_sig_type path ~loc:sloc kid crcm ns r tdl)
@@ -1550,4 +1552,4 @@ and type_sig_item path penv muc sig_item =
   muc
 
 let type_sig_item penv muc sig_item =
-  type_sig_item [ muc.muc_nm.id_str ] penv muc sig_item
+  type_sig_item [ (get_module_name muc).id_str ] penv muc sig_item

--- a/src/typing.ml
+++ b/src/typing.ml
@@ -1296,7 +1296,7 @@ let penv lpaths parsing =
 
 let rec open_file ~loc penv muc nm =
   if Sstr.mem nm penv.parsing then W.error ~loc W.Circular_open;
-  try add_ns ~export:true muc nm (get_file muc nm).fl_export
+  try add_ns ~export:true muc nm (get_file muc nm |> get_file_export)
   with Not_found ->
     let file_nm = nm ^ ".mli" in
     let file_nm =


### PR DESCRIPTION
This PR adds an interface file for Tmodule, documents the less trivial parts
and remove unused code.

It becomes quite clear that the abstraction provided by Tmodule is not perfect,
but improvement of it is left to a future PR.
