### PR TITLE
Add test for function returning an option

### DIFF
--- a/test/typechecking/val_specs/dune.inc
+++ b/test/typechecking/val_specs/dune.inc
@@ -273,6 +273,20 @@
   (:checker %{project_root}/test/utils/testchecker.exe)
        _gospel)
  (action
+  (with-outputs-to return_option.mli.output
+   (run %{checker} %{dep:return_option.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff return_option.mli return_option.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
   (with-outputs-to valid_exn_match.mli.output
    (run %{checker} %{dep:valid_exn_match.mli}))))
 

--- a/test/typechecking/val_specs/return_option.mli
+++ b/test/typechecking/val_specs/return_option.mli
@@ -1,0 +1,9 @@
+val f : int -> int option
+(*@ o = f i *)
+(* {gospel_expected|
+[1] File "return_option.mli", line 1, characters 19-25:
+    1 | val f : int -> int option
+                           ^^^^^^
+    Error: Unbound type constructor option
+    
+|gospel_expected} *)


### PR DESCRIPTION
Test is failing, complaining to don't know about `option` type constructor.