### PR TITLE
Add test for conditional in terms

### DIFF
--- a/test/typechecking/terms/conditional.mli
+++ b/test/typechecking/terms/conditional.mli
@@ -1,0 +1,11 @@
+(*@ function hd_opt (s : 'a sequence) : 'a option =
+      if s = Sequence.empty
+      then None
+      else Some (Sequence.hd s) *)
+(* {gospel_expected|
+[1] File "conditional.mli", line 2, characters 9-27:
+    2 |       if s = Sequence.empty
+                 ^^^^^^^^^^^^^^^^^^
+    Error: Mismatch between type bool and type prop
+    
+|gospel_expected} *)

--- a/test/typechecking/terms/dune.inc
+++ b/test/typechecking/terms/dune.inc
@@ -7,6 +7,20 @@
   (:checker %{project_root}/test/utils/testchecker.exe)
        _gospel)
  (action
+  (with-outputs-to conditional.mli.output
+   (run %{checker} %{dep:conditional.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff conditional.mli conditional.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
   (with-outputs-to ho1.mli.output
    (run %{checker} %{dep:ho1.mli}))))
 


### PR DESCRIPTION
An equality test has type `prop` but `Solver.has_type` asks for the condition of an if-then-else construct to have type `bool`.