### PR TITLE
Fix filename for `check_file` output

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version = 0.27.0
+version = 0.29.0
 break-infix = fit-or-vertical
 module-item-spacing = compact

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 ## Improved
 
+- Fix filename for `check_file` output
+  [\#478](https://github.com/ocaml-gospel/gospel/pull/478)
 - Add `option` as an OCaml primitive type constructor
   [\#464](https://github.com/ocaml-gospel/gospel/pull/464)
 - Check for repeated name of module and module types

--- a/src/bin_utils.ml
+++ b/src/bin_utils.ml
@@ -64,9 +64,12 @@ let read_gospel_file f =
     @raise Warnings.Error if there is a parsing or typing error in [file]. *)
 let check_file ?(comp_dir = "") ?(env = Namespace.empty_env) ~verbose file =
   let module_nm, tast, mods = type_sigs ~verbose env file in
-  let comp =
-    open_out_bin (Format.sprintf "%s%s%s" comp_dir module_nm gospel_ext)
+  let out =
+    match comp_dir with
+    | "" -> Format.sprintf "%s%s" module_nm gospel_ext
+    | dir -> Format.sprintf "%s/%s%s" dir module_nm gospel_ext
   in
+  let comp = open_out_bin out in
   Marshal.to_channel comp mods [];
   close_out comp;
   (tast, mods)


### PR DESCRIPTION
`*.gospel` files were written in `_gospel*.gospel` rather than `_gospel/*.gospel`