### PR TITLE
Improve behaviour regarding unsupported constructs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
 
 ## Improved
 
+- Improve how unsupported OCaml constructs are handled
+  [\#468](https://github.com/ocaml-gospel/gospel/pull/468)
 - Fix filename for `check_file` output
   [\#478](https://github.com/ocaml-gospel/gospel/pull/478)
 - Add `option` as an OCaml primitive type constructor

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 
 ## Improved
 
+- Improve how unsupported OCaml constructs are handled
+  [\#468](https://github.com/ocaml-gospel/gospel/pull/468)
 - Fix filename for `check_file` output
   [\#478](https://github.com/ocaml-gospel/gospel/pull/478)
 - Add `option` as an OCaml primitive type constructor

--- a/src/uattr2spec.ml
+++ b/src/uattr2spec.ml
@@ -74,6 +74,8 @@ let rec preid_of_long (loc : location) (s : longident) =
   | Ldot (id, s) -> Qdot (preid_of_long id, Preid.create ~loc s)
   | _ -> assert false
 
+exception Unsupported
+
 let rec core_to_pty cty =
   let loc = cty.ptyp_loc in
   match cty.ptyp_desc with
@@ -82,7 +84,7 @@ let rec core_to_pty cty =
       PTtyapp (preid_of_long id.loc id.txt, List.map core_to_pty l)
   | Ptyp_arrow (_, t1, t2) -> PTarrow (core_to_pty t1, core_to_pty t2)
   | Ptyp_tuple l -> PTtuple (List.map core_to_pty l)
-  | _ -> assert false (* TODO replace with unsupported*)
+  | _ -> raise Unsupported
 
 let ptype_kind = function
   | Ptype_abstract -> PTtype_abstract
@@ -99,15 +101,22 @@ let ptype_kind = function
         }
       in
       PTtype_record (List.map to_gospel_label l)
-  | _ -> assert false
+  | _ -> raise Unsupported
+
+let core_to_pty cty =
+  try Option.some @@ core_to_pty cty with Unsupported -> None
+
+let ptype_kind tk = try Option.some @@ ptype_kind tk with Unsupported -> None
 
 let mk_tdecl t attrs spec =
-  let* tparams = params_to_id t.ptype_params in
+  let* tparams = params_to_id t.ptype_params
+  and* tkind = ptype_kind t.ptype_kind in
+  let tmanifest = Option.bind t.ptype_manifest core_to_pty in
   {
     tname = preid_of_loc t.ptype_name;
     tparams;
-    tkind = ptype_kind t.ptype_kind;
-    tmanifest = Option.map core_to_pty t.ptype_manifest;
+    tkind;
+    tmanifest;
     tattributes = attrs;
     tspec = spec;
     tloc = t.ptype_loc;
@@ -131,9 +140,10 @@ let val_description ~filename v =
     { spec with sp_text; sp_loc }
   in
   let spec = Option.map parse spec_attr in
+  let* vtype = core_to_pty v.pval_type in
   {
     vname = preid_of_loc v.pval_name;
-    vtype = core_to_pty v.pval_type;
+    vtype;
     vattributes = other_attrs;
     vspec = spec;
     vloc = v.pval_loc;
@@ -148,9 +158,9 @@ let sig_exception exn =
   let exn_id = preid_of_loc c.pext_name in
   let exn_loc = c.pext_loc in
   let exn_attributes = c.pext_attributes in
-  let exn_args =
+  let* exn_args =
     match c.pext_kind with
-    | Pext_decl ([], Pcstr_tuple args, _) -> List.map core_to_pty args
+    | Pext_decl ([], Pcstr_tuple args, _) -> map_option core_to_pty args
     | Pext_rebind _ -> assert false (* Cannot occur on an interface file. *)
     | _ -> assert false
   in
@@ -162,8 +172,8 @@ let sig_exception exn =
 *)
 let rec signature_item_desc ~filename = function
   | Psig_value v ->
-      let v = val_description ~filename v in
-      Some (Sig_val v)
+      let* v = val_description ~filename v in
+      Sig_val v
   | Psig_type (_, tl) ->
       let* tl = map_option (type_declaration ~filename) tl in
       Sig_type tl
@@ -173,7 +183,9 @@ let rec signature_item_desc ~filename = function
   | Psig_module m ->
       let* decl = module_declaration ~filename m in
       Sig_module decl
-  | Psig_exception e -> Some (Sig_exception (sig_exception e))
+  | Psig_exception e ->
+      let* exn = sig_exception e in
+      Sig_exception exn
   (* Unsupported *)
   | Psig_recmodule _ -> None
   | Psig_modtype _ -> None

--- a/src/uattr2spec.ml
+++ b/src/uattr2spec.ml
@@ -113,15 +113,32 @@ let ptype_kind ~loc = function
   | Ptype_variant _ -> raise @@ Unsupported ("variant type", loc)
 
 let core_to_pty cty =
-  try Option.some @@ core_to_pty cty with Unsupported _ -> None
+  try Result.ok @@ core_to_pty cty with Unsupported info -> Result.Error info
 
 let ptype_kind ~loc tk =
-  try Option.some @@ ptype_kind ~loc tk with Unsupported _ -> None
+  try Result.ok @@ ptype_kind ~loc tk
+  with Unsupported info -> Result.Error info
+
+let unwrap_unsupported opt res =
+  match res with
+  | Ok x -> Some x (* the construction is supported *)
+  | Error (str, loc) ->
+      (* the construction is unsupported, raise an error if there are some
+         specifications attached to it, ignore it otherwise *)
+      if Option.is_some opt then W.(error ~loc (Unsupported str)) else None
+
+let unwrap_core_to_pty spec_opt cty =
+  unwrap_unsupported spec_opt (core_to_pty cty)
+
+let unwrap_ptyp_kind ~loc spec_opt tk =
+  unwrap_unsupported spec_opt (ptype_kind ~loc tk)
 
 let mk_tdecl t attrs spec =
   let* tparams = params_to_id t.ptype_params
-  and* tkind = ptype_kind ~loc:t.ptype_loc t.ptype_kind in
-  let tmanifest = Option.bind t.ptype_manifest core_to_pty in
+  and* tkind = unwrap_ptyp_kind ~loc:t.ptype_loc spec t.ptype_kind in
+  let tmanifest =
+    Option.(join @@ map (unwrap_core_to_pty spec) t.ptype_manifest)
+  in
   {
     tname = preid_of_loc t.ptype_name;
     tparams;
@@ -150,7 +167,7 @@ let val_description ~filename v =
     { spec with sp_text; sp_loc }
   in
   let spec = Option.map parse spec_attr in
-  let* vtype = core_to_pty v.pval_type in
+  let* vtype = unwrap_core_to_pty spec v.pval_type in
   {
     vname = preid_of_loc v.pval_name;
     vtype;
@@ -170,7 +187,9 @@ let sig_exception exn =
   let exn_attributes = c.pext_attributes in
   let* exn_args =
     match c.pext_kind with
-    | Pext_decl ([], Pcstr_tuple args, _) -> map_option core_to_pty args
+    | Pext_decl ([], Pcstr_tuple args, _) ->
+        (* Exception specification is not supported *)
+        map_option (unwrap_core_to_pty None) args
     | Pext_rebind _ -> assert false (* Cannot occur on an interface file. *)
     | _ -> assert false
   in

--- a/src/uattr2spec.ml
+++ b/src/uattr2spec.ml
@@ -74,7 +74,7 @@ let rec preid_of_long (loc : location) (s : longident) =
   | Ldot (id, s) -> Qdot (preid_of_long id, Preid.create ~loc s)
   | _ -> assert false
 
-exception Unsupported
+exception Unsupported of (string * Location.t)
 
 let rec core_to_pty cty =
   let loc = cty.ptyp_loc in
@@ -84,9 +84,17 @@ let rec core_to_pty cty =
       PTtyapp (preid_of_long id.loc id.txt, List.map core_to_pty l)
   | Ptyp_arrow (_, t1, t2) -> PTarrow (core_to_pty t1, core_to_pty t2)
   | Ptyp_tuple l -> PTtuple (List.map core_to_pty l)
-  | _ -> raise Unsupported
+  | Ptyp_open (_, _) -> raise @@ Unsupported ("local open", loc)
+  | Ptyp_any -> raise @@ Unsupported ("type parameter wild pattern", loc)
+  | Ptyp_object _ -> raise @@ Unsupported ("object", loc)
+  | Ptyp_class _ -> raise @@ Unsupported ("class", loc)
+  | Ptyp_alias _ -> raise @@ Unsupported ("type alias", loc)
+  | Ptyp_variant _ -> raise @@ Unsupported ("polymorphic variant", loc)
+  | Ptyp_poly _ -> raise @@ Unsupported ("polymorhic type variable", loc)
+  | Ptyp_package _ -> raise @@ Unsupported ("first class module", loc)
+  | Ptyp_extension _ -> raise @@ Unsupported ("extension point", loc)
 
-let ptype_kind = function
+let ptype_kind ~loc = function
   | Ptype_abstract -> PTtype_abstract
   | Ptype_record l ->
       let to_gospel_label l =
@@ -101,16 +109,18 @@ let ptype_kind = function
         }
       in
       PTtype_record (List.map to_gospel_label l)
-  | _ -> raise Unsupported
+  | Ptype_open -> raise @@ Unsupported ("extensible type", loc)
+  | Ptype_variant _ -> raise @@ Unsupported ("variant type", loc)
 
 let core_to_pty cty =
-  try Option.some @@ core_to_pty cty with Unsupported -> None
+  try Option.some @@ core_to_pty cty with Unsupported _ -> None
 
-let ptype_kind tk = try Option.some @@ ptype_kind tk with Unsupported -> None
+let ptype_kind ~loc tk =
+  try Option.some @@ ptype_kind ~loc tk with Unsupported _ -> None
 
 let mk_tdecl t attrs spec =
   let* tparams = params_to_id t.ptype_params
-  and* tkind = ptype_kind t.ptype_kind in
+  and* tkind = ptype_kind ~loc:t.ptype_loc t.ptype_kind in
   let tmanifest = Option.bind t.ptype_manifest core_to_pty in
   {
     tname = preid_of_loc t.ptype_name;

--- a/test/typechecking/unsupported/dune.inc
+++ b/test/typechecking/unsupported/dune.inc
@@ -21,6 +21,20 @@
   (:checker %{project_root}/test/utils/testchecker.exe)
        _gospel)
  (action
+  (with-outputs-to polymorphic_variant_with_spec.mli.output
+   (run %{checker} %{dep:polymorphic_variant_with_spec.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff polymorphic_variant_with_spec.mli polymorphic_variant_with_spec.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
   (with-outputs-to type_extension.mli.output
    (run %{checker} %{dep:type_extension.mli}))))
 
@@ -98,4 +112,74 @@
  (alias runtest)
  (action
   (diff value_first_class_module_with_spec.mli value_first_class_module_with_spec.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
+  (with-outputs-to value_polymorphic_variant.mli.output
+   (run %{checker} %{dep:value_polymorphic_variant.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff value_polymorphic_variant.mli value_polymorphic_variant.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
+  (with-outputs-to value_polymorphic_variant_with_spec.mli.output
+   (run %{checker} %{dep:value_polymorphic_variant_with_spec.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff value_polymorphic_variant_with_spec.mli value_polymorphic_variant_with_spec.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
+  (with-outputs-to variant.mli.output
+   (run %{checker} %{dep:variant.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff variant.mli variant.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
+  (with-outputs-to variant_as_argument.mli.output
+   (run %{checker} %{dep:variant_as_argument.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff variant_as_argument.mli variant_as_argument.mli.output)))
+
+(rule
+ (deps
+  %{bin:gospel}
+  (:checker %{project_root}/test/utils/testchecker.exe)
+       _gospel)
+ (action
+  (with-outputs-to variant_with_spec.mli.output
+   (run %{checker} %{dep:variant_with_spec.mli}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff variant_with_spec.mli variant_with_spec.mli.output)))
 

--- a/test/typechecking/unsupported/polymorphic_variant.mli
+++ b/test/typechecking/unsupported/polymorphic_variant.mli
@@ -1,7 +1,1 @@
 type t = [ `A | `B ]
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
@@ -1,2 +1,9 @@
 type t = [ `A | `B ]
 (*@ model : integer *)
+(* {gospel_expected|
+[1] File "./polymorphic_variant_with_spec.mli", line 1, characters 9-20:
+    1 | type t = [ `A | `B ]
+                 ^^^^^^^^^^^
+    Error: Not yet supported: polymorphic variant
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
@@ -1,0 +1,8 @@
+type t = [ `A | `B ]
+(*@ model : integer *)
+(* {gospel_expected|
+[125] gospel: internal error, uncaught exception:
+              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
+              
+      
+|gospel_expected} *)

--- a/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
@@ -1,8 +1,2 @@
 type t = [ `A | `B ]
 (*@ model : integer *)
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/polymorphic_variant_with_spec.mli
@@ -1,2 +1,9 @@
 type t = [ `A | `B ]
 (*@ model : integer *)
+(* {gospel_expected|
+[1] File "polymorphic_variant_with_spec.mli", line 1, characters 9-20:
+    1 | type t = [ `A | `B ]
+                 ^^^^^^^^^^^
+    Error: Not yet supported: polymorphic variant
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/type_extension.mli
+++ b/test/typechecking/unsupported/type_extension.mli
@@ -1,7 +1,1 @@
 type t = ..
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/type_extension_with_spec.mli
+++ b/test/typechecking/unsupported/type_extension_with_spec.mli
@@ -1,8 +1,2 @@
 type t = ..
 (*@ model : integer *)
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/type_extension_with_spec.mli
+++ b/test/typechecking/unsupported/type_extension_with_spec.mli
@@ -1,2 +1,9 @@
 type t = ..
 (*@ model : integer *)
+(* {gospel_expected|
+[1] File "./type_extension_with_spec.mli", line 1, characters 0-34:
+    1 | type t = ..
+    2 | (*@ model : integer *)
+    Error: Not yet supported: extensible type
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/type_extension_with_spec.mli
+++ b/test/typechecking/unsupported/type_extension_with_spec.mli
@@ -1,2 +1,9 @@
 type t = ..
 (*@ model : integer *)
+(* {gospel_expected|
+[1] File "type_extension_with_spec.mli", line 1, characters 0-34:
+    1 | type t = ..
+    2 | (*@ model : integer *)
+    Error: Not yet supported: extensible type
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/value_first_class_module.mli
+++ b/test/typechecking/unsupported/value_first_class_module.mli
@@ -3,9 +3,3 @@ module type S = sig
 end
 
 val f : (module S) -> string
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/value_first_class_module_with_spec.mli
+++ b/test/typechecking/unsupported/value_first_class_module_with_spec.mli
@@ -4,9 +4,3 @@ end
 
 val f : (module S) -> string
 (*@ s = f m *)
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/value_first_class_module_with_spec.mli
+++ b/test/typechecking/unsupported/value_first_class_module_with_spec.mli
@@ -4,3 +4,10 @@ end
 
 val f : (module S) -> string
 (*@ s = f m *)
+(* {gospel_expected|
+[1] File "./value_first_class_module_with_spec.mli", line 5, characters 8-18:
+    5 | val f : (module S) -> string
+                ^^^^^^^^^^
+    Error: Not yet supported: first class module
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/value_first_class_module_with_spec.mli
+++ b/test/typechecking/unsupported/value_first_class_module_with_spec.mli
@@ -4,3 +4,10 @@ end
 
 val f : (module S) -> string
 (*@ s = f m *)
+(* {gospel_expected|
+[1] File "value_first_class_module_with_spec.mli", line 5, characters 8-18:
+    5 | val f : (module S) -> string
+                ^^^^^^^^^^
+    Error: Not yet supported: first class module
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/value_polymorphic_variant.mli
+++ b/test/typechecking/unsupported/value_polymorphic_variant.mli
@@ -1,7 +1,1 @@
 val f : [ `A | `B ] -> bool
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/value_polymorphic_variant.mli
+++ b/test/typechecking/unsupported/value_polymorphic_variant.mli
@@ -1,0 +1,7 @@
+val f : [ `A | `B ] -> bool
+(* {gospel_expected|
+[125] gospel: internal error, uncaught exception:
+              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
+              
+      
+|gospel_expected} *)

--- a/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
@@ -1,2 +1,9 @@
 val f : [ `A | `B ] -> bool
 (*@ b = f v *)
+(* {gospel_expected|
+[1] File "./value_polymorphic_variant_with_spec.mli", line 1, characters 8-19:
+    1 | val f : [ `A | `B ] -> bool
+                ^^^^^^^^^^^
+    Error: Not yet supported: polymorphic variant
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
@@ -1,8 +1,2 @@
 val f : [ `A | `B ] -> bool
 (*@ b = f v *)
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
@@ -1,0 +1,8 @@
+val f : [ `A | `B ] -> bool
+(*@ b = f v *)
+(* {gospel_expected|
+[125] gospel: internal error, uncaught exception:
+              File "src/uattr2spec.ml", line 85, characters 9-15: Assertion failed
+              
+      
+|gospel_expected} *)

--- a/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
+++ b/test/typechecking/unsupported/value_polymorphic_variant_with_spec.mli
@@ -1,2 +1,9 @@
 val f : [ `A | `B ] -> bool
 (*@ b = f v *)
+(* {gospel_expected|
+[1] File "value_polymorphic_variant_with_spec.mli", line 1, characters 8-19:
+    1 | val f : [ `A | `B ] -> bool
+                ^^^^^^^^^^^
+    Error: Not yet supported: polymorphic variant
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/variant.mli
+++ b/test/typechecking/unsupported/variant.mli
@@ -1,0 +1,7 @@
+type t = A | B
+(* {gospel_expected|
+[125] gospel: internal error, uncaught exception:
+              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
+              
+      
+|gospel_expected} *)

--- a/test/typechecking/unsupported/variant.mli
+++ b/test/typechecking/unsupported/variant.mli
@@ -1,7 +1,1 @@
 type t = A | B
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/variant_as_argument.mli
+++ b/test/typechecking/unsupported/variant_as_argument.mli
@@ -2,8 +2,9 @@ type t = A | B
 
 val f : t -> bool
 (* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
-              
-      
+[1] File "./variant_as_argument.mli", line 3, characters 8-9:
+    3 | val f : t -> bool
+                ^
+    Error: Unbound type constructor t
+    
 |gospel_expected} *)

--- a/test/typechecking/unsupported/variant_as_argument.mli
+++ b/test/typechecking/unsupported/variant_as_argument.mli
@@ -1,0 +1,9 @@
+type t = A | B
+
+val f : t -> bool
+(* {gospel_expected|
+[125] gospel: internal error, uncaught exception:
+              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
+              
+      
+|gospel_expected} *)

--- a/test/typechecking/unsupported/variant_as_argument.mli
+++ b/test/typechecking/unsupported/variant_as_argument.mli
@@ -2,8 +2,9 @@ type t = A | B
 
 val f : t -> bool
 (* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
-              
-      
+[1] File "variant_as_argument.mli", line 3, characters 8-9:
+    3 | val f : t -> bool
+                ^
+    Error: Unbound type constructor t
+    
 |gospel_expected} *)

--- a/test/typechecking/unsupported/variant_with_spec.mli
+++ b/test/typechecking/unsupported/variant_with_spec.mli
@@ -1,8 +1,2 @@
 type t = A | B
 (*@ model : integer *)
-(* {gospel_expected|
-[125] gospel: internal error, uncaught exception:
-              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
-              
-      
-|gospel_expected} *)

--- a/test/typechecking/unsupported/variant_with_spec.mli
+++ b/test/typechecking/unsupported/variant_with_spec.mli
@@ -1,2 +1,9 @@
 type t = A | B
 (*@ model : integer *)
+(* {gospel_expected|
+[1] File "./variant_with_spec.mli", line 1, characters 0-37:
+    1 | type t = A | B
+    2 | (*@ model : integer *)
+    Error: Not yet supported: variant type
+    
+|gospel_expected} *)

--- a/test/typechecking/unsupported/variant_with_spec.mli
+++ b/test/typechecking/unsupported/variant_with_spec.mli
@@ -1,0 +1,8 @@
+type t = A | B
+(*@ model : integer *)
+(* {gospel_expected|
+[125] gospel: internal error, uncaught exception:
+              File "src/uattr2spec.ml", line 102, characters 9-15: Assertion failed
+              
+      
+|gospel_expected} *)

--- a/test/typechecking/unsupported/variant_with_spec.mli
+++ b/test/typechecking/unsupported/variant_with_spec.mli
@@ -1,2 +1,9 @@
 type t = A | B
 (*@ model : integer *)
+(* {gospel_expected|
+[1] File "variant_with_spec.mli", line 1, characters 0-37:
+    1 | type t = A | B
+    2 | (*@ model : integer *)
+    Error: Not yet supported: variant type
+    
+|gospel_expected} *)


### PR DESCRIPTION
This patch proposes to improve how unsupported OCaml constructs are handled by the Gospel type-checker.

Fixes #467

The current behaviour is to fail with an `assert false` when we encounter an unsupported construct.
This is decided when parsing the OCaml attributes containing the Gospel annotation (with the AST traversal).

The proposed behaviour is to fail with an informative error message when an unsupported OCaml contruct is annotated with some Gospel specifications.
Unupported OCaml constructs that are not annotated are simply ignored.

The information carried by the error is the name of the construct and the location so that the incriminated line of code is displayed with the error message.

Caveat: `test/Typechecking/unsupported/variant_as_argument.mli` reads as follow:

```ocaml
type t = A | B

val f : t -> bool
(* {gospel_expected|
[1] File "variant_as_argument.mli", line 3, characters 8-9:
    3 | val f : t -> bool
                ^
    Error: Unbound type constructor t
    
|gospel_expected} *)
```

What is happening is that the type declaration is ignored (unsupported but not specified), the type-checker later adds a header to the unspecified value definition and fail to find `t` in the typing environment.

But this is related to another problem, hence out of scope of this patch.
