### PR TITLE
Add Option module to Gospel stdlib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Add failing test case about map
   [\#480](https://github.com/ocaml-gospel/gospel/pull/480)
+- Add `Option.{get,is_none,is_some}` in Gospel stdlib
+  [\#479](https://github.com/ocaml-gospel/gospel/pull/479)
 - Add test cases for some unsupported constructs
   [\#466](https://github.com/ocaml-gospel/gospel/pull/466)
 - Adapt to cmdliner.2.0.0

--- a/README.md
+++ b/README.md
@@ -48,13 +48,19 @@ val push : 'a -> 'a t -> unit
     modifies s
     ensures s = Sequence.cons a (old s) *)
 
-val pop : 'a t -> 'a
-(*@ a = pop s
+val pop_exn : 'a t -> 'a
+(*@ a = pop_exn s
     modifies s
     ensures a = Sequence.hd (old s)
     ensures s = Sequence.tl (old s)
     raises Empty
       ensures old s = Sequence.empty = s *)
+
+val pop_opt : 'a t -> 'a option
+(*@ o = pop_opt s
+    modifies s
+    ensures Option.is_none o /\ old s = Sequence.empty = s
+            \/ Option.is_some o /\ let x = Option.get o in old s = Sequence.cons x s *)
 ```
 
 We designed Gospel to provide a tool-agnostic frontend for bringing formal

--- a/stdlib/gospelstdlib.mli
+++ b/stdlib/gospelstdlib.mli
@@ -116,6 +116,29 @@
         monoid f neutral /\
         (forall x y. f x y = f y x) *)
 
+module Option : sig
+  (*@ type 'a t = 'a option *)
+  (** An alias for {!option} *)
+
+  (*@ predicate is_none (o : 'a t) *)
+
+  (*@ axiom is_none_def :
+        forall o.
+        is_none o <-> o = None *)
+
+  (*@ predicate is_some (o : 'a t) *)
+
+  (*@ axiom is_some_def :
+        forall o.
+        is_some o <-> o <> None *)
+
+  (*@ function get (o : 'a t) : 'a *)
+
+  (*@ axiom get_def :
+        forall a.
+        get (Some a) = a *)
+end
+
 module Sequence : sig
   (*@ type 'a t = 'a sequence *)
   (** An alias for {!sequence} *)


### PR DESCRIPTION
This PR proposes to add

- `Option.is_none`
- `Option.is_some`
- `Option.get`

to the Gospel standard library.

Closes https://github.com/ocaml-gospel/gospel/issues/469