### PR TITLE
Promote new format for filename in error printing

### DIFF
--- a/test/duplicates/duplicate_consumes_top_level1.mli
+++ b/test/duplicates/duplicate_consumes_top_level1.mli
@@ -14,7 +14,7 @@ val f : unit -> unit
     consumes x *)
 
 (* {gospel_expected|
-[1] File "duplicate_consumes_top_level1.mli", line 14, characters 13-14:
+[1] File "./duplicate_consumes_top_level1.mli", line 14, characters 13-14:
     14 |     consumes x *)
                       ^
     Error: The variable x is listed as consumes twice

--- a/test/duplicates/duplicate_consumes_top_level2.mli
+++ b/test/duplicates/duplicate_consumes_top_level2.mli
@@ -16,7 +16,7 @@ val f : unit -> unit
     consumes x *)
 
 (* {gospel_expected|
-[1] File "duplicate_consumes_top_level2.mli", line 16, characters 13-14:
+[1] File "./duplicate_consumes_top_level2.mli", line 16, characters 13-14:
     16 |     consumes x *)
                       ^
     Error: The variable x is listed as consumes twice

--- a/test/duplicates/duplicate_consumes_top_level3.mli
+++ b/test/duplicates/duplicate_consumes_top_level3.mli
@@ -16,7 +16,7 @@ val f : unit -> unit
     consumes y *)
 
 (* {gospel_expected|
-[1] File "duplicate_consumes_top_level3.mli", line 15, characters 13-14:
+[1] File "./duplicate_consumes_top_level3.mli", line 15, characters 13-14:
     15 |     consumes x
                       ^
     Error: The variable x is listed as consumes twice

--- a/test/duplicates/duplicate_exn1.mli
+++ b/test/duplicates/duplicate_exn1.mli
@@ -16,7 +16,7 @@ val f : unit -> unit
     raises E1 *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn1.mli", line 16, characters 4-13:
+[1] File "./duplicate_exn1.mli", line 16, characters 4-13:
     16 |     raises E1 *)
              ^^^^^^^^^
     Error: The exception E1 is listed twice in this specification

--- a/test/duplicates/duplicate_exn2.mli
+++ b/test/duplicates/duplicate_exn2.mli
@@ -18,7 +18,7 @@ val f : unit -> unit
     raises E1 *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn2.mli", line 18, characters 4-13:
+[1] File "./duplicate_exn2.mli", line 18, characters 4-13:
     18 |     raises E1 *)
              ^^^^^^^^^
     Error: The exception E1 is listed twice in this specification

--- a/test/duplicates/duplicate_exn3.mli
+++ b/test/duplicates/duplicate_exn3.mli
@@ -18,7 +18,7 @@ val f : unit -> unit
     raises E1 *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn3.mli", line 18, characters 4-13:
+[1] File "./duplicate_exn3.mli", line 18, characters 4-13:
     18 |     raises E1 *)
              ^^^^^^^^^
     Error: The exception E1 is listed twice in this specification

--- a/test/duplicates/duplicate_exn4.mli
+++ b/test/duplicates/duplicate_exn4.mli
@@ -19,7 +19,7 @@ val f : unit -> unit
 *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn4.mli", line 17, characters 4-27:
+[1] File "./duplicate_exn4.mli", line 17, characters 4-27:
     17 | ....raises E1
     18 |     raises E2
     Error: The exception E1 is listed twice in this specification

--- a/test/duplicates/duplicate_exn_ret1.mli
+++ b/test/duplicates/duplicate_exn_ret1.mli
@@ -16,7 +16,7 @@ val f : int -> unit
       ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn_ret1.mli", line 14, characters 6-7:
+[1] File "./duplicate_exn_ret1.mli", line 14, characters 6-7:
     14 | (*@ f x
                ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_exn_ret2.mli
+++ b/test/duplicates/duplicate_exn_ret2.mli
@@ -16,7 +16,7 @@ val f : int -> unit
       ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn_ret2.mli", line 14, characters 6-7:
+[1] File "./duplicate_exn_ret2.mli", line 14, characters 6-7:
     14 | (*@ f x
                ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_exn_ret3.mli
+++ b/test/duplicates/duplicate_exn_ret3.mli
@@ -16,7 +16,7 @@ val f : int -> unit
       ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn_ret3.mli", line 15, characters 17-18:
+[1] File "./duplicate_exn_ret3.mli", line 15, characters 17-18:
     15 |     raises E (x, x)
                           ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_exn_ret4.mli
+++ b/test/duplicates/duplicate_exn_ret4.mli
@@ -16,7 +16,7 @@ val f : int -> unit
       ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_exn_ret4.mli", line 15, characters 17-18:
+[1] File "./duplicate_exn_ret4.mli", line 15, characters 17-18:
     15 |     raises E (x, x)
                           ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_fun_args1.mli
+++ b/test/duplicates/duplicate_fun_args1.mli
@@ -11,7 +11,7 @@
 (*@ function f (x : integer) (x : integer) : integer *)
 
 (* {gospel_expected|
-[1] File "duplicate_fun_args1.mli", line 11, characters 30-31:
+[1] File "./duplicate_fun_args1.mli", line 11, characters 30-31:
     11 | (*@ function f (x : integer) (x : integer) : integer *)
                                        ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_fun_args2.mli
+++ b/test/duplicates/duplicate_fun_args2.mli
@@ -11,7 +11,7 @@
 (*@ function f (y : integer) (x : integer) (x : integer) : integer *)
 
 (* {gospel_expected|
-[1] File "duplicate_fun_args2.mli", line 11, characters 44-45:
+[1] File "./duplicate_fun_args2.mli", line 11, characters 44-45:
     11 | (*@ function f (y : integer) (x : integer) (x : integer) : integer *)
                                                      ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_fun_args3.mli
+++ b/test/duplicates/duplicate_fun_args3.mli
@@ -11,7 +11,7 @@
 (*@ function f (x : integer) (y : integer) (x : integer) : integer *)
 
 (* {gospel_expected|
-[1] File "duplicate_fun_args3.mli", line 11, characters 44-45:
+[1] File "./duplicate_fun_args3.mli", line 11, characters 44-45:
     11 | (*@ function f (x : integer) (y : integer) (x : integer) : integer *)
                                                      ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_fun_args4.mli
+++ b/test/duplicates/duplicate_fun_args4.mli
@@ -11,7 +11,7 @@
 (*@ function f (x : integer) (x :integer) (y : integer) : integer *)
 
 (* {gospel_expected|
-[1] File "duplicate_fun_args4.mli", line 11, characters 30-31:
+[1] File "./duplicate_fun_args4.mli", line 11, characters 30-31:
     11 | (*@ function f (x : integer) (x :integer) (y : integer) : integer *)
                                        ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_header_args1.mli
+++ b/test/duplicates/duplicate_header_args1.mli
@@ -13,7 +13,7 @@ val f : int -> int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_args1.mli", line 12, characters 8-9:
+[1] File "./duplicate_header_args1.mli", line 12, characters 8-9:
     12 | (*@ f x x
                  ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_args2.mli
+++ b/test/duplicates/duplicate_header_args2.mli
@@ -13,7 +13,7 @@ val f : int -> int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_args2.mli", line 12, characters 10-11:
+[1] File "./duplicate_header_args2.mli", line 12, characters 10-11:
     12 | (*@ f y x x
                    ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_args3.mli
+++ b/test/duplicates/duplicate_header_args3.mli
@@ -13,7 +13,7 @@ val f : int -> int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_args3.mli", line 12, characters 10-11:
+[1] File "./duplicate_header_args3.mli", line 12, characters 10-11:
     12 | (*@ f x y x
                    ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_args4.mli
+++ b/test/duplicates/duplicate_header_args4.mli
@@ -13,7 +13,7 @@ val f : int -> int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_args4.mli", line 12, characters 8-9:
+[1] File "./duplicate_header_args4.mli", line 12, characters 8-9:
     12 | (*@ f x x y
                  ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_rets1.mli
+++ b/test/duplicates/duplicate_header_rets1.mli
@@ -13,7 +13,7 @@ val f : unit -> int * int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_rets1.mli", line 12, characters 7-8:
+[1] File "./duplicate_header_rets1.mli", line 12, characters 7-8:
     12 | (*@ x, x = f ()
                 ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_rets2.mli
+++ b/test/duplicates/duplicate_header_rets2.mli
@@ -13,7 +13,7 @@ val f : unit -> int * int * int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_rets2.mli", line 12, characters 10-11:
+[1] File "./duplicate_header_rets2.mli", line 12, characters 10-11:
     12 | (*@ y, x, x = f ()
                    ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_rets3.mli
+++ b/test/duplicates/duplicate_header_rets3.mli
@@ -13,7 +13,7 @@ val f : unit -> int * int * int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_rets3.mli", line 12, characters 10-11:
+[1] File "./duplicate_header_rets3.mli", line 12, characters 10-11:
     12 | (*@ x, y, x = f ()
                    ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_rets4.mli
+++ b/test/duplicates/duplicate_header_rets4.mli
@@ -13,7 +13,7 @@ val f : unit -> int * int * int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_rets4.mli", line 12, characters 7-8:
+[1] File "./duplicate_header_rets4.mli", line 12, characters 7-8:
     12 | (*@ x, x, y = f ()
                 ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_vars1.mli
+++ b/test/duplicates/duplicate_header_vars1.mli
@@ -13,7 +13,7 @@ val f : int -> int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_vars1.mli", line 12, characters 10-11:
+[1] File "./duplicate_header_vars1.mli", line 12, characters 10-11:
     12 | (*@ x = f x
                    ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_vars2.mli
+++ b/test/duplicates/duplicate_header_vars2.mli
@@ -13,7 +13,7 @@ val f : int -> int -> int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_vars2.mli", line 12, characters 10-11:
+[1] File "./duplicate_header_vars2.mli", line 12, characters 10-11:
     12 | (*@ x = f x y
                    ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_vars3.mli
+++ b/test/duplicates/duplicate_header_vars3.mli
@@ -13,7 +13,7 @@ val f : int -> int -> int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_vars3.mli", line 12, characters 12-13:
+[1] File "./duplicate_header_vars3.mli", line 12, characters 12-13:
     12 | (*@ x = f y x
                      ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_vars4.mli
+++ b/test/duplicates/duplicate_header_vars4.mli
@@ -13,7 +13,7 @@ val f : int -> int * int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_vars4.mli", line 12, characters 13-14:
+[1] File "./duplicate_header_vars4.mli", line 12, characters 13-14:
     12 | (*@ x, y = f x
                       ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_header_vars5.mli
+++ b/test/duplicates/duplicate_header_vars5.mli
@@ -13,7 +13,7 @@ val f : int -> int * int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "duplicate_header_vars5.mli", line 12, characters 13-14:
+[1] File "./duplicate_header_vars5.mli", line 12, characters 13-14:
     12 | (*@ y, x = f x
                       ^
     Error: The variable x is defined twice in this header

--- a/test/duplicates/duplicate_label1.mli
+++ b/test/duplicates/duplicate_label1.mli
@@ -11,7 +11,7 @@
 (*@ type t = { x : integer; x : integer } *)
 
 (* {gospel_expected|
-[1] File "duplicate_label1.mli", line 11, characters 28-39:
+[1] File "./duplicate_label1.mli", line 11, characters 28-39:
     11 | (*@ type t = { x : integer; x : integer } *)
                                      ^^^^^^^^^^^
     Error: Two labels are named x

--- a/test/duplicates/duplicate_label2.mli
+++ b/test/duplicates/duplicate_label2.mli
@@ -11,7 +11,7 @@
 (*@ type t = { y : integer; x : integer; x : integer } *)
 
 (* {gospel_expected|
-[1] File "duplicate_label2.mli", line 11, characters 41-52:
+[1] File "./duplicate_label2.mli", line 11, characters 41-52:
     11 | (*@ type t = { y : integer; x : integer; x : integer } *)
                                                   ^^^^^^^^^^^
     Error: Two labels are named x

--- a/test/duplicates/duplicate_label3.mli
+++ b/test/duplicates/duplicate_label3.mli
@@ -11,7 +11,7 @@
 (*@ type t = { x : integer; y : integer; x : integer } *)
 
 (* {gospel_expected|
-[1] File "duplicate_label3.mli", line 11, characters 41-52:
+[1] File "./duplicate_label3.mli", line 11, characters 41-52:
     11 | (*@ type t = { x : integer; y : integer; x : integer } *)
                                                   ^^^^^^^^^^^
     Error: Two labels are named x

--- a/test/duplicates/duplicate_label4.mli
+++ b/test/duplicates/duplicate_label4.mli
@@ -11,7 +11,7 @@
 (*@ type t = { x : integer; x : integer; y : integer } *)
 
 (* {gospel_expected|
-[1] File "duplicate_label4.mli", line 11, characters 28-39:
+[1] File "./duplicate_label4.mli", line 11, characters 28-39:
     11 | (*@ type t = { x : integer; x : integer; y : integer } *)
                                      ^^^^^^^^^^^
     Error: Two labels are named x

--- a/test/duplicates/duplicate_label_creation1.mli
+++ b/test/duplicates/duplicate_label_creation1.mli
@@ -12,7 +12,7 @@
 
 (*@ function f : t = { x = 0; x = 0 }*)
 (* {gospel_expected|
-[1] File "duplicate_label_creation1.mli", line 13, characters 21-37:
+[1] File "./duplicate_label_creation1.mli", line 13, characters 21-37:
     13 | (*@ function f : t = { x = 0; x = 0 }*)
                               ^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/duplicates/duplicate_label_creation2.mli
+++ b/test/duplicates/duplicate_label_creation2.mli
@@ -12,7 +12,7 @@
 
 (*@ function f : t = { y = 0; x = 0; x = 0 }*)
 (* {gospel_expected|
-[1] File "duplicate_label_creation2.mli", line 13, characters 21-44:
+[1] File "./duplicate_label_creation2.mli", line 13, characters 21-44:
     13 | (*@ function f : t = { y = 0; x = 0; x = 0 }*)
                               ^^^^^^^^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/duplicates/duplicate_label_creation3.mli
+++ b/test/duplicates/duplicate_label_creation3.mli
@@ -12,7 +12,7 @@
 
 (*@ function f : t = { x = 0; y = 0; x = 0 }*)
 (* {gospel_expected|
-[1] File "duplicate_label_creation3.mli", line 13, characters 21-44:
+[1] File "./duplicate_label_creation3.mli", line 13, characters 21-44:
     13 | (*@ function f : t = { x = 0; y = 0; x = 0 }*)
                               ^^^^^^^^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/duplicates/duplicate_label_creation4.mli
+++ b/test/duplicates/duplicate_label_creation4.mli
@@ -12,7 +12,7 @@
 
 (*@ function f : t = { x = 0; x = 0; y = 0 }*)
 (* {gospel_expected|
-[1] File "duplicate_label_creation4.mli", line 13, characters 21-44:
+[1] File "./duplicate_label_creation4.mli", line 13, characters 21-44:
     13 | (*@ function f : t = { x = 0; x = 0; y = 0 }*)
                               ^^^^^^^^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/duplicates/duplicate_modifies_top_level1.mli
+++ b/test/duplicates/duplicate_modifies_top_level1.mli
@@ -14,7 +14,7 @@ val f : unit -> unit
     modifies x *)
 
 (* {gospel_expected|
-[1] File "duplicate_modifies_top_level1.mli", line 14, characters 13-14:
+[1] File "./duplicate_modifies_top_level1.mli", line 14, characters 13-14:
     14 |     modifies x *)
                       ^
     Error: The variable x is listed as modified twice

--- a/test/duplicates/duplicate_modifies_top_level2.mli
+++ b/test/duplicates/duplicate_modifies_top_level2.mli
@@ -16,7 +16,7 @@ val f : unit -> unit
     modifies x *)
 
 (* {gospel_expected|
-[1] File "duplicate_modifies_top_level2.mli", line 16, characters 13-14:
+[1] File "./duplicate_modifies_top_level2.mli", line 16, characters 13-14:
     16 |     modifies x *)
                       ^
     Error: The variable x is listed as modified twice

--- a/test/duplicates/duplicate_modifies_top_level3.mli
+++ b/test/duplicates/duplicate_modifies_top_level3.mli
@@ -16,7 +16,7 @@ val f : unit -> unit
     modifies y *)
 
 (* {gospel_expected|
-[1] File "duplicate_modifies_top_level3.mli", line 15, characters 13-14:
+[1] File "./duplicate_modifies_top_level3.mli", line 15, characters 13-14:
     15 |     modifies x
                       ^
     Error: The variable x is listed as modified twice

--- a/test/duplicates/duplicate_pred_args1.mli
+++ b/test/duplicates/duplicate_pred_args1.mli
@@ -11,7 +11,7 @@
 (*@ predicate f (x : integer) (x : integer) *)
 
 (* {gospel_expected|
-[1] File "duplicate_pred_args1.mli", line 11, characters 31-32:
+[1] File "./duplicate_pred_args1.mli", line 11, characters 31-32:
     11 | (*@ predicate f (x : integer) (x : integer) *)
                                         ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_pred_args2.mli
+++ b/test/duplicates/duplicate_pred_args2.mli
@@ -11,7 +11,7 @@
 (*@ predicate f (y : integer) (x : integer) (x : integer) *)
 
 (* {gospel_expected|
-[1] File "duplicate_pred_args2.mli", line 11, characters 45-46:
+[1] File "./duplicate_pred_args2.mli", line 11, characters 45-46:
     11 | (*@ predicate f (y : integer) (x : integer) (x : integer) *)
                                                       ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_pred_args3.mli
+++ b/test/duplicates/duplicate_pred_args3.mli
@@ -11,7 +11,7 @@
 (*@ predicate f (x : integer) (y : integer) (x : integer) *)
 
 (* {gospel_expected|
-[1] File "duplicate_pred_args3.mli", line 11, characters 45-46:
+[1] File "./duplicate_pred_args3.mli", line 11, characters 45-46:
     11 | (*@ predicate f (x : integer) (y : integer) (x : integer) *)
                                                       ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_pred_args4.mli
+++ b/test/duplicates/duplicate_pred_args4.mli
@@ -11,7 +11,7 @@
 (*@ predicate f (x : integer) (x : integer) (y : integer) *)
 
 (* {gospel_expected|
-[1] File "duplicate_pred_args4.mli", line 11, characters 31-32:
+[1] File "./duplicate_pred_args4.mli", line 11, characters 31-32:
     11 | (*@ predicate f (x : integer) (x : integer) (y : integer) *)
                                         ^
     Error: Duplicated argument x

--- a/test/duplicates/duplicate_preserves_top_level1.mli
+++ b/test/duplicates/duplicate_preserves_top_level1.mli
@@ -14,7 +14,7 @@ val f : unit -> unit
     preserves x *)
 
 (* {gospel_expected|
-[1] File "duplicate_preserves_top_level1.mli", line 14, characters 14-15:
+[1] File "./duplicate_preserves_top_level1.mli", line 14, characters 14-15:
     14 |     preserves x *)
                        ^
     Error: The variable x is listed as preserved twice

--- a/test/duplicates/duplicate_preserves_top_level2.mli
+++ b/test/duplicates/duplicate_preserves_top_level2.mli
@@ -16,7 +16,7 @@ val f : unit -> unit
     preserves x *)
 
 (* {gospel_expected|
-[1] File "duplicate_preserves_top_level2.mli", line 16, characters 14-15:
+[1] File "./duplicate_preserves_top_level2.mli", line 16, characters 14-15:
     16 |     preserves x *)
                        ^
     Error: The variable x is listed as preserved twice

--- a/test/duplicates/duplicate_preserves_top_level3.mli
+++ b/test/duplicates/duplicate_preserves_top_level3.mli
@@ -16,7 +16,7 @@ val f : unit -> unit
     preserves y *)
 
 (* {gospel_expected|
-[1] File "duplicate_preserves_top_level3.mli", line 15, characters 14-15:
+[1] File "./duplicate_preserves_top_level3.mli", line 15, characters 14-15:
     15 |     preserves x
                        ^
     Error: The variable x is listed as preserved twice

--- a/test/duplicates/duplicate_type_vars1.mli
+++ b/test/duplicates/duplicate_type_vars1.mli
@@ -11,7 +11,7 @@
 (*@ type ('a, 'a) t *)
 
 (* {gospel_expected|
-[1] File "duplicate_type_vars1.mli", line 11, characters 14-16:
+[1] File "./duplicate_type_vars1.mli", line 11, characters 14-16:
     11 | (*@ type ('a, 'a) t *)
                        ^^
     Error: The type parameter a occurs several times

--- a/test/duplicates/duplicate_type_vars2.mli
+++ b/test/duplicates/duplicate_type_vars2.mli
@@ -11,7 +11,7 @@
 (*@ type ('b, 'a, 'a) t *)
 
 (* {gospel_expected|
-[1] File "duplicate_type_vars2.mli", line 11, characters 18-20:
+[1] File "./duplicate_type_vars2.mli", line 11, characters 18-20:
     11 | (*@ type ('b, 'a, 'a) t *)
                            ^^
     Error: The type parameter a occurs several times

--- a/test/duplicates/duplicate_type_vars3.mli
+++ b/test/duplicates/duplicate_type_vars3.mli
@@ -11,7 +11,7 @@
 (*@ type ('a, 'b, 'a) t *)
 
 (* {gospel_expected|
-[1] File "duplicate_type_vars3.mli", line 11, characters 18-20:
+[1] File "./duplicate_type_vars3.mli", line 11, characters 18-20:
     11 | (*@ type ('a, 'b, 'a) t *)
                            ^^
     Error: The type parameter a occurs several times

--- a/test/duplicates/duplicate_type_vars4.mli
+++ b/test/duplicates/duplicate_type_vars4.mli
@@ -11,7 +11,7 @@
 (*@ type ('a, 'a, 'b) t *)
 
 (* {gospel_expected|
-[1] File "duplicate_type_vars4.mli", line 11, characters 14-16:
+[1] File "./duplicate_type_vars4.mli", line 11, characters 14-16:
     11 | (*@ type ('a, 'a, 'b) t *)
                        ^^
     Error: The type parameter a occurs several times

--- a/test/name_res/modules/module_not_found1.mli
+++ b/test/name_res/modules/module_not_found1.mli
@@ -11,7 +11,7 @@
 (*@ open M *)
 
 (* {gospel_expected|
-[1] File "module_not_found1.mli", line 11, characters 9-10:
+[1] File "./module_not_found1.mli", line 11, characters 9-10:
     11 | (*@ open M *)
                   ^
     Error: Unbound module M

--- a/test/name_res/modules/module_not_found2.mli
+++ b/test/name_res/modules/module_not_found2.mli
@@ -13,7 +13,7 @@ module N : sig end
 (*@ open M *)
 
 (* {gospel_expected|
-[1] File "module_not_found2.mli", line 13, characters 9-10:
+[1] File "./module_not_found2.mli", line 13, characters 9-10:
     13 | (*@ open M *)
                   ^
     Error: Unbound module M

--- a/test/name_res/modules/module_not_found3.mli
+++ b/test/name_res/modules/module_not_found3.mli
@@ -15,7 +15,7 @@ end
 (*@ open M *)
 
 (* {gospel_expected|
-[1] File "module_not_found3.mli", line 15, characters 9-10:
+[1] File "./module_not_found3.mli", line 15, characters 9-10:
     15 | (*@ open M *)
                   ^
     Error: Unbound module M

--- a/test/name_res/modules/module_not_found4.mli
+++ b/test/name_res/modules/module_not_found4.mli
@@ -15,7 +15,7 @@ end
 (*@ open M.N *)
 
 (* {gospel_expected|
-[1] File "module_not_found4.mli", line 15, characters 9-10:
+[1] File "./module_not_found4.mli", line 15, characters 9-10:
     15 | (*@ open M.N *)
                   ^
     Error: Unbound module M

--- a/test/name_res/modules/module_not_found5.mli
+++ b/test/name_res/modules/module_not_found5.mli
@@ -14,7 +14,7 @@ module N : sig end
 (*@ open M *)
 
 (* {gospel_expected|
-[1] File "module_not_found5.mli", line 14, characters 9-10:
+[1] File "./module_not_found5.mli", line 14, characters 9-10:
     14 | (*@ open M *)
                   ^
     Error: Unbound module M

--- a/test/name_res/modules/module_not_found6.mli
+++ b/test/name_res/modules/module_not_found6.mli
@@ -14,7 +14,7 @@ module N : sig end
 (*@ open N.M *)
 
 (* {gospel_expected|
-[1] File "module_not_found6.mli", line 14, characters 11-12:
+[1] File "./module_not_found6.mli", line 14, characters 11-12:
     14 | (*@ open N.M *)
                     ^
     Error: Unbound module N.M

--- a/test/name_res/modules/module_not_found7.mli
+++ b/test/name_res/modules/module_not_found7.mli
@@ -14,7 +14,7 @@ module M : sig
   (*@ axiom test : M.p *)
 end
 (* {gospel_expected|
-[1] File "module_not_found7.mli", line 14, characters 19-20:
+[1] File "./module_not_found7.mli", line 14, characters 19-20:
     14 |   (*@ axiom test : M.p *)
                             ^
     Error: Unbound module M

--- a/test/name_res/modules/module_not_found8.mli
+++ b/test/name_res/modules/module_not_found8.mli
@@ -16,7 +16,7 @@ module M : sig
   end
 end
 (* {gospel_expected|
-[1] File "module_not_found8.mli", line 15, characters 21-22:
+[1] File "./module_not_found8.mli", line 15, characters 21-22:
     15 |     (*@ axiom test : M.p *)
                               ^
     Error: Unbound module M

--- a/test/name_res/modules/module_not_found9.mli
+++ b/test/name_res/modules/module_not_found9.mli
@@ -16,7 +16,7 @@ module M : sig
   end
 end
 (* {gospel_expected|
-[1] File "module_not_found9.mli", line 15, characters 21-22:
+[1] File "./module_not_found9.mli", line 15, characters 21-22:
     15 |     (*@ axiom test : M.N.p *)
                               ^
     Error: Unbound module M

--- a/test/name_res/modules/scope_not_found1.mli
+++ b/test/name_res/modules/scope_not_found1.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : M.(0 = 0) *)
 
 (* {gospel_expected|
-[1] File "scope_not_found1.mli", line 11, characters 17-18:
+[1] File "./scope_not_found1.mli", line 11, characters 17-18:
     11 | (*@ axiom test : M.(0 = 0) *)
                           ^
     Error: Unbound module M

--- a/test/name_res/modules/scope_not_found2.mli
+++ b/test/name_res/modules/scope_not_found2.mli
@@ -13,7 +13,7 @@ module N : sig end
 (*@ axiom test : M.(0 = 0) *)
 
 (* {gospel_expected|
-[1] File "scope_not_found2.mli", line 13, characters 17-18:
+[1] File "./scope_not_found2.mli", line 13, characters 17-18:
     13 | (*@ axiom test : M.(0 = 0) *)
                           ^
     Error: Unbound module M

--- a/test/name_res/modules/scope_not_found3.mli
+++ b/test/name_res/modules/scope_not_found3.mli
@@ -15,7 +15,7 @@ end
 (*@ axiom test : M.(0 = 0) *)
 
 (* {gospel_expected|
-[1] File "scope_not_found3.mli", line 15, characters 17-18:
+[1] File "./scope_not_found3.mli", line 15, characters 17-18:
     15 | (*@ axiom test : M.(0 = 0) *)
                           ^
     Error: Unbound module M

--- a/test/name_res/modules/scope_not_found4.mli
+++ b/test/name_res/modules/scope_not_found4.mli
@@ -15,7 +15,7 @@ end
 (*@ axiom test : M.(0 = 0) *)
 
 (* {gospel_expected|
-[1] File "scope_not_found4.mli", line 15, characters 17-18:
+[1] File "./scope_not_found4.mli", line 15, characters 17-18:
     15 | (*@ axiom test : M.(0 = 0) *)
                           ^
     Error: Unbound module M

--- a/test/name_res/modules/scope_not_found5.mli
+++ b/test/name_res/modules/scope_not_found5.mli
@@ -13,7 +13,7 @@ module N : sig end
 (*@ axiom test : N.(0 = 0) -> M.(0 = 0) *)
 
 (* {gospel_expected|
-[1] File "scope_not_found5.mli", line 13, characters 30-31:
+[1] File "./scope_not_found5.mli", line 13, characters 30-31:
     13 | (*@ axiom test : N.(0 = 0) -> M.(0 = 0) *)
                                        ^
     Error: Unbound module M

--- a/test/name_res/modules/scope_not_found7.mli
+++ b/test/name_res/modules/scope_not_found7.mli
@@ -13,7 +13,7 @@ module N : sig
 end
 
 (* {gospel_expected|
-[1] File "scope_not_found7.mli", line 12, characters 19-20:
+[1] File "./scope_not_found7.mli", line 12, characters 19-20:
     12 |   (*@ axiom test : N.(0 = 0) *)
                             ^
     Error: Unbound module N

--- a/test/name_res/modules/scope_not_found8.mli
+++ b/test/name_res/modules/scope_not_found8.mli
@@ -15,7 +15,7 @@ module N : sig
 end
 
 (* {gospel_expected|
-[1] File "scope_not_found8.mli", line 13, characters 21-22:
+[1] File "./scope_not_found8.mli", line 13, characters 21-22:
     13 |     (*@ axiom test : N.(0 = 0) *)
                               ^
     Error: Unbound module N

--- a/test/name_res/modules/scope_not_found9.mli
+++ b/test/name_res/modules/scope_not_found9.mli
@@ -15,7 +15,7 @@ module N : sig
 end
 
 (* {gospel_expected|
-[1] File "scope_not_found9.mli", line 13, characters 21-22:
+[1] File "./scope_not_found9.mli", line 13, characters 21-22:
     13 |     (*@ axiom test : N.M.(0 = 0) *)
                               ^
     Error: Unbound module N

--- a/test/name_res/records/access_neg/field_not_axiom.mli
+++ b/test/name_res/records/access_neg/field_not_axiom.mli
@@ -13,7 +13,7 @@
 (*@ axiom test : forall r. r.ax *)
 
 (* {gospel_expected|
-[1] File "field_not_axiom.mli", line 13, characters 29-31:
+[1] File "./field_not_axiom.mli", line 13, characters 29-31:
     13 | (*@ axiom test : forall r. r.ax *)
                                       ^^
     Error: Unbound record label ax

--- a/test/name_res/records/access_neg/field_not_type.mli
+++ b/test/name_res/records/access_neg/field_not_type.mli
@@ -13,7 +13,7 @@
 (*@ axiom ax : forall r. r.t *)
 
 (* {gospel_expected|
-[1] File "field_not_type.mli", line 13, characters 27-28:
+[1] File "./field_not_type.mli", line 13, characters 27-28:
     13 | (*@ axiom ax : forall r. r.t *)
                                     ^
     Error: Unbound record label t

--- a/test/name_res/records/access_neg/field_not_var.mli
+++ b/test/name_res/records/access_neg/field_not_var.mli
@@ -13,7 +13,7 @@
 (*@ axiom ax : forall r. r.f *)
 
 (* {gospel_expected|
-[1] File "field_not_var.mli", line 13, characters 27-28:
+[1] File "./field_not_var.mli", line 13, characters 27-28:
     13 | (*@ axiom ax : forall r. r.f *)
                                     ^
     Error: Unbound record label f

--- a/test/name_res/records/access_neg/unbound_field1.mli
+++ b/test/name_res/records/access_neg/unbound_field1.mli
@@ -11,7 +11,7 @@
 (*@ predicate test = forall r. r.x *)
 
 (* {gospel_expected|
-[1] File "unbound_field1.mli", line 11, characters 33-34:
+[1] File "./unbound_field1.mli", line 11, characters 33-34:
     11 | (*@ predicate test = forall r. r.x *)
                                           ^
     Error: Unbound record label x

--- a/test/name_res/records/access_neg/unbound_field2.mli
+++ b/test/name_res/records/access_neg/unbound_field2.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : t) = x.x *)
 
 (* {gospel_expected|
-[1] File "unbound_field2.mli", line 13, characters 31-32:
+[1] File "./unbound_field2.mli", line 13, characters 31-32:
     13 | (*@ predicate test (x : t) = x.x *)
                                         ^
     Error: Unbound record label x

--- a/test/name_res/records/access_neg/unbound_field3.mli
+++ b/test/name_res/records/access_neg/unbound_field3.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : t) = x.x = x.y *)
 
 (* {gospel_expected|
-[1] File "unbound_field3.mli", line 13, characters 31-32:
+[1] File "./unbound_field3.mli", line 13, characters 31-32:
     13 | (*@ predicate test (x : t) = x.x = x.y *)
                                         ^
     Error: Unbound record label x

--- a/test/name_res/records/access_neg/unbound_field4.mli
+++ b/test/name_res/records/access_neg/unbound_field4.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (r : t) = r.y = r.x *)
 
 (* {gospel_expected|
-[1] File "unbound_field4.mli", line 13, characters 37-38:
+[1] File "./unbound_field4.mli", line 13, characters 37-38:
     13 | (*@ predicate test (r : t) = r.y = r.x *)
                                               ^
     Error: Unbound record label x

--- a/test/name_res/records/access_neg/unbound_field5.mli
+++ b/test/name_res/records/access_neg/unbound_field5.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : t) = x.y = x.x *)
 
 (* {gospel_expected|
-[1] File "unbound_field5.mli", line 13, characters 37-38:
+[1] File "./unbound_field5.mli", line 13, characters 37-38:
     13 | (*@ predicate test (x : t) = x.y = x.x *)
                                               ^
     Error: Unbound record label x

--- a/test/name_res/records/access_neg/unbound_module1.mli
+++ b/test/name_res/records/access_neg/unbound_module1.mli
@@ -15,7 +15,7 @@ end
 (*@ predicate test (x : M.t) = x.x + x.x *)
 
 (* {gospel_expected|
-[1] File "unbound_module1.mli", line 15, characters 39-40:
+[1] File "./unbound_module1.mli", line 15, characters 39-40:
     15 | (*@ predicate test (x : M.t) = x.x + x.x *)
                                                 ^
     Error: Unbound record label x

--- a/test/name_res/records/access_neg/unbound_module2.mli
+++ b/test/name_res/records/access_neg/unbound_module2.mli
@@ -15,7 +15,7 @@ end
 (*@ predicate test (x : M.t) = x.x *)
 
 (* {gospel_expected|
-[1] File "unbound_module2.mli", line 15, characters 33-34:
+[1] File "./unbound_module2.mli", line 15, characters 33-34:
     15 | (*@ predicate test (x : M.t) = x.x *)
                                           ^
     Error: Unbound record label x

--- a/test/name_res/records/creation_neg/incompatible_fields1.mli
+++ b/test/name_res/records/creation_neg/incompatible_fields1.mli
@@ -14,7 +14,7 @@
 (*@ function t : t1 = { x = 0; y = 0 } *)
 
 (* {gospel_expected|
-[1] File "incompatible_fields1.mli", line 14, characters 22-38:
+[1] File "./incompatible_fields1.mli", line 14, characters 22-38:
     14 | (*@ function t : t1 = { x = 0; y = 0 } *)
                                ^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/incompatible_fields2.mli
+++ b/test/name_res/records/creation_neg/incompatible_fields2.mli
@@ -19,7 +19,7 @@ end
 (*@ function t : M1.t1 = { M1.x = 0; M2.y = 0 } *)
 
 (* {gospel_expected|
-[1] File "incompatible_fields2.mli", line 19, characters 25-47:
+[1] File "./incompatible_fields2.mli", line 19, characters 25-47:
     19 | (*@ function t : M1.t1 = { M1.x = 0; M2.y = 0 } *)
                                   ^^^^^^^^^^^^^^^^^^^^^^
     Error: The identifier M2.y belongs to the type M2.t2 but is mixed here with fields of type t1

--- a/test/name_res/records/creation_neg/incompatible_fields3.mli
+++ b/test/name_res/records/creation_neg/incompatible_fields3.mli
@@ -19,7 +19,7 @@ end
 (*@ function t : M1.t1 = { M1.x = 0; M2.y = 0 } *)
 
 (* {gospel_expected|
-[1] File "incompatible_fields3.mli", line 19, characters 25-47:
+[1] File "./incompatible_fields3.mli", line 19, characters 25-47:
     19 | (*@ function t : M1.t1 = { M1.x = 0; M2.y = 0 } *)
                                   ^^^^^^^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/incompatible_fields4.mli
+++ b/test/name_res/records/creation_neg/incompatible_fields4.mli
@@ -19,7 +19,7 @@ end
 (*@ function t : M1.t1 = { M2.y = 0; M1.x = 0 } *)
 
 (* {gospel_expected|
-[1] File "incompatible_fields4.mli", line 19, characters 25-47:
+[1] File "./incompatible_fields4.mli", line 19, characters 25-47:
     19 | (*@ function t : M1.t1 = { M2.y = 0; M1.x = 0 } *)
                                   ^^^^^^^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/incompatible_fields5.mli
+++ b/test/name_res/records/creation_neg/incompatible_fields5.mli
@@ -17,7 +17,7 @@ end
 (*@ function f : t = { z = 0; M.y = 0 }*)
 
 (* {gospel_expected|
-[1] File "incompatible_fields5.mli", line 17, characters 21-39:
+[1] File "./incompatible_fields5.mli", line 17, characters 21-39:
     17 | (*@ function f : t = { z = 0; M.y = 0 }*)
                               ^^^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/unbound_field1.mli
+++ b/test/name_res/records/creation_neg/unbound_field1.mli
@@ -13,7 +13,7 @@
 (*@ function test : t = { x = 0 }  *)
 
 (* {gospel_expected|
-[1] File "unbound_field1.mli", line 13, characters 24-33:
+[1] File "./unbound_field1.mli", line 13, characters 24-33:
     13 | (*@ function test : t = { x = 0 }  *)
                                  ^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/unbound_field2.mli
+++ b/test/name_res/records/creation_neg/unbound_field2.mli
@@ -13,7 +13,7 @@
 (*@ function test : t = { x = 0 } *)
 
 (* {gospel_expected|
-[1] File "unbound_field2.mli", line 13, characters 24-33:
+[1] File "./unbound_field2.mli", line 13, characters 24-33:
     13 | (*@ function test : t = { x = 0 } *)
                                  ^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/unbound_field3.mli
+++ b/test/name_res/records/creation_neg/unbound_field3.mli
@@ -15,7 +15,7 @@ end
 (*@ axiom ax : forall r. { x = 0 } *)
 
 (* {gospel_expected|
-[1] File "unbound_field3.mli", line 15, characters 25-34:
+[1] File "./unbound_field3.mli", line 15, characters 25-34:
     15 | (*@ axiom ax : forall r. { x = 0 } *)
                                   ^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/unbound_field4.mli
+++ b/test/name_res/records/creation_neg/unbound_field4.mli
@@ -13,7 +13,7 @@
 (*@ axiom ax : forall r : t. { x = 0 } *)
 
 (* {gospel_expected|
-[1] File "unbound_field4.mli", line 13, characters 29-38:
+[1] File "./unbound_field4.mli", line 13, characters 29-38:
     13 | (*@ axiom ax : forall r : t. { x = 0 } *)
                                       ^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/unbound_field5.mli
+++ b/test/name_res/records/creation_neg/unbound_field5.mli
@@ -13,7 +13,7 @@
 (*@ axiom ax : forall r : t. { x = 0; y = 0 } *)
 
 (* {gospel_expected|
-[1] File "unbound_field5.mli", line 13, characters 29-45:
+[1] File "./unbound_field5.mli", line 13, characters 29-45:
     13 | (*@ axiom ax : forall r : t. { x = 0; y = 0 } *)
                                       ^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/records/creation_neg/unbound_field6.mli
+++ b/test/name_res/records/creation_neg/unbound_field6.mli
@@ -13,7 +13,7 @@
 (*@ axiom ax : forall r : t. { x = 0; y = 0 } *)
 
 (* {gospel_expected|
-[1] File "unbound_field6.mli", line 13, characters 29-45:
+[1] File "./unbound_field6.mli", line 13, characters 29-45:
     13 | (*@ axiom ax : forall r : t. { x = 0; y = 0 } *)
                                       ^^^^^^^^^^^^^^^^
     Error: No record found with the provided labels

--- a/test/name_res/types/aliases/cyclic_alias1.mli
+++ b/test/name_res/types/aliases/cyclic_alias1.mli
@@ -11,7 +11,7 @@
 (*@ type t1 = t1 *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias1.mli", line 11, characters 4-16:
+[1] File "./cyclic_alias1.mli", line 11, characters 4-16:
     11 | (*@ type t1 = t1 *)
              ^^^^^^^^^^^^
     Error: The type abbreviation t1 is cyclic

--- a/test/name_res/types/aliases/cyclic_alias10.mli
+++ b/test/name_res/types/aliases/cyclic_alias10.mli
@@ -15,7 +15,7 @@
     and t4 = (integer * integer) -> t3 sequence *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias10.mli", line 12, characters 4-52:
+[1] File "./cyclic_alias10.mli", line 12, characters 4-52:
     12 | ....and t1 = (integer * integer) -> t2 sequence
     13 |     ...........................................
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias11.mli
+++ b/test/name_res/types/aliases/cyclic_alias11.mli
@@ -15,7 +15,7 @@
     and t4 = (integer * t) -> t3 sequence *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias11.mli", line 12, characters 4-46:
+[1] File "./cyclic_alias11.mli", line 12, characters 4-46:
     12 | ....and t1 = (integer * t) -> t2 sequence
     13 |     .....................................
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias2.mli
+++ b/test/name_res/types/aliases/cyclic_alias2.mli
@@ -11,7 +11,7 @@
 (*@ type t1 = t2 and t2 = t1 *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias2.mli", line 11, characters 4-17:
+[1] File "./cyclic_alias2.mli", line 11, characters 4-17:
     11 | (*@ type t1 = t2 and t2 = t1 *)
              ^^^^^^^^^^^^^
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias3.mli
+++ b/test/name_res/types/aliases/cyclic_alias3.mli
@@ -11,7 +11,7 @@
 (*@ type t1 = t2 and t2 = t3 and t3 = t1 *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias3.mli", line 11, characters 4-17:
+[1] File "./cyclic_alias3.mli", line 11, characters 4-17:
     11 | (*@ type t1 = t2 and t2 = t3 and t3 = t1 *)
              ^^^^^^^^^^^^^
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias4.mli
+++ b/test/name_res/types/aliases/cyclic_alias4.mli
@@ -11,7 +11,7 @@
 (*@ type t1 = t2 * integer and t2 = t3 * integer and t3 = t1 * integer *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias4.mli", line 11, characters 4-27:
+[1] File "./cyclic_alias4.mli", line 11, characters 4-27:
     11 | (*@ type t1 = t2 * integer and t2 = t3 * integer and t3 = t1 * integer *)
              ^^^^^^^^^^^^^^^^^^^^^^^
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias5.mli
+++ b/test/name_res/types/aliases/cyclic_alias5.mli
@@ -11,7 +11,7 @@
 (*@ type t1 = t2 -> integer and t2 = t3 -> integer and t3 = t1 -> integer *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias5.mli", line 11, characters 4-28:
+[1] File "./cyclic_alias5.mli", line 11, characters 4-28:
     11 | (*@ type t1 = t2 -> integer and t2 = t3 -> integer and t3 = t1 -> integer *)
              ^^^^^^^^^^^^^^^^^^^^^^^^
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias6.mli
+++ b/test/name_res/types/aliases/cyclic_alias6.mli
@@ -13,7 +13,7 @@
     and t3 = (t1 * integer) -> integer *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias6.mli", line 11, characters 4-44:
+[1] File "./cyclic_alias6.mli", line 11, characters 4-44:
     11 | ....type t1 = (t2 * integer) -> integer
     12 |     ..................................
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias7.mli
+++ b/test/name_res/types/aliases/cyclic_alias7.mli
@@ -13,7 +13,7 @@
     and t3 = (integer * t1) *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias7.mli", line 11, characters 4-33:
+[1] File "./cyclic_alias7.mli", line 11, characters 4-33:
     11 | ....type t1 = (integer * t2)
     12 |     .......................
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias8.mli
+++ b/test/name_res/types/aliases/cyclic_alias8.mli
@@ -14,7 +14,7 @@
     and t4 = (integer * integer) -> t1 sequence *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias8.mli", line 11, characters 4-53:
+[1] File "./cyclic_alias8.mli", line 11, characters 4-53:
     11 | ....type t1 = (integer * integer) -> t2 sequence
     12 |     ...........................................
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/aliases/cyclic_alias9.mli
+++ b/test/name_res/types/aliases/cyclic_alias9.mli
@@ -14,7 +14,7 @@
     and t4 = (integer * integer) -> t3 sequence *)
 
 (* {gospel_expected|
-[1] File "cyclic_alias9.mli", line 11, characters 4-53:
+[1] File "./cyclic_alias9.mli", line 11, characters 4-53:
     11 | ....type t1 = (integer * integer) -> t2 sequence
     12 |     ...........................................
     Error: The type abbreviation t1 contains a cycle

--- a/test/name_res/types/type_not_axiom.mli
+++ b/test/name_res/types/type_not_axiom.mli
@@ -13,7 +13,7 @@
 (*@ type t = ax *)
 
 (* {gospel_expected|
-[1] File "type_not_axiom.mli", line 13, characters 13-15:
+[1] File "./type_not_axiom.mli", line 13, characters 13-15:
     13 | (*@ type t = ax *)
                       ^^
     Error: Unbound type constructor ax

--- a/test/name_res/types/type_not_field.mli
+++ b/test/name_res/types/type_not_field.mli
@@ -13,7 +13,7 @@
 (*@ type test = field *)
 
 (* {gospel_expected|
-[1] File "type_not_field.mli", line 13, characters 16-21:
+[1] File "./type_not_field.mli", line 13, characters 16-21:
     13 | (*@ type test = field *)
                          ^^^^^
     Error: Unbound type constructor field

--- a/test/name_res/types/type_not_var.mli
+++ b/test/name_res/types/type_not_var.mli
@@ -13,7 +13,7 @@
 (*@ type t = f *)
 
 (* {gospel_expected|
-[1] File "type_not_var.mli", line 13, characters 13-14:
+[1] File "./type_not_var.mli", line 13, characters 13-14:
     13 | (*@ type t = f *)
                       ^
     Error: Unbound type constructor f

--- a/test/name_res/types/unbound_module1.mli
+++ b/test/name_res/types/unbound_module1.mli
@@ -15,7 +15,7 @@ end
 (*@ type test = t *)
 
 (* {gospel_expected|
-[1] File "unbound_module1.mli", line 15, characters 16-17:
+[1] File "./unbound_module1.mli", line 15, characters 16-17:
     15 | (*@ type test = t *)
                          ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_module2.mli
+++ b/test/name_res/types/unbound_module2.mli
@@ -13,7 +13,7 @@ module M : sig end
 (*@ type test = M.t *)
 
 (* {gospel_expected|
-[1] File "unbound_module2.mli", line 13, characters 18-19:
+[1] File "./unbound_module2.mli", line 13, characters 18-19:
     13 | (*@ type test = M.t *)
                            ^
     Error: Unbound type constructor M.t

--- a/test/name_res/types/unbound_module3.mli
+++ b/test/name_res/types/unbound_module3.mli
@@ -15,7 +15,7 @@ module M : sig end
 (*@ type test = M.t *)
 
 (* {gospel_expected|
-[1] File "unbound_module3.mli", line 15, characters 18-19:
+[1] File "./unbound_module3.mli", line 15, characters 18-19:
     15 | (*@ type test = M.t *)
                            ^
     Error: Unbound type constructor M.t

--- a/test/name_res/types/unbound_module4.mli
+++ b/test/name_res/types/unbound_module4.mli
@@ -17,7 +17,7 @@ end
 (*@ type test = M.t *)
 
 (* {gospel_expected|
-[1] File "unbound_module4.mli", line 17, characters 18-19:
+[1] File "./unbound_module4.mli", line 17, characters 18-19:
     17 | (*@ type test = M.t *)
                            ^
     Error: Unbound type constructor M.t

--- a/test/name_res/types/unbound_type1.mli
+++ b/test/name_res/types/unbound_type1.mli
@@ -11,7 +11,7 @@
 (*@ type test = t *)
 
 (* {gospel_expected|
-[1] File "unbound_type1.mli", line 11, characters 16-17:
+[1] File "./unbound_type1.mli", line 11, characters 16-17:
     11 | (*@ type test = t *)
                          ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type10.mli
+++ b/test/name_res/types/unbound_type10.mli
@@ -11,7 +11,7 @@
 (*@ type test = (t, t) map *)
 
 (* {gospel_expected|
-[1] File "unbound_type10.mli", line 11, characters 17-18:
+[1] File "./unbound_type10.mli", line 11, characters 17-18:
     11 | (*@ type test = (t, t) map *)
                           ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type2.mli
+++ b/test/name_res/types/unbound_type2.mli
@@ -11,7 +11,7 @@
 (*@ type test = t sequence *)
 
 (* {gospel_expected|
-[1] File "unbound_type2.mli", line 11, characters 16-17:
+[1] File "./unbound_type2.mli", line 11, characters 16-17:
     11 | (*@ type test = t sequence *)
                          ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type3.mli
+++ b/test/name_res/types/unbound_type3.mli
@@ -11,7 +11,7 @@
 (*@ type test = integer -> t *)
 
 (* {gospel_expected|
-[1] File "unbound_type3.mli", line 11, characters 27-28:
+[1] File "./unbound_type3.mli", line 11, characters 27-28:
     11 | (*@ type test = integer -> t *)
                                     ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type4.mli
+++ b/test/name_res/types/unbound_type4.mli
@@ -11,7 +11,7 @@
 (*@ type test = t -> integer *)
 
 (* {gospel_expected|
-[1] File "unbound_type4.mli", line 11, characters 16-17:
+[1] File "./unbound_type4.mli", line 11, characters 16-17:
     11 | (*@ type test = t -> integer *)
                          ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type5.mli
+++ b/test/name_res/types/unbound_type5.mli
@@ -11,7 +11,7 @@
 (*@ type test = t -> t *)
 
 (* {gospel_expected|
-[1] File "unbound_type5.mli", line 11, characters 16-17:
+[1] File "./unbound_type5.mli", line 11, characters 16-17:
     11 | (*@ type test = t -> t *)
                          ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type6.mli
+++ b/test/name_res/types/unbound_type6.mli
@@ -11,7 +11,7 @@
 (*@ type test = integer * t *)
 
 (* {gospel_expected|
-[1] File "unbound_type6.mli", line 11, characters 26-27:
+[1] File "./unbound_type6.mli", line 11, characters 26-27:
     11 | (*@ type test = integer * t *)
                                    ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type7.mli
+++ b/test/name_res/types/unbound_type7.mli
@@ -13,7 +13,7 @@
 (*@ type test = t2 *)
 
 (* {gospel_expected|
-[1] File "unbound_type7.mli", line 13, characters 16-18:
+[1] File "./unbound_type7.mli", line 13, characters 16-18:
     13 | (*@ type test = t2 *)
                          ^^
     Error: Unbound type constructor t2

--- a/test/name_res/types/unbound_type8.mli
+++ b/test/name_res/types/unbound_type8.mli
@@ -11,7 +11,7 @@
 (*@ type test = t * t *)
 
 (* {gospel_expected|
-[1] File "unbound_type8.mli", line 11, characters 16-17:
+[1] File "./unbound_type8.mli", line 11, characters 16-17:
     11 | (*@ type test = t * t *)
                          ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_type9.mli
+++ b/test/name_res/types/unbound_type9.mli
@@ -11,7 +11,7 @@
 (*@ type test = integer * t *)
 
 (* {gospel_expected|
-[1] File "unbound_type9.mli", line 11, characters 26-27:
+[1] File "./unbound_type9.mli", line 11, characters 26-27:
     11 | (*@ type test = integer * t *)
                                    ^
     Error: Unbound type constructor t

--- a/test/name_res/types/unbound_var1.mli
+++ b/test/name_res/types/unbound_var1.mli
@@ -11,7 +11,7 @@
 (*@ type t = 'a sequence *)
 
 (* {gospel_expected|
-[1] File "unbound_var1.mli", line 11, characters 13-15:
+[1] File "./unbound_var1.mli", line 11, characters 13-15:
     11 | (*@ type t = 'a sequence *)
                       ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var10.mli
+++ b/test/name_res/types/unbound_var10.mli
@@ -11,7 +11,7 @@
 (*@ type ('b, 'c) t = { y : 'b; x : 'a } *)
 
 (* {gospel_expected|
-[1] File "unbound_var10.mli", line 11, characters 36-38:
+[1] File "./unbound_var10.mli", line 11, characters 36-38:
     11 | (*@ type ('b, 'c) t = { y : 'b; x : 'a } *)
                                              ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var19.mli
+++ b/test/name_res/types/unbound_var19.mli
@@ -11,7 +11,7 @@
 (*@ type ('b, 'c) t = { x : 'a; y : 'b } *)
 
 (* {gospel_expected|
-[1] File "unbound_var19.mli", line 11, characters 28-30:
+[1] File "./unbound_var19.mli", line 11, characters 28-30:
     11 | (*@ type ('b, 'c) t = { x : 'a; y : 'b } *)
                                      ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var2.mli
+++ b/test/name_res/types/unbound_var2.mli
@@ -11,7 +11,7 @@
 (*@ type 'b t = 'a sequence *)
 
 (* {gospel_expected|
-[1] File "unbound_var2.mli", line 11, characters 16-18:
+[1] File "./unbound_var2.mli", line 11, characters 16-18:
     11 | (*@ type 'b t = 'a sequence *)
                          ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var3.mli
+++ b/test/name_res/types/unbound_var3.mli
@@ -11,7 +11,7 @@
 (*@ type ('c, 'b) t = 'a sequence *)
 
 (* {gospel_expected|
-[1] File "unbound_var3.mli", line 11, characters 22-24:
+[1] File "./unbound_var3.mli", line 11, characters 22-24:
     11 | (*@ type ('c, 'b) t = 'a sequence *)
                                ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var4.mli
+++ b/test/name_res/types/unbound_var4.mli
@@ -11,7 +11,7 @@
 (*@ type ('c, 'b) t = ('a, 'b) map *)
 
 (* {gospel_expected|
-[1] File "unbound_var4.mli", line 11, characters 23-25:
+[1] File "./unbound_var4.mli", line 11, characters 23-25:
     11 | (*@ type ('c, 'b) t = ('a, 'b) map *)
                                 ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var5.mli
+++ b/test/name_res/types/unbound_var5.mli
@@ -11,7 +11,7 @@
 (*@ type ('c, 'b) t = ('b, 'a) map *)
 
 (* {gospel_expected|
-[1] File "unbound_var5.mli", line 11, characters 27-29:
+[1] File "./unbound_var5.mli", line 11, characters 27-29:
     11 | (*@ type ('c, 'b) t = ('b, 'a) map *)
                                     ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var6.mli
+++ b/test/name_res/types/unbound_var6.mli
@@ -11,7 +11,7 @@
 (*@ type 'b t = { x : 'a } *)
 
 (* {gospel_expected|
-[1] File "unbound_var6.mli", line 11, characters 22-24:
+[1] File "./unbound_var6.mli", line 11, characters 22-24:
     11 | (*@ type 'b t = { x : 'a } *)
                                ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var7.mli
+++ b/test/name_res/types/unbound_var7.mli
@@ -11,7 +11,7 @@
 (*@ type ('b, 'c) t = { x : 'a } *)
 
 (* {gospel_expected|
-[1] File "unbound_var7.mli", line 11, characters 28-30:
+[1] File "./unbound_var7.mli", line 11, characters 28-30:
     11 | (*@ type ('b, 'c) t = { x : 'a } *)
                                      ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var8.mli
+++ b/test/name_res/types/unbound_var8.mli
@@ -11,7 +11,7 @@
 (*@ type ('b, 'c) t = { x : 'a; y : 'b } *)
 
 (* {gospel_expected|
-[1] File "unbound_var8.mli", line 11, characters 28-30:
+[1] File "./unbound_var8.mli", line 11, characters 28-30:
     11 | (*@ type ('b, 'c) t = { x : 'a; y : 'b } *)
                                      ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/types/unbound_var9.mli
+++ b/test/name_res/types/unbound_var9.mli
@@ -11,7 +11,7 @@
 (*@ type ('b, 'c) t = { x : 'a; y : 'b } *)
 
 (* {gospel_expected|
-[1] File "unbound_var9.mli", line 11, characters 28-30:
+[1] File "./unbound_var9.mli", line 11, characters 28-30:
     11 | (*@ type ('b, 'c) t = { x : 'a; y : 'b } *)
                                      ^^
     Error: The type variable 'a is unbound in this type declaration

--- a/test/name_res/val_specs/consume_ret.mli
+++ b/test/name_res/val_specs/consume_ret.mli
@@ -14,7 +14,7 @@ val f : int -> int
  *)
 
 (* {gospel_expected|
-[1] File "consume_ret.mli", line 13, characters 13-14:
+[1] File "./consume_ret.mli", line 13, characters 13-14:
     13 |     consumes y
                       ^
     Error: Unbound value y

--- a/test/name_res/val_specs/invalid_header_nm.mli
+++ b/test/name_res/val_specs/invalid_header_nm.mli
@@ -13,7 +13,7 @@ val inc : int -> int
     ensures y = x - 1 *)
 
 (* {gospel_expected|
-[1] File "invalid_header_nm.mli", line 12, characters 8-11:
+[1] File "./invalid_header_nm.mli", line 12, characters 8-11:
     12 | (*@ y = dec x
                  ^^^
     Error: Header name dec does not match the declared value inc in the OCaml interface

--- a/test/name_res/val_specs/no_gospel_rep1.mli
+++ b/test/name_res/val_specs/no_gospel_rep1.mli
@@ -15,7 +15,7 @@ val f : unit -> t
     ensures x = x *)
 
 (* {gospel_expected|
-[1] File "no_gospel_rep1.mli", line 15, characters 16-17:
+[1] File "./no_gospel_rep1.mli", line 15, characters 16-17:
     15 |     ensures x = x *)
                          ^
     Error: Unbound value x

--- a/test/name_res/val_specs/no_gospel_rep2.mli
+++ b/test/name_res/val_specs/no_gospel_rep2.mli
@@ -17,7 +17,7 @@ val f : unit -> t
     ensures x = x *)
 
 (* {gospel_expected|
-[1] File "no_gospel_rep2.mli", line 17, characters 16-17:
+[1] File "./no_gospel_rep2.mli", line 17, characters 16-17:
     17 |     ensures x = x *)
                          ^
     Error: Unbound value x

--- a/test/name_res/val_specs/no_gospel_rep3.mli
+++ b/test/name_res/val_specs/no_gospel_rep3.mli
@@ -17,7 +17,7 @@ val f : t -> unit
     requires x = x *)
 
 (* {gospel_expected|
-[1] File "no_gospel_rep3.mli", line 17, characters 17-18:
+[1] File "./no_gospel_rep3.mli", line 17, characters 17-18:
     17 |     requires x = x *)
                           ^
     Error: Unbound value x

--- a/test/name_res/val_specs/not_produced.mli
+++ b/test/name_res/val_specs/not_produced.mli
@@ -18,7 +18,7 @@ val free : t -> unit
 *)
 
 (* {gospel_expected|
-[1] File "not_produced.mli", line 17, characters 16-17:
+[1] File "./not_produced.mli", line 17, characters 16-17:
     17 |     ensures x = x
                          ^
     Error: Unbound value x

--- a/test/name_res/val_specs/not_produced_top_level1.mli
+++ b/test/name_res/val_specs/not_produced_top_level1.mli
@@ -15,7 +15,7 @@ val f : int -> int
  *)
 
 (* {gospel_expected|
-[1] File "not_produced_top_level1.mli", line 14, characters 12-13:
+[1] File "./not_produced_top_level1.mli", line 14, characters 12-13:
     14 |     ensures x = y
                      ^
     Error: Unbound value x

--- a/test/name_res/val_specs/not_produced_top_level2.mli
+++ b/test/name_res/val_specs/not_produced_top_level2.mli
@@ -15,7 +15,7 @@ val f : int -> int
  *)
 
 (* {gospel_expected|
-[1] File "not_produced_top_level2.mli", line 14, characters 12-13:
+[1] File "./not_produced_top_level2.mli", line 14, characters 12-13:
     14 |     ensures x = y
                      ^
     Error: Unbound value x

--- a/test/name_res/val_specs/not_produced_top_level3.mli
+++ b/test/name_res/val_specs/not_produced_top_level3.mli
@@ -17,7 +17,7 @@ val f : int -> int
  *)
 
 (* {gospel_expected|
-[1] File "not_produced_top_level3.mli", line 16, characters 14-15:
+[1] File "./not_produced_top_level3.mli", line 16, characters 14-15:
     16 |     ensures M.x = y
                        ^
     Error: Unbound value M.x

--- a/test/name_res/val_specs/not_produced_top_level4.mli
+++ b/test/name_res/val_specs/not_produced_top_level4.mli
@@ -19,7 +19,7 @@ val f : int -> int
  *)
 
 (* {gospel_expected|
-[1] File "not_produced_top_level4.mli", line 18, characters 12-13:
+[1] File "./not_produced_top_level4.mli", line 18, characters 12-13:
     18 |     ensures x = y
                      ^
     Error: Unbound value x

--- a/test/name_res/val_specs/own_ghost1.mli
+++ b/test/name_res/val_specs/own_ghost1.mli
@@ -13,7 +13,7 @@ val f : int -> int
     consumes x *)
 
 (* {gospel_expected|
-[1] File "own_ghost1.mli", line 13, characters 13-14:
+[1] File "./own_ghost1.mli", line 13, characters 13-14:
     13 |     consumes x *)
                       ^
     Error: Unbound value x

--- a/test/name_res/val_specs/own_ghost2.mli
+++ b/test/name_res/val_specs/own_ghost2.mli
@@ -13,7 +13,7 @@ val f : int -> int
     modifies x *)
 
 (* {gospel_expected|
-[1] File "own_ghost2.mli", line 13, characters 13-14:
+[1] File "./own_ghost2.mli", line 13, characters 13-14:
     13 |     modifies x *)
                       ^
     Error: Unbound value x

--- a/test/name_res/val_specs/own_ghost3.mli
+++ b/test/name_res/val_specs/own_ghost3.mli
@@ -13,7 +13,7 @@ val f : int -> int
     consumes x *)
 
 (* {gospel_expected|
-[1] File "own_ghost3.mli", line 13, characters 13-14:
+[1] File "./own_ghost3.mli", line 13, characters 13-14:
     13 |     consumes x *)
                       ^
     Error: Unbound value x

--- a/test/name_res/variables/axiom_name_invalid.mli
+++ b/test/name_res/variables/axiom_name_invalid.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom ax : ax *)
 (* {gospel_expected|
-[1] File "axiom_name_invalid.mli", line 11, characters 15-17:
+[1] File "./axiom_name_invalid.mli", line 11, characters 15-17:
     11 | (*@ axiom ax : ax *)
                         ^^
     Error: Unbound value ax

--- a/test/name_res/variables/escape_scope1.mli
+++ b/test/name_res/variables/escape_scope1.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : (let x = 0 in x) + x *)
 
 (* {gospel_expected|
-[1] File "escape_scope1.mli", line 11, characters 36-37:
+[1] File "./escape_scope1.mli", line 11, characters 36-37:
     11 | (*@ axiom test : (let x = 0 in x) + x *)
                                              ^
     Error: Unbound value x

--- a/test/name_res/variables/escape_scope2.mli
+++ b/test/name_res/variables/escape_scope2.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : x + (let x = 0 in x) *)
 
 (* {gospel_expected|
-[1] File "escape_scope2.mli", line 11, characters 17-18:
+[1] File "./escape_scope2.mli", line 11, characters 17-18:
     11 | (*@ axiom test : x + (let x = 0 in x) *)
                           ^
     Error: Unbound value x

--- a/test/name_res/variables/escape_scope3.mli
+++ b/test/name_res/variables/escape_scope3.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : (fun x -> x) x *)
 
 (* {gospel_expected|
-[1] File "escape_scope3.mli", line 11, characters 28-29:
+[1] File "./escape_scope3.mli", line 11, characters 28-29:
     11 | (*@ axiom ax : (fun x -> x) x *)
                                      ^
     Error: Unbound value x

--- a/test/name_res/variables/escape_scope4.mli
+++ b/test/name_res/variables/escape_scope4.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : let f = (fun x -> x) in f x *)
 
 (* {gospel_expected|
-[1] File "escape_scope4.mli", line 11, characters 41-42:
+[1] File "./escape_scope4.mli", line 11, characters 41-42:
     11 | (*@ axiom ax : let f = (fun x -> x) in f x *)
                                                   ^
     Error: Unbound value x

--- a/test/name_res/variables/escape_scope5.mli
+++ b/test/name_res/variables/escape_scope5.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : (forall x. True) /\ x *)
 
 (* {gospel_expected|
-[1] File "escape_scope5.mli", line 11, characters 35-36:
+[1] File "./escape_scope5.mli", line 11, characters 35-36:
     11 | (*@ axiom ax : (forall x. True) /\ x *)
                                             ^
     Error: Unbound value x

--- a/test/name_res/variables/escape_scope6.mli
+++ b/test/name_res/variables/escape_scope6.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : (exists x. True) /\ x *)
 
 (* {gospel_expected|
-[1] File "escape_scope6.mli", line 11, characters 37-38:
+[1] File "./escape_scope6.mli", line 11, characters 37-38:
     11 | (*@ axiom test : (exists x. True) /\ x *)
                                               ^
     Error: Unbound value x

--- a/test/name_res/variables/non_recursive1.mli
+++ b/test/name_res/variables/non_recursive1.mli
@@ -11,7 +11,7 @@
 (*@ function f : integer = f *)
 
 (* {gospel_expected|
-[1] File "non_recursive1.mli", line 11, characters 27-28:
+[1] File "./non_recursive1.mli", line 11, characters 27-28:
     11 | (*@ function f : integer = f *)
                                     ^
     Error: Unbound value f

--- a/test/name_res/variables/non_recursive2.mli
+++ b/test/name_res/variables/non_recursive2.mli
@@ -11,7 +11,7 @@
 (*@ predicate p = p *)
 
 (* {gospel_expected|
-[1] File "non_recursive2.mli", line 11, characters 18-19:
+[1] File "./non_recursive2.mli", line 11, characters 18-19:
     11 | (*@ predicate p = p *)
                            ^
     Error: Unbound value p

--- a/test/name_res/variables/non_recursive3.mli
+++ b/test/name_res/variables/non_recursive3.mli
@@ -11,7 +11,7 @@
 (*@ predicate p (n : integer) = p *)
 
 (* {gospel_expected|
-[1] File "non_recursive3.mli", line 11, characters 32-33:
+[1] File "./non_recursive3.mli", line 11, characters 32-33:
     11 | (*@ predicate p (n : integer) = p *)
                                          ^
     Error: Unbound value p

--- a/test/name_res/variables/non_recursive4.mli
+++ b/test/name_res/variables/non_recursive4.mli
@@ -11,7 +11,7 @@
 (*@ function f (n : integer) : integer = f *)
 
 (* {gospel_expected|
-[1] File "non_recursive4.mli", line 11, characters 41-42:
+[1] File "./non_recursive4.mli", line 11, characters 41-42:
     11 | (*@ function f (n : integer) : integer = f *)
                                                   ^
     Error: Unbound value f

--- a/test/name_res/variables/non_recursive5.mli
+++ b/test/name_res/variables/non_recursive5.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : let x = x in True *)
 
 (* {gospel_expected|
-[1] File "non_recursive5.mli", line 11, characters 25-26:
+[1] File "./non_recursive5.mli", line 11, characters 25-26:
     11 | (*@ axiom test : let x = x in True *)
                                   ^
     Error: Unbound value x

--- a/test/name_res/variables/unbound_module1.mli
+++ b/test/name_res/variables/unbound_module1.mli
@@ -13,7 +13,7 @@ module M : sig end
 (*@ axiom test : M.f *)
 
 (* {gospel_expected|
-[1] File "unbound_module1.mli", line 13, characters 19-20:
+[1] File "./unbound_module1.mli", line 13, characters 19-20:
     13 | (*@ axiom test : M.f *)
                             ^
     Error: Unbound value M.f

--- a/test/name_res/variables/unbound_module2.mli
+++ b/test/name_res/variables/unbound_module2.mli
@@ -15,7 +15,7 @@ end
 (*@ axiom test : M.f *)
 
 (* {gospel_expected|
-[1] File "unbound_module2.mli", line 15, characters 19-20:
+[1] File "./unbound_module2.mli", line 15, characters 19-20:
     15 | (*@ axiom test : M.f *)
                             ^
     Error: Unbound value M.f

--- a/test/name_res/variables/unbound_module3.mli
+++ b/test/name_res/variables/unbound_module3.mli
@@ -17,7 +17,7 @@ end
 (*@ axiom test : M.f *)
 
 (* {gospel_expected|
-[1] File "unbound_module3.mli", line 17, characters 19-20:
+[1] File "./unbound_module3.mli", line 17, characters 19-20:
     17 | (*@ axiom test : M.f *)
                             ^
     Error: Unbound value M.f

--- a/test/name_res/variables/unbound_module4.mli
+++ b/test/name_res/variables/unbound_module4.mli
@@ -15,7 +15,7 @@ end
 (*@ axiom test : f *)
 
 (* {gospel_expected|
-[1] File "unbound_module4.mli", line 15, characters 17-18:
+[1] File "./unbound_module4.mli", line 15, characters 17-18:
     15 | (*@ axiom test : f *)
                           ^
     Error: Unbound value f

--- a/test/name_res/variables/unbound_var1.mli
+++ b/test/name_res/variables/unbound_var1.mli
@@ -11,7 +11,7 @@
 (*@ function f : integer = n *)
 
 (* {gospel_expected|
-[1] File "unbound_var1.mli", line 11, characters 27-28:
+[1] File "./unbound_var1.mli", line 11, characters 27-28:
     11 | (*@ function f : integer = n *)
                                     ^
     Error: Unbound value n

--- a/test/name_res/variables/unbound_var2.mli
+++ b/test/name_res/variables/unbound_var2.mli
@@ -13,7 +13,7 @@
 (*@ function n : integer *)
 
 (* {gospel_expected|
-[1] File "unbound_var2.mli", line 11, characters 27-28:
+[1] File "./unbound_var2.mli", line 11, characters 27-28:
     11 | (*@ function f : integer = n *)
                                     ^
     Error: Unbound value n

--- a/test/name_res/variables/var_not_field.mli
+++ b/test/name_res/variables/var_not_field.mli
@@ -13,7 +13,7 @@
 (*@ axiom test : field *)
 
 (* {gospel_expected|
-[1] File "var_not_field.mli", line 13, characters 17-22:
+[1] File "./var_not_field.mli", line 13, characters 17-22:
     13 | (*@ axiom test : field *)
                           ^^^^^
     Error: Unbound value field

--- a/test/name_res/variables/var_not_module.mli
+++ b/test/name_res/variables/var_not_module.mli
@@ -13,7 +13,7 @@ module M : sig end
 (*@ axiom ax : M *)
 
 (* {gospel_expected|
-[1] File "var_not_module.mli", line 13, characters 15-16:
+[1] File "./var_not_module.mli", line 13, characters 15-16:
     13 | (*@ axiom ax : M *)
                         ^
     Error: Unbound value M

--- a/test/name_res/variables/var_not_type.mli
+++ b/test/name_res/variables/var_not_type.mli
@@ -13,7 +13,7 @@
 (*@ axiom test : t *)
 
 (* {gospel_expected|
-[1] File "var_not_type.mli", line 13, characters 17-18:
+[1] File "./var_not_type.mli", line 13, characters 17-18:
     13 | (*@ axiom test : t *)
                           ^
     Error: Unbound value t

--- a/test/namespaces/ocaml_record1.mli
+++ b/test/namespaces/ocaml_record1.mli
@@ -13,7 +13,7 @@ type t1 = { f : int }
 (*@ axiom ax : forall x. x.f = x.f *)
 
 (* {gospel_expected|
-[1] File "ocaml_record1.mli", line 13, characters 33-34:
+[1] File "./ocaml_record1.mli", line 13, characters 33-34:
     13 | (*@ axiom ax : forall x. x.f = x.f *)
                                           ^
     Error: Unbound record label f

--- a/test/namespaces/ocaml_record3.mli
+++ b/test/namespaces/ocaml_record3.mli
@@ -14,7 +14,7 @@ type t1 = { f : int; g : int }
 (*@ axiom ax : forall x. x.g = x.f *)
 
 (* {gospel_expected|
-[1] File "ocaml_record3.mli", line 14, characters 27-28:
+[1] File "./ocaml_record3.mli", line 14, characters 27-28:
     14 | (*@ axiom ax : forall x. x.g = x.f *)
                                     ^
     Error: Unbound record label g

--- a/test/namespaces/ocaml_type1.mli
+++ b/test/namespaces/ocaml_type1.mli
@@ -13,7 +13,7 @@ type t1
 (*@ type t2 = t1 *)
 
 (* {gospel_expected|
-[1] File "ocaml_type1.mli", line 13, characters 14-16:
+[1] File "./ocaml_type1.mli", line 13, characters 14-16:
     13 | (*@ type t2 = t1 *)
                        ^^
     Error: Unbound type constructor t1

--- a/test/namespaces/ocaml_type2.mli
+++ b/test/namespaces/ocaml_type2.mli
@@ -13,7 +13,7 @@ type t1
 (*@ type t2 = t1 sequence *)
 
 (* {gospel_expected|
-[1] File "ocaml_type2.mli", line 13, characters 14-16:
+[1] File "./ocaml_type2.mli", line 13, characters 14-16:
     13 | (*@ type t2 = t1 sequence *)
                        ^^
     Error: Unbound type constructor t1

--- a/test/namespaces/ocaml_type3.mli
+++ b/test/namespaces/ocaml_type3.mli
@@ -13,7 +13,7 @@
 type t2 = t1
 
 (* {gospel_expected|
-[1] File "ocaml_type3.mli", line 13, characters 10-12:
+[1] File "./ocaml_type3.mli", line 13, characters 10-12:
     13 | type t2 = t1
                    ^^
     Error: Unbound type constructor t1

--- a/test/namespaces/ocaml_type4.mli
+++ b/test/namespaces/ocaml_type4.mli
@@ -13,7 +13,7 @@
 type t2 = t1 list
 
 (* {gospel_expected|
-[1] File "ocaml_type4.mli", line 13, characters 10-12:
+[1] File "./ocaml_type4.mli", line 13, characters 10-12:
     13 | type t2 = t1 list
                    ^^
     Error: Unbound type constructor t1

--- a/test/namespaces/ocaml_type5.mli
+++ b/test/namespaces/ocaml_type5.mli
@@ -13,7 +13,7 @@ type t1
 (*@ function test (x : t1) : integer = 0 *)
 
 (* {gospel_expected|
-[1] File "ocaml_type5.mli", line 13, characters 23-25:
+[1] File "./ocaml_type5.mli", line 13, characters 23-25:
     13 | (*@ function test (x : t1) : integer = 0 *)
                                 ^^
     Error: Unbound type constructor t1

--- a/test/parser/axioms_neg/axiom_no_def1.mli
+++ b/test/parser/axioms_neg/axiom_no_def1.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom a *)
 (* {gospel_expected|
-[1] File "axiom_no_def1.mli", line 11, characters 12-12:
+[1] File "./axiom_no_def1.mli", line 11, characters 12-12:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/axioms_neg/axiom_no_def2.mli
+++ b/test/parser/axioms_neg/axiom_no_def2.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom a : *)
 (* {gospel_expected|
-[1] File "axiom_no_def2.mli", line 11, characters 14-14:
+[1] File "./axiom_no_def2.mli", line 11, characters 14-14:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/axioms_neg/axiom_no_name.mli
+++ b/test/parser/axioms_neg/axiom_no_name.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom : True *)
 (* {gospel_expected|
-[1] File "axiom_no_name.mli", line 11, characters 10-11:
+[1] File "./axiom_no_name.mli", line 11, characters 10-11:
     11 | (*@ axiom : True *)
                    ^
     Error: Syntax error

--- a/test/parser/axioms_neg/axiom_num_name.mli
+++ b/test/parser/axioms_neg/axiom_num_name.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom 1 : True *)
 (* {gospel_expected|
-[1] File "axiom_num_name.mli", line 11, characters 10-11:
+[1] File "./axiom_num_name.mli", line 11, characters 10-11:
     11 | (*@ axiom 1 : True *)
                    ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_let.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_let.mli
@@ -11,7 +11,7 @@
 (*@ function (let) (x : integer) (y : integer) : integer *)
 
 (* {gospel_expected|
-[1] File "function_invalid_let.mli", line 11, characters 14-17:
+[1] File "./function_invalid_let.mli", line 11, characters 14-17:
     11 | (*@ function (let) (x : integer) (y : integer) : integer *)
                        ^^^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_operator1.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_operator1.mli
@@ -10,7 +10,7 @@
 
 (*@ function (f) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_operator1.mli", line 11, characters 14-15:
+[1] File "./function_invalid_operator1.mli", line 11, characters 14-15:
     11 | (*@ function (f) : integer *)
                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_operator2.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_operator2.mli
@@ -10,7 +10,7 @@
 
 (*@ function (+f) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_operator2.mli", line 11, characters 15-16:
+[1] File "./function_invalid_operator2.mli", line 11, characters 15-16:
     11 | (*@ function (+f) : integer *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_operator3.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_operator3.mli
@@ -10,7 +10,7 @@
 
 (*@ function (+g+) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_operator3.mli", line 11, characters 15-16:
+[1] File "./function_invalid_operator3.mli", line 11, characters 15-16:
     11 | (*@ function (+g+) : integer *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_parameter1.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_parameter1.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (X : integer) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter1.mli", line 11, characters 16-17:
+[1] File "./function_invalid_parameter1.mli", line 11, characters 16-17:
     11 | (*@ function f (X : integer) : integer *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_parameter2.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_parameter2.mli
@@ -10,7 +10,7 @@
 
 (*@ function f n : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter2.mli", line 11, characters 15-16:
+[1] File "./function_invalid_parameter2.mli", line 11, characters 15-16:
     11 | (*@ function f n : integer *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_parameter3.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_parameter3.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (n : integer) (X : integer) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter3.mli", line 11, characters 30-31:
+[1] File "./function_invalid_parameter3.mli", line 11, characters 30-31:
     11 | (*@ function f (n : integer) (X : integer) : integer *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_invalid_parameter4.mli
+++ b/test/parser/functions_neg/lowercase/function_invalid_parameter4.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (n : integer) n : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter4.mli", line 11, characters 29-30:
+[1] File "./function_invalid_parameter4.mli", line 11, characters 29-30:
     11 | (*@ function f (n : integer) n : integer *)
                                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_no_name.mli
+++ b/test/parser/functions_neg/lowercase/function_no_name.mli
@@ -10,7 +10,7 @@
 
 (*@ function = 0*)
 (* {gospel_expected|
-[1] File "function_no_name.mli", line 11, characters 13-14:
+[1] File "./function_no_name.mli", line 11, characters 13-14:
     11 | (*@ function = 0*)
                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_no_ret1.mli
+++ b/test/parser/functions_neg/lowercase/function_no_ret1.mli
@@ -10,7 +10,7 @@
 
 (*@ function f *)
 (* {gospel_expected|
-[1] File "function_no_ret1.mli", line 11, characters 15-15:
+[1] File "./function_no_ret1.mli", line 11, characters 15-15:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/functions_neg/lowercase/function_no_ret2.mli
+++ b/test/parser/functions_neg/lowercase/function_no_ret2.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (n : integer) *)
 (* {gospel_expected|
-[1] File "function_no_ret2.mli", line 11, characters 29-29:
+[1] File "./function_no_ret2.mli", line 11, characters 29-29:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/functions_neg/lowercase/function_no_ret3.mli
+++ b/test/parser/functions_neg/lowercase/function_no_ret3.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (n1 : integer) (n2 : integer) *)
 (* {gospel_expected|
-[1] File "function_no_ret3.mli", line 11, characters 45-45:
+[1] File "./function_no_ret3.mli", line 11, characters 45-45:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/functions_neg/lowercase/function_no_ret4.mli
+++ b/test/parser/functions_neg/lowercase/function_no_ret4.mli
@@ -10,7 +10,7 @@
 
 (*@ function f = 0 *)
 (* {gospel_expected|
-[1] File "function_no_ret4.mli", line 11, characters 15-16:
+[1] File "./function_no_ret4.mli", line 11, characters 15-16:
     11 | (*@ function f = 0 *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_no_ret5.mli
+++ b/test/parser/functions_neg/lowercase/function_no_ret5.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (n : integer) = 0 *)
 (* {gospel_expected|
-[1] File "function_no_ret5.mli", line 11, characters 29-30:
+[1] File "./function_no_ret5.mli", line 11, characters 29-30:
     11 | (*@ function f (n : integer) = 0 *)
                                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_no_ret6.mli
+++ b/test/parser/functions_neg/lowercase/function_no_ret6.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (n1 : integer) (n2 : integer) = 0 *)
 (* {gospel_expected|
-[1] File "function_no_ret6.mli", line 11, characters 45-46:
+[1] File "./function_no_ret6.mli", line 11, characters 45-46:
     11 | (*@ function f (n1 : integer) (n2 : integer) = 0 *)
                                                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/function_num_name.mli
+++ b/test/parser/functions_neg/lowercase/function_num_name.mli
@@ -10,7 +10,7 @@
 
 (*@ function 1 : integer *)
 (* {gospel_expected|
-[1] File "function_num_name.mli", line 11, characters 13-14:
+[1] File "./function_num_name.mli", line 11, characters 13-14:
     11 | (*@ function 1 : integer *)
                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_invalid_operator1.mli
+++ b/test/parser/functions_neg/lowercase/predicate_invalid_operator1.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate (f) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_operator1.mli", line 11, characters 15-16:
+[1] File "./predicate_invalid_operator1.mli", line 11, characters 15-16:
     11 | (*@ predicate (f) *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_invalid_operator2.mli
+++ b/test/parser/functions_neg/lowercase/predicate_invalid_operator2.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate (+f) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_operator2.mli", line 11, characters 16-17:
+[1] File "./predicate_invalid_operator2.mli", line 11, characters 16-17:
     11 | (*@ predicate (+f) *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_invalid_operator3.mli
+++ b/test/parser/functions_neg/lowercase/predicate_invalid_operator3.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate (+g+) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_operator3.mli", line 11, characters 16-17:
+[1] File "./predicate_invalid_operator3.mli", line 11, characters 16-17:
     11 | (*@ predicate (+g+) *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_invalid_parameter1.mli
+++ b/test/parser/functions_neg/lowercase/predicate_invalid_parameter1.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f (X : integer) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter1.mli", line 11, characters 17-18:
+[1] File "./predicate_invalid_parameter1.mli", line 11, characters 17-18:
     11 | (*@ predicate f (X : integer) *)
                           ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_invalid_parameter2.mli
+++ b/test/parser/functions_neg/lowercase/predicate_invalid_parameter2.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f n *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter2.mli", line 11, characters 16-17:
+[1] File "./predicate_invalid_parameter2.mli", line 11, characters 16-17:
     11 | (*@ predicate f n *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_invalid_parameter3.mli
+++ b/test/parser/functions_neg/lowercase/predicate_invalid_parameter3.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f (n : integer) (X : integer) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter3.mli", line 11, characters 31-32:
+[1] File "./predicate_invalid_parameter3.mli", line 11, characters 31-32:
     11 | (*@ predicate f (n : integer) (X : integer) *)
                                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_invalid_parameter4.mli
+++ b/test/parser/functions_neg/lowercase/predicate_invalid_parameter4.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f (n : integer) n *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter4.mli", line 11, characters 30-31:
+[1] File "./predicate_invalid_parameter4.mli", line 11, characters 30-31:
     11 | (*@ predicate f (n : integer) n *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_no_name.mli
+++ b/test/parser/functions_neg/lowercase/predicate_no_name.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate = True *)
 (* {gospel_expected|
-[1] File "predicate_no_name.mli", line 11, characters 14-15:
+[1] File "./predicate_no_name.mli", line 11, characters 14-15:
     11 | (*@ predicate = True *)
                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_num_name.mli
+++ b/test/parser/functions_neg/lowercase/predicate_num_name.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate 1 *)
 (* {gospel_expected|
-[1] File "predicate_num_name.mli", line 11, characters 14-15:
+[1] File "./predicate_num_name.mli", line 11, characters 14-15:
     11 | (*@ predicate 1 *)
                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_ret1.mli
+++ b/test/parser/functions_neg/lowercase/predicate_ret1.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f : prop *)
 (* {gospel_expected|
-[1] File "predicate_ret1.mli", line 11, characters 16-17:
+[1] File "./predicate_ret1.mli", line 11, characters 16-17:
     11 | (*@ predicate f : prop *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_ret2.mli
+++ b/test/parser/functions_neg/lowercase/predicate_ret2.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f (n : integer) : prop *)
 (* {gospel_expected|
-[1] File "predicate_ret2.mli", line 11, characters 30-31:
+[1] File "./predicate_ret2.mli", line 11, characters 30-31:
     11 | (*@ predicate f (n : integer) : prop *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_ret3.mli
+++ b/test/parser/functions_neg/lowercase/predicate_ret3.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f (n1 : integer) (n2 : integer) : prop *)
 (* {gospel_expected|
-[1] File "predicate_ret3.mli", line 11, characters 46-47:
+[1] File "./predicate_ret3.mli", line 11, characters 46-47:
     11 | (*@ predicate f (n1 : integer) (n2 : integer) : prop *)
                                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_ret4.mli
+++ b/test/parser/functions_neg/lowercase/predicate_ret4.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f : prop = 0 *)
 (* {gospel_expected|
-[1] File "predicate_ret4.mli", line 11, characters 16-17:
+[1] File "./predicate_ret4.mli", line 11, characters 16-17:
     11 | (*@ predicate f : prop = 0 *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_ret5.mli
+++ b/test/parser/functions_neg/lowercase/predicate_ret5.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f (n : integer) : prop = 0 *)
 (* {gospel_expected|
-[1] File "predicate_ret5.mli", line 11, characters 30-31:
+[1] File "./predicate_ret5.mli", line 11, characters 30-31:
     11 | (*@ predicate f (n : integer) : prop = 0 *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/lowercase/predicate_ret6.mli
+++ b/test/parser/functions_neg/lowercase/predicate_ret6.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate f (n1 : integer) (n2 : integer) : prop = 0 *)
 (* {gospel_expected|
-[1] File "predicate_ret6.mli", line 11, characters 46-47:
+[1] File "./predicate_ret6.mli", line 11, characters 46-47:
     11 | (*@ predicate f (n1 : integer) (n2 : integer) : prop = 0 *)
                                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_invalid_operator1.mli
+++ b/test/parser/functions_neg/uppercase/function_invalid_operator1.mli
@@ -10,7 +10,7 @@
 
 (*@ function (F) : integer*)
 (* {gospel_expected|
-[1] File "function_invalid_operator1.mli", line 11, characters 14-15:
+[1] File "./function_invalid_operator1.mli", line 11, characters 14-15:
     11 | (*@ function (F) : integer*)
                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_invalid_operator2.mli
+++ b/test/parser/functions_neg/uppercase/function_invalid_operator2.mli
@@ -10,7 +10,7 @@
 
 (*@ function (+F) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_operator2.mli", line 11, characters 15-16:
+[1] File "./function_invalid_operator2.mli", line 11, characters 15-16:
     11 | (*@ function (+F) : integer *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_invalid_operator3.mli
+++ b/test/parser/functions_neg/uppercase/function_invalid_operator3.mli
@@ -10,7 +10,7 @@
 
 (*@ function (+G+) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_operator3.mli", line 11, characters 15-16:
+[1] File "./function_invalid_operator3.mli", line 11, characters 15-16:
     11 | (*@ function (+G+) : integer *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_invalid_parameter1.mli
+++ b/test/parser/functions_neg/uppercase/function_invalid_parameter1.mli
@@ -10,7 +10,7 @@
 
 (*@ function f (X : integer) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter1.mli", line 11, characters 16-17:
+[1] File "./function_invalid_parameter1.mli", line 11, characters 16-17:
     11 | (*@ function f (X : integer) : integer *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_invalid_parameter2.mli
+++ b/test/parser/functions_neg/uppercase/function_invalid_parameter2.mli
@@ -10,7 +10,7 @@
 
 (*@ function F N : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter2.mli", line 11, characters 15-16:
+[1] File "./function_invalid_parameter2.mli", line 11, characters 15-16:
     11 | (*@ function F N : integer *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_invalid_parameter3.mli
+++ b/test/parser/functions_neg/uppercase/function_invalid_parameter3.mli
@@ -10,7 +10,7 @@
 
 (*@ function F (n : integer) (X : integer) : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter3.mli", line 11, characters 30-31:
+[1] File "./function_invalid_parameter3.mli", line 11, characters 30-31:
     11 | (*@ function F (n : integer) (X : integer) : integer *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_invalid_parameter4.mli
+++ b/test/parser/functions_neg/uppercase/function_invalid_parameter4.mli
@@ -10,7 +10,7 @@
 
 (*@ function F (n : integer) N : integer *)
 (* {gospel_expected|
-[1] File "function_invalid_parameter4.mli", line 11, characters 29-30:
+[1] File "./function_invalid_parameter4.mli", line 11, characters 29-30:
     11 | (*@ function F (n : integer) N : integer *)
                                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_no_ret1.mli
+++ b/test/parser/functions_neg/uppercase/function_no_ret1.mli
@@ -10,7 +10,7 @@
 
 (*@ function F *)
 (* {gospel_expected|
-[1] File "function_no_ret1.mli", line 11, characters 15-15:
+[1] File "./function_no_ret1.mli", line 11, characters 15-15:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/functions_neg/uppercase/function_no_ret2.mli
+++ b/test/parser/functions_neg/uppercase/function_no_ret2.mli
@@ -10,7 +10,7 @@
 
 (*@ function F (n : integer) *)
 (* {gospel_expected|
-[1] File "function_no_ret2.mli", line 11, characters 29-29:
+[1] File "./function_no_ret2.mli", line 11, characters 29-29:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/functions_neg/uppercase/function_no_ret3.mli
+++ b/test/parser/functions_neg/uppercase/function_no_ret3.mli
@@ -10,7 +10,7 @@
 
 (*@ function F (n1 : integer) (n2 : integer) *)
 (* {gospel_expected|
-[1] File "function_no_ret3.mli", line 11, characters 45-45:
+[1] File "./function_no_ret3.mli", line 11, characters 45-45:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/functions_neg/uppercase/function_no_ret4.mli
+++ b/test/parser/functions_neg/uppercase/function_no_ret4.mli
@@ -10,7 +10,7 @@
 
 (*@ function F = 0 *)
 (* {gospel_expected|
-[1] File "function_no_ret4.mli", line 11, characters 15-16:
+[1] File "./function_no_ret4.mli", line 11, characters 15-16:
     11 | (*@ function F = 0 *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_no_ret5.mli
+++ b/test/parser/functions_neg/uppercase/function_no_ret5.mli
@@ -10,7 +10,7 @@
 
 (*@ function F (n : integer) = 0 *)
 (* {gospel_expected|
-[1] File "function_no_ret5.mli", line 11, characters 29-30:
+[1] File "./function_no_ret5.mli", line 11, characters 29-30:
     11 | (*@ function F (n : integer) = 0 *)
                                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/function_no_ret6.mli
+++ b/test/parser/functions_neg/uppercase/function_no_ret6.mli
@@ -10,7 +10,7 @@
 
 (*@ function F (n1 : integer) (n2 : integer) = 0 *)
 (* {gospel_expected|
-[1] File "function_no_ret6.mli", line 11, characters 45-46:
+[1] File "./function_no_ret6.mli", line 11, characters 45-46:
     11 | (*@ function F (n1 : integer) (n2 : integer) = 0 *)
                                                       ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_invalid_operator1.mli
+++ b/test/parser/functions_neg/uppercase/predicate_invalid_operator1.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate (F) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_operator1.mli", line 11, characters 15-16:
+[1] File "./predicate_invalid_operator1.mli", line 11, characters 15-16:
     11 | (*@ predicate (F) *)
                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_invalid_operator2.mli
+++ b/test/parser/functions_neg/uppercase/predicate_invalid_operator2.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate (+F) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_operator2.mli", line 11, characters 16-17:
+[1] File "./predicate_invalid_operator2.mli", line 11, characters 16-17:
     11 | (*@ predicate (+F) *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_invalid_operator3.mli
+++ b/test/parser/functions_neg/uppercase/predicate_invalid_operator3.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate (+G+) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_operator3.mli", line 11, characters 16-17:
+[1] File "./predicate_invalid_operator3.mli", line 11, characters 16-17:
     11 | (*@ predicate (+G+) *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_invalid_parameter1.mli
+++ b/test/parser/functions_neg/uppercase/predicate_invalid_parameter1.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F (X : integer) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter1.mli", line 11, characters 17-18:
+[1] File "./predicate_invalid_parameter1.mli", line 11, characters 17-18:
     11 | (*@ predicate F (X : integer) *)
                           ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_invalid_parameter2.mli
+++ b/test/parser/functions_neg/uppercase/predicate_invalid_parameter2.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F n *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter2.mli", line 11, characters 16-17:
+[1] File "./predicate_invalid_parameter2.mli", line 11, characters 16-17:
     11 | (*@ predicate F n *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_invalid_parameter3.mli
+++ b/test/parser/functions_neg/uppercase/predicate_invalid_parameter3.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F (n : integer) (X : integer) *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter3.mli", line 11, characters 31-32:
+[1] File "./predicate_invalid_parameter3.mli", line 11, characters 31-32:
     11 | (*@ predicate F (n : integer) (X : integer) *)
                                         ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_invalid_parameter4.mli
+++ b/test/parser/functions_neg/uppercase/predicate_invalid_parameter4.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F (n : integer) n *)
 (* {gospel_expected|
-[1] File "predicate_invalid_parameter4.mli", line 11, characters 30-31:
+[1] File "./predicate_invalid_parameter4.mli", line 11, characters 30-31:
     11 | (*@ predicate F (n : integer) n *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_ret1.mli
+++ b/test/parser/functions_neg/uppercase/predicate_ret1.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F : prop *)
 (* {gospel_expected|
-[1] File "predicate_ret1.mli", line 11, characters 16-17:
+[1] File "./predicate_ret1.mli", line 11, characters 16-17:
     11 | (*@ predicate F : prop *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_ret2.mli
+++ b/test/parser/functions_neg/uppercase/predicate_ret2.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F (n : integer) : prop *)
 (* {gospel_expected|
-[1] File "predicate_ret2.mli", line 11, characters 30-31:
+[1] File "./predicate_ret2.mli", line 11, characters 30-31:
     11 | (*@ predicate F (n : integer) : prop *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_ret3.mli
+++ b/test/parser/functions_neg/uppercase/predicate_ret3.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F (n1 : integer) (n2 : integer) : prop *)
 (* {gospel_expected|
-[1] File "predicate_ret3.mli", line 11, characters 46-47:
+[1] File "./predicate_ret3.mli", line 11, characters 46-47:
     11 | (*@ predicate F (n1 : integer) (n2 : integer) : prop *)
                                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_ret4.mli
+++ b/test/parser/functions_neg/uppercase/predicate_ret4.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F : prop = 0 *)
 (* {gospel_expected|
-[1] File "predicate_ret4.mli", line 11, characters 16-17:
+[1] File "./predicate_ret4.mli", line 11, characters 16-17:
     11 | (*@ predicate F : prop = 0 *)
                          ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_ret5.mli
+++ b/test/parser/functions_neg/uppercase/predicate_ret5.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F (n : integer) : prop = 0 *)
 (* {gospel_expected|
-[1] File "predicate_ret5.mli", line 11, characters 30-31:
+[1] File "./predicate_ret5.mli", line 11, characters 30-31:
     11 | (*@ predicate F (n : integer) : prop = 0 *)
                                        ^
     Error: Syntax error

--- a/test/parser/functions_neg/uppercase/predicate_ret6.mli
+++ b/test/parser/functions_neg/uppercase/predicate_ret6.mli
@@ -10,7 +10,7 @@
 
 (*@ predicate F (n1 : integer) (n2 : integer) : prop = 0 *)
 (* {gospel_expected|
-[1] File "predicate_ret6.mli", line 11, characters 46-47:
+[1] File "./predicate_ret6.mli", line 11, characters 46-47:
     11 | (*@ predicate F (n1 : integer) (n2 : integer) : prop = 0 *)
                                                        ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/empty_record1.mli
+++ b/test/parser/gospel_types_neg/empty_record1.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = {} *)
 (* {gospel_expected|
-[1] File "empty_record1.mli", line 11, characters 13-15:
+[1] File "./empty_record1.mli", line 11, characters 13-15:
     11 | (*@ type t = {} *)
                       ^^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/empty_record2.mli
+++ b/test/parser/gospel_types_neg/empty_record2.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = { ; } *)
 (* {gospel_expected|
-[1] File "empty_record2.mli", line 11, characters 15-16:
+[1] File "./empty_record2.mli", line 11, characters 15-16:
     11 | (*@ type t = { ; } *)
                         ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_name1.mli
+++ b/test/parser/gospel_types_neg/invalid_name1.mli
@@ -10,7 +10,7 @@
 
 (*@ type T *)
 (* {gospel_expected|
-[1] File "invalid_name1.mli", line 11, characters 9-10:
+[1] File "./invalid_name1.mli", line 11, characters 9-10:
     11 | (*@ type T *)
                   ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_name2.mli
+++ b/test/parser/gospel_types_neg/invalid_name2.mli
@@ -10,7 +10,7 @@
 
 (*@ type 1 *)
 (* {gospel_expected|
-[1] File "invalid_name2.mli", line 11, characters 9-10:
+[1] File "./invalid_name2.mli", line 11, characters 9-10:
     11 | (*@ type 1 *)
                   ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_record_field1.mli
+++ b/test/parser/gospel_types_neg/invalid_record_field1.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = { X : int }*)
 (* {gospel_expected|
-[1] File "invalid_record_field1.mli", line 11, characters 15-16:
+[1] File "./invalid_record_field1.mli", line 11, characters 15-16:
     11 | (*@ type t = { X : int }*)
                         ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_record_field2.mli
+++ b/test/parser/gospel_types_neg/invalid_record_field2.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = { x }*)
 (* {gospel_expected|
-[1] File "invalid_record_field2.mli", line 11, characters 17-18:
+[1] File "./invalid_record_field2.mli", line 11, characters 17-18:
     11 | (*@ type t = { x }*)
                           ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_record_field3.mli
+++ b/test/parser/gospel_types_neg/invalid_record_field3.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = { x : integer; X : integer }*)
 (* {gospel_expected|
-[1] File "invalid_record_field3.mli", line 11, characters 28-29:
+[1] File "./invalid_record_field3.mli", line 11, characters 28-29:
     11 | (*@ type t = { x : integer; X : integer }*)
                                      ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_record_field4.mli
+++ b/test/parser/gospel_types_neg/invalid_record_field4.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = { x : integer; x }*)
 (* {gospel_expected|
-[1] File "invalid_record_field4.mli", line 11, characters 30-31:
+[1] File "./invalid_record_field4.mli", line 11, characters 30-31:
     11 | (*@ type t = { x : integer; x }*)
                                        ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_type_annot1.mli
+++ b/test/parser/gospel_types_neg/invalid_type_annot1.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = -> *)
 (* {gospel_expected|
-[1] File "invalid_type_annot1.mli", line 11, characters 13-15:
+[1] File "./invalid_type_annot1.mli", line 11, characters 13-15:
     11 | (*@ type t = -> *)
                       ^^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_type_annot2.mli
+++ b/test/parser/gospel_types_neg/invalid_type_annot2.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = 0 *)
 (* {gospel_expected|
-[1] File "invalid_type_annot2.mli", line 11, characters 13-14:
+[1] File "./invalid_type_annot2.mli", line 11, characters 13-14:
     11 | (*@ type t = 0 *)
                       ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_type_annot3.mli
+++ b/test/parser/gospel_types_neg/invalid_type_annot3.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = integer -> *)
 (* {gospel_expected|
-[1] File "invalid_type_annot3.mli", line 11, characters 24-24:
+[1] File "./invalid_type_annot3.mli", line 11, characters 24-24:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/gospel_types_neg/invalid_type_annot4.mli
+++ b/test/parser/gospel_types_neg/invalid_type_annot4.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = * *)
 (* {gospel_expected|
-[1] File "invalid_type_annot4.mli", line 11, characters 13-14:
+[1] File "./invalid_type_annot4.mli", line 11, characters 13-14:
     11 | (*@ type t = * *)
                       ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_type_annot5.mli
+++ b/test/parser/gospel_types_neg/invalid_type_annot5.mli
@@ -10,7 +10,7 @@
 
 (*@ type t = integer * *)
 (* {gospel_expected|
-[1] File "invalid_type_annot5.mli", line 11, characters 23-23:
+[1] File "./invalid_type_annot5.mli", line 11, characters 23-23:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/gospel_types_neg/invalid_type_params1.mli
+++ b/test/parser/gospel_types_neg/invalid_type_params1.mli
@@ -10,7 +10,7 @@
 
 (*@ type 'a 'b t *)
 (* {gospel_expected|
-[1] File "invalid_type_params1.mli", line 11, characters 12-14:
+[1] File "./invalid_type_params1.mli", line 11, characters 12-14:
     11 | (*@ type 'a 'b t *)
                      ^^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_type_params2.mli
+++ b/test/parser/gospel_types_neg/invalid_type_params2.mli
@@ -10,7 +10,7 @@
 
 (*@ type a t *)
 (* {gospel_expected|
-[1] File "invalid_type_params2.mli", line 11, characters 11-12:
+[1] File "./invalid_type_params2.mli", line 11, characters 11-12:
     11 | (*@ type a t *)
                     ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_type_params3.mli
+++ b/test/parser/gospel_types_neg/invalid_type_params3.mli
@@ -10,7 +10,7 @@
 
 (*@ type ('a, b) t *)
 (* {gospel_expected|
-[1] File "invalid_type_params3.mli", line 11, characters 14-15:
+[1] File "./invalid_type_params3.mli", line 11, characters 14-15:
     11 | (*@ type ('a, b) t *)
                        ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/invalid_type_params4.mli
+++ b/test/parser/gospel_types_neg/invalid_type_params4.mli
@@ -10,7 +10,7 @@
 
 (*@ type (a, 'b) t *)
 (* {gospel_expected|
-[1] File "invalid_type_params4.mli", line 11, characters 10-11:
+[1] File "./invalid_type_params4.mli", line 11, characters 10-11:
     11 | (*@ type (a, 'b) t *)
                    ^
     Error: Syntax error

--- a/test/parser/gospel_types_neg/no_name.mli
+++ b/test/parser/gospel_types_neg/no_name.mli
@@ -10,7 +10,7 @@
 
 (*@ type = integer *)
 (* {gospel_expected|
-[1] File "no_name.mli", line 11, characters 9-10:
+[1] File "./no_name.mli", line 11, characters 9-10:
     11 | (*@ type = integer *)
                   ^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_field_access.mli
+++ b/test/parser/terms_neg/invalid_field_access.mli
@@ -12,7 +12,7 @@
 
 (*@ axiom test : forall x. x..f *)
 (* {gospel_expected|
-[1] File "invalid_field_access.mli", line 13, characters 28-30:
+[1] File "./invalid_field_access.mli", line 13, characters 28-30:
     13 | (*@ axiom test : forall x. x..f *)
                                      ^^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_infix.mli
+++ b/test/parser/terms_neg/invalid_infix.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : 0 + *)
 (* {gospel_expected|
-[1] File "invalid_infix.mli", line 11, characters 21-21:
+[1] File "./invalid_infix.mli", line 11, characters 21-21:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/terms_neg/invalid_let1.mli
+++ b/test/parser/terms_neg/invalid_let1.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : let x = 0 *)
 (* {gospel_expected|
-[1] File "invalid_let1.mli", line 11, characters 27-27:
+[1] File "./invalid_let1.mli", line 11, characters 27-27:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/terms_neg/invalid_let2.mli
+++ b/test/parser/terms_neg/invalid_let2.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : let X = 0 in X *)
 (* {gospel_expected|
-[1] File "invalid_let2.mli", line 11, characters 21-22:
+[1] File "./invalid_let2.mli", line 11, characters 21-22:
     11 | (*@ axiom test : let X = 0 in X *)
                               ^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_let3.mli
+++ b/test/parser/terms_neg/invalid_let3.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : let x = 0 in in 0 *)
 (* {gospel_expected|
-[1] File "invalid_let3.mli", line 11, characters 30-32:
+[1] File "./invalid_let3.mli", line 11, characters 30-32:
     11 | (*@ axiom test : let x = 0 in in 0 *)
                                        ^^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_let4.mli
+++ b/test/parser/terms_neg/invalid_let4.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : let let x = 0 in x *)
 (* {gospel_expected|
-[1] File "invalid_let4.mli", line 11, characters 21-24:
+[1] File "./invalid_let4.mli", line 11, characters 21-24:
     11 | (*@ axiom test : let let x = 0 in x *)
                               ^^^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_quant1.mli
+++ b/test/parser/terms_neg/invalid_quant1.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : forall . True *)
 (* {gospel_expected|
-[1] File "invalid_quant1.mli", line 11, characters 24-25:
+[1] File "./invalid_quant1.mli", line 11, characters 24-25:
     11 | (*@ axiom test : forall . True *)
                                  ^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_quant2.mli
+++ b/test/parser/terms_neg/invalid_quant2.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : forall x : . x*)
 (* {gospel_expected|
-[1] File "invalid_quant2.mli", line 11, characters 28-29:
+[1] File "./invalid_quant2.mli", line 11, characters 28-29:
     11 | (*@ axiom test : forall x : . x*)
                                      ^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_quant3.mli
+++ b/test/parser/terms_neg/invalid_quant3.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : exists . True *)
 (* {gospel_expected|
-[1] File "invalid_quant3.mli", line 11, characters 24-25:
+[1] File "./invalid_quant3.mli", line 11, characters 24-25:
     11 | (*@ axiom test : exists . True *)
                                  ^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_quant4.mli
+++ b/test/parser/terms_neg/invalid_quant4.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : exists x : . x*)
 (* {gospel_expected|
-[1] File "invalid_quant4.mli", line 11, characters 28-29:
+[1] File "./invalid_quant4.mli", line 11, characters 28-29:
     11 | (*@ axiom test : exists x : . x*)
                                      ^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_record1.mli
+++ b/test/parser/terms_neg/invalid_record1.mli
@@ -12,7 +12,7 @@
 
 (*@ axiom test : { x = 0  *)
 (* {gospel_expected|
-[1] File "invalid_record1.mli", line 13, characters 26-26:
+[1] File "./invalid_record1.mli", line 13, characters 26-26:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/terms_neg/invalid_record2.mli
+++ b/test/parser/terms_neg/invalid_record2.mli
@@ -12,7 +12,7 @@
 
 (*@ axiom test :  x = 0 } *)
 (* {gospel_expected|
-[1] File "invalid_record2.mli", line 13, characters 24-25:
+[1] File "./invalid_record2.mli", line 13, characters 24-25:
     13 | (*@ axiom test :  x = 0 } *)
                                  ^
     Error: Syntax error

--- a/test/parser/terms_neg/invalid_record3.mli
+++ b/test/parser/terms_neg/invalid_record3.mli
@@ -12,7 +12,7 @@
 
 (*@ axiom test : { x : 0 } *)
 (* {gospel_expected|
-[1] File "invalid_record3.mli", line 13, characters 21-22:
+[1] File "./invalid_record3.mli", line 13, characters 21-22:
     13 | (*@ axiom test : { x : 0 } *)
                               ^
     Error: Syntax error

--- a/test/parser/terms_neg/unmatched_paren1.mli
+++ b/test/parser/terms_neg/unmatched_paren1.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : (True *)
 (* {gospel_expected|
-[1] File "unmatched_paren1.mli", line 11, characters 23-23:
+[1] File "./unmatched_paren1.mli", line 11, characters 23-23:
     Error: Syntax error
     
 |gospel_expected} *)

--- a/test/parser/terms_neg/unmatched_paren2.mli
+++ b/test/parser/terms_neg/unmatched_paren2.mli
@@ -10,7 +10,7 @@
 
 (*@ axiom test : True) *)
 (* {gospel_expected|
-[1] File "unmatched_paren2.mli", line 11, characters 21-22:
+[1] File "./unmatched_paren2.mli", line 11, characters 21-22:
     11 | (*@ axiom test : True) *)
                               ^
     Error: Syntax error

--- a/test/typechecking/casts/invalid_cast1.mli
+++ b/test/typechecking/casts/invalid_cast1.mli
@@ -11,7 +11,7 @@
 (*@ function f (n : integer) : integer = (n : prop) *)
 
 (* {gospel_expected|
-[1] File "invalid_cast1.mli", line 11, characters 41-51:
+[1] File "./invalid_cast1.mli", line 11, characters 41-51:
     11 | (*@ function f (n : integer) : integer = (n : prop) *)
                                                   ^^^^^^^^^^
     Error: Mismatch between type integer and type prop

--- a/test/typechecking/casts/invalid_cast2.mli
+++ b/test/typechecking/casts/invalid_cast2.mli
@@ -11,7 +11,7 @@
 (*@ function f (n : integer) : integer = ((n + n) : prop) *)
 
 (* {gospel_expected|
-[1] File "invalid_cast2.mli", line 11, characters 41-57:
+[1] File "./invalid_cast2.mli", line 11, characters 41-57:
     11 | (*@ function f (n : integer) : integer = ((n + n) : prop) *)
                                                   ^^^^^^^^^^^^^^^^
     Error: Mismatch between type integer and type prop

--- a/test/typechecking/casts/invalid_cast3.mli
+++ b/test/typechecking/casts/invalid_cast3.mli
@@ -11,7 +11,7 @@
 (*@ function f (n : integer) : integer = (((n : integer) + (n : integer)) : prop) *)
 
 (* {gospel_expected|
-[1] File "invalid_cast3.mli", line 11, characters 41-81:
+[1] File "./invalid_cast3.mli", line 11, characters 41-81:
     11 | (*@ function f (n : integer) : integer = (((n : integer) + (n : integer)) : prop) *)
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     Error: Mismatch between type integer and type prop

--- a/test/typechecking/casts/invalid_cast4.mli
+++ b/test/typechecking/casts/invalid_cast4.mli
@@ -12,7 +12,7 @@
       (((n : prop) + (n : integer)) : integer) *)
 
 (* {gospel_expected|
-[1] File "invalid_cast4.mli", line 12, characters 8-18:
+[1] File "./invalid_cast4.mli", line 12, characters 8-18:
     12 |       (((n : prop) + (n : integer)) : integer) *)
                  ^^^^^^^^^^
     Error: Mismatch between type integer and type prop

--- a/test/typechecking/casts/invalid_cast_tvar1.mli
+++ b/test/typechecking/casts/invalid_cast_tvar1.mli
@@ -11,7 +11,7 @@
 (*@ function f (n : 'a) : 'a = (n : 'b) *)
 
 (* {gospel_expected|
-[1] File "invalid_cast_tvar1.mli", line 11, characters 31-39:
+[1] File "./invalid_cast_tvar1.mli", line 11, characters 31-39:
     11 | (*@ function f (n : 'a) : 'a = (n : 'b) *)
                                         ^^^^^^^^
     Error: Mismatch between type 'a and type 'b

--- a/test/typechecking/casts/invalid_cast_tvar2.mli
+++ b/test/typechecking/casts/invalid_cast_tvar2.mli
@@ -11,7 +11,7 @@
 (*@ function f (n : 'a) (f : 'a -> 'a) : 'a = (f : 'a) (n : 'a) *)
 
 (* {gospel_expected|
-[1] File "invalid_cast_tvar2.mli", line 11, characters 46-54:
+[1] File "./invalid_cast_tvar2.mli", line 11, characters 46-54:
     11 | (*@ function f (n : 'a) (f : 'a -> 'a) : 'a = (f : 'a) (n : 'a) *)
                                                        ^^^^^^^^
     Error: Mismatch between type 'a -> 'a and type 'a

--- a/test/typechecking/casts/invalid_cast_tvar3.mli
+++ b/test/typechecking/casts/invalid_cast_tvar3.mli
@@ -11,7 +11,7 @@
 (*@ function f (n : 'a) (f : 'a -> 'a) : 'a = ((f : ('a -> 'a)) (n : 'a)) : 'b *)
 
 (* {gospel_expected|
-[1] File "invalid_cast_tvar3.mli", line 11, characters 46-78:
+[1] File "./invalid_cast_tvar3.mli", line 11, characters 46-78:
     11 | (*@ function f (n : 'a) (f : 'a -> 'a) : 'a = ((f : ('a -> 'a)) (n : 'a)) : 'b *)
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     Error: Mismatch between type 'a and type 'b

--- a/test/typechecking/fun_spec/fun_name_scope.mli
+++ b/test/typechecking/fun_spec/fun_name_scope.mli
@@ -11,7 +11,7 @@
 (*@ predicate rec f
       requires f *)
 (* {gospel_expected|
-[1] File "fun_name_scope.mli", line 12, characters 15-16:
+[1] File "./fun_name_scope.mli", line 12, characters 15-16:
     12 |       requires f *)
                         ^
     Error: Unbound value f

--- a/test/typechecking/fun_spec/invalid_invariant.mli
+++ b/test/typechecking/fun_spec/invalid_invariant.mli
@@ -11,7 +11,7 @@
 (*@ function f (x : prop) : integer
       variant x *)
 (* {gospel_expected|
-[1] File "invalid_invariant.mli", line 12, characters 14-15:
+[1] File "./invalid_invariant.mli", line 12, characters 14-15:
     12 |       variant x *)
                        ^
     Error: Mismatch between type prop and type integer

--- a/test/typechecking/fun_spec/invalid_post.mli
+++ b/test/typechecking/fun_spec/invalid_post.mli
@@ -11,7 +11,7 @@
 (*@ function f (x : integer) : integer
       ensures x *)
 (* {gospel_expected|
-[1] File "invalid_post.mli", line 12, characters 14-15:
+[1] File "./invalid_post.mli", line 12, characters 14-15:
     12 |       ensures x *)
                        ^
     Error: Mismatch between type integer and type prop

--- a/test/typechecking/fun_spec/invalid_pre.mli
+++ b/test/typechecking/fun_spec/invalid_pre.mli
@@ -11,7 +11,7 @@
 (*@ function f (x : integer) : integer
       requires x *)
 (* {gospel_expected|
-[1] File "invalid_pre.mli", line 12, characters 15-16:
+[1] File "./invalid_pre.mli", line 12, characters 15-16:
     12 |       requires x *)
                         ^
     Error: Mismatch between type integer and type prop

--- a/test/typechecking/invalid_fmla/fmla_not_fun1.mli
+++ b/test/typechecking/invalid_fmla/fmla_not_fun1.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : (+) 0 *)
 
 (* {gospel_expected|
-[1] File "fmla_not_fun1.mli", line 11, characters 15-20:
+[1] File "./fmla_not_fun1.mli", line 11, characters 15-20:
     11 | (*@ axiom ax : (+) 0 *)
                         ^^^^^
     Error: Mismatch between type prop and type integer -> integer

--- a/test/typechecking/invalid_fmla/fmla_not_fun2.mli
+++ b/test/typechecking/invalid_fmla/fmla_not_fun2.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : (=) 0 *)
 
 (* {gospel_expected|
-[1] File "fmla_not_fun2.mli", line 11, characters 15-20:
+[1] File "./fmla_not_fun2.mli", line 11, characters 15-20:
     11 | (*@ axiom ax : (=) 0 *)
                         ^^^^^
     Error: Mismatch between type prop and type integer -> prop

--- a/test/typechecking/invalid_fmla/fmla_not_fun3.mli
+++ b/test/typechecking/invalid_fmla/fmla_not_fun3.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : (=) *)
 
 (* {gospel_expected|
-[1] File "fmla_not_fun3.mli", line 11, characters 15-18:
+[1] File "./fmla_not_fun3.mli", line 11, characters 15-18:
     11 | (*@ axiom ax : (=) *)
                         ^^^
     Error: Mismatch between type prop and type 'a -> 'a -> prop

--- a/test/typechecking/invalid_fmla/fmla_not_integer.mli
+++ b/test/typechecking/invalid_fmla/fmla_not_integer.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : 0 *)
 
 (* {gospel_expected|
-[1] File "fmla_not_integer.mli", line 11, characters 15-16:
+[1] File "./fmla_not_integer.mli", line 11, characters 15-16:
     11 | (*@ axiom ax : 0 *)
                         ^
     Error: Mismatch between type prop and type integer

--- a/test/typechecking/invalid_fmla/fmla_not_record.mli
+++ b/test/typechecking/invalid_fmla/fmla_not_record.mli
@@ -13,7 +13,7 @@
 (*@ axiom test : { x = 0 } *)
 
 (* {gospel_expected|
-[1] File "fmla_not_record.mli", line 13, characters 17-26:
+[1] File "./fmla_not_record.mli", line 13, characters 17-26:
     13 | (*@ axiom test : { x = 0 } *)
                           ^^^^^^^^^
     Error: Mismatch between type prop and type t

--- a/test/typechecking/invalid_fmla/fmla_not_set.mli
+++ b/test/typechecking/invalid_fmla/fmla_not_set.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : { v | True } *)
 
 (* {gospel_expected|
-[1] File "fmla_not_set.mli", line 11, characters 17-29:
+[1] File "./fmla_not_set.mli", line 11, characters 17-29:
     11 | (*@ axiom test : { v | True } *)
                           ^^^^^^^^^^^^
     Error: Mismatch between type prop and type 'a set

--- a/test/typechecking/invalid_fun/not_fun1.mli
+++ b/test/typechecking/invalid_fun/not_fun1.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : 0 0 *)
 
 (* {gospel_expected|
-[1] File "not_fun1.mli", line 11, characters 17-18:
+[1] File "./not_fun1.mli", line 11, characters 17-18:
     11 | (*@ axiom test : 0 0 *)
                           ^
     Error: Mismatch between type 'b -> 'a and type integer

--- a/test/typechecking/invalid_fun/not_fun2.mli
+++ b/test/typechecking/invalid_fun/not_fun2.mli
@@ -13,7 +13,7 @@
 (*@ axiom test : n n *)
 
 (* {gospel_expected|
-[1] File "not_fun2.mli", line 13, characters 17-18:
+[1] File "./not_fun2.mli", line 13, characters 17-18:
     13 | (*@ axiom test : n n *)
                           ^
     Error: Mismatch between type 'b -> 'a and type integer

--- a/test/typechecking/invalid_ret/invalid_ret1.mli
+++ b/test/typechecking/invalid_ret/invalid_ret1.mli
@@ -10,7 +10,7 @@
 
 (*@ function f : integer = True *)
 (* {gospel_expected|
-[1] File "invalid_ret1.mli", line 11, characters 27-31:
+[1] File "./invalid_ret1.mli", line 11, characters 27-31:
     11 | (*@ function f : integer = True *)
                                     ^^^^
     Error: Mismatch between type integer and type prop

--- a/test/typechecking/invalid_ret/invalid_ret2.mli
+++ b/test/typechecking/invalid_ret/invalid_ret2.mli
@@ -10,7 +10,7 @@
 
 (*@ function f : prop = 0 *)
 (* {gospel_expected|
-[1] File "invalid_ret2.mli", line 11, characters 24-25:
+[1] File "./invalid_ret2.mli", line 11, characters 24-25:
     11 | (*@ function f : prop = 0 *)
                                  ^
     Error: Mismatch between type prop and type integer

--- a/test/typechecking/invalid_ret/invalid_ret3.mli
+++ b/test/typechecking/invalid_ret/invalid_ret3.mli
@@ -10,7 +10,7 @@
 
 (*@ function f : 'a = 0 *)
 (* {gospel_expected|
-[1] File "invalid_ret3.mli", line 11, characters 22-23:
+[1] File "./invalid_ret3.mli", line 11, characters 22-23:
     11 | (*@ function f : 'a = 0 *)
                                ^
     Error: Mismatch between type 'a and type integer

--- a/test/typechecking/invalid_ret/invalid_ret4.mli
+++ b/test/typechecking/invalid_ret/invalid_ret4.mli
@@ -12,7 +12,7 @@
 
 (*@ function g (x : integer) : 'a = f x *)
 (* {gospel_expected|
-[1] File "invalid_ret4.mli", line 13, characters 36-39:
+[1] File "./invalid_ret4.mli", line 13, characters 36-39:
     13 | (*@ function g (x : integer) : 'a = f x *)
                                              ^^^
     Error: Mismatch between type 'a and type integer

--- a/test/typechecking/let/let_destruct1.mli
+++ b/test/typechecking/let/let_destruct1.mli
@@ -11,7 +11,7 @@
 (*@ axiom wrong : forall x : integer. let y, z = x in True *)
 
 (* {gospel_expected|
-[1] File "let_destruct1.mli", line 11, characters 49-50:
+[1] File "./let_destruct1.mli", line 11, characters 49-50:
     11 | (*@ axiom wrong : forall x : integer. let y, z = x in True *)
                                                           ^
     Error: Mismatch between type integer and type 'a * 'b

--- a/test/typechecking/let/let_destruct2.mli
+++ b/test/typechecking/let/let_destruct2.mli
@@ -11,7 +11,7 @@
 (*@ axiom wrong : forall x : (integer * integer). let w, y, z = x in True *)
 
 (* {gospel_expected|
-[1] File "let_destruct2.mli", line 11, characters 64-65:
+[1] File "./let_destruct2.mli", line 11, characters 64-65:
     11 | (*@ axiom wrong : forall x : (integer * integer). let w, y, z = x in True *)
                                                                          ^
     Error: Mismatch between type integer * integer and type 'a * 'b * 'c

--- a/test/typechecking/let/let_destruct3.mli
+++ b/test/typechecking/let/let_destruct3.mli
@@ -11,7 +11,7 @@
 (*@ axiom wrong : forall x : integer. let y : bool = x in False *)
 
 (* {gospel_expected|
-[1] File "let_destruct3.mli", line 11, characters 42-50:
+[1] File "./let_destruct3.mli", line 11, characters 42-50:
     11 | (*@ axiom wrong : forall x : integer. let y : bool = x in False *)
                                                    ^^^^^^^^
     Error: Mismatch between type bool and type integer

--- a/test/typechecking/let/let_destruct4.mli
+++ b/test/typechecking/let/let_destruct4.mli
@@ -12,7 +12,7 @@
                     let y, z, w = x in x *)
 
 (* {gospel_expected|
-[1] File "let_destruct4.mli", line 12, characters 34-35:
+[1] File "./let_destruct4.mli", line 12, characters 34-35:
     12 |                     let y, z, w = x in x *)
                                            ^
     Error: Mismatch between type integer * (integer * integer)

--- a/test/typechecking/let/let_destruct5.mli
+++ b/test/typechecking/let/let_destruct5.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : forall x : ('a * 'b * 'c). let x, (y, z) = x in True *)
 
 (* {gospel_expected|
-[1] File "let_destruct5.mli", line 11, characters 60-61:
+[1] File "./let_destruct5.mli", line 11, characters 60-61:
     11 | (*@ axiom test : forall x : ('a * 'b * 'c). let x, (y, z) = x in True *)
                                                                      ^
     Error: Mismatch between type 'a * 'b * 'c and type 'd * ('e * 'f)

--- a/test/typechecking/let/let_destruct7.mli
+++ b/test/typechecking/let/let_destruct7.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : forall x : ('a * 'b * 'b). let x, y, z = x in x = y *)
 
 (* {gospel_expected|
-[1] File "let_destruct7.mli", line 11, characters 67-68:
+[1] File "./let_destruct7.mli", line 11, characters 67-68:
     11 | (*@ axiom test : forall x : ('a * 'b * 'b). let x, y, z = x in x = y *)
                                                                             ^
     Error: Mismatch between type 'b and type 'a

--- a/test/typechecking/prop_expected/axiom.mli
+++ b/test/typechecking/prop_expected/axiom.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : 0 *)
 
 (* {gospel_expected|
-[1] File "axiom.mli", line 11, characters 15-16:
+[1] File "./axiom.mli", line 11, characters 15-16:
     11 | (*@ axiom ax : 0 *)
                         ^
     Error: Mismatch between type prop and type integer

--- a/test/typechecking/prop_expected/if.mli
+++ b/test/typechecking/prop_expected/if.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : if 0 then True else false *)
 
 (* {gospel_expected|
-[1] File "if.mli", line 11, characters 18-19:
+[1] File "./if.mli", line 11, characters 18-19:
     11 | (*@ axiom ax : if 0 then True else false *)
                            ^
     Error: Mismatch between type bool and type integer

--- a/test/typechecking/prop_expected/pred.mli
+++ b/test/typechecking/prop_expected/pred.mli
@@ -11,7 +11,7 @@
 (*@ predicate test = 0 *)
 
 (* {gospel_expected|
-[1] File "pred.mli", line 11, characters 21-22:
+[1] File "./pred.mli", line 11, characters 21-22:
     11 | (*@ predicate test = 0 *)
                               ^
     Error: Mismatch between type prop and type integer

--- a/test/typechecking/prop_expected/quant.mli
+++ b/test/typechecking/prop_expected/quant.mli
@@ -11,7 +11,7 @@
 (*@ axiom ax : forall x. 0 *)
 
 (* {gospel_expected|
-[1] File "quant.mli", line 11, characters 25-26:
+[1] File "./quant.mli", line 11, characters 25-26:
     11 | (*@ axiom ax : forall x. 0 *)
                                   ^
     Error: Mismatch between type prop and type integer

--- a/test/typechecking/terms/conditional.mli
+++ b/test/typechecking/terms/conditional.mli
@@ -3,7 +3,7 @@
       then None
       else Some (Sequence.hd s) *)
 (* {gospel_expected|
-[1] File "conditional.mli", line 2, characters 9-27:
+[1] File "./conditional.mli", line 2, characters 9-27:
     2 |       if s = Sequence.empty
                  ^^^^^^^^^^^^^^^^^^
     Error: Mismatch between type bool and type prop

--- a/test/typechecking/terms/ho1.mli
+++ b/test/typechecking/terms/ho1.mli
@@ -11,7 +11,7 @@
 (*@ axiom fail : forall f : ((integer -> integer) -> integer). f ((/\) True) *)
 
 (* {gospel_expected|
-[1] File "ho1.mli", line 11, characters 65-76:
+[1] File "./ho1.mli", line 11, characters 65-76:
     11 | (*@ axiom fail : forall f : ((integer -> integer) -> integer). f ((/\) True) *)
                                                                           ^^^^^^^^^^^
     Error: Mismatch between type integer -> integer

--- a/test/typechecking/terms/ho2.mli
+++ b/test/typechecking/terms/ho2.mli
@@ -11,7 +11,7 @@
 (*@ axiom fail : (fun x -> x) = 0 *)
 
 (* {gospel_expected|
-[1] File "ho2.mli", line 11, characters 32-33:
+[1] File "./ho2.mli", line 11, characters 32-33:
     11 | (*@ axiom fail : (fun x -> x) = 0 *)
                                          ^
     Error: Mismatch between type 'a -> 'a and type integer

--- a/test/typechecking/terms/ho3.mli
+++ b/test/typechecking/terms/ho3.mli
@@ -11,7 +11,7 @@
 (*@ axiom fail : ((fun x -> x + x) (fun x -> x)) = 0 *)
 
 (* {gospel_expected|
-[1] File "ho3.mli", line 11, characters 35-47:
+[1] File "./ho3.mli", line 11, characters 35-47:
     11 | (*@ axiom fail : ((fun x -> x + x) (fun x -> x)) = 0 *)
                                             ^^^^^^^^^^^^
     Error: Mismatch between type integer and type 'a -> 'a

--- a/test/typechecking/terms/ho4.mli
+++ b/test/typechecking/terms/ho4.mli
@@ -12,7 +12,7 @@
       forall f. f + f = f (fun x -> x) *)
 
 (* {gospel_expected|
-[1] File "ho4.mli", line 12, characters 24-25:
+[1] File "./ho4.mli", line 12, characters 24-25:
     12 |       forall f. f + f = f (fun x -> x) *)
                                  ^
     Error: Mismatch between type integer and type 'b -> 'a

--- a/test/typechecking/terms/map.mli
+++ b/test/typechecking/terms/map.mli
@@ -6,7 +6,7 @@ val add : ('a, 'b) t -> 'a -> 'b -> ('a, 'b) t
     ensures m1 = m0[a -> b]
 *)
 (* {gospel_expected|
-[1] File "map.mli", line 6, characters 20-21:
+[1] File "./map.mli", line 6, characters 20-21:
     6 |     ensures m1 = m0[a -> b]
                             ^
     Error: Mismatch between type 'a and type 'a

--- a/test/typechecking/tuple_arity/wrong_arity1.mli
+++ b/test/typechecking/tuple_arity/wrong_arity1.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : (0, 0) = (0, 0, 0) *)
 
 (* {gospel_expected|
-[1] File "wrong_arity1.mli", line 11, characters 26-35:
+[1] File "./wrong_arity1.mli", line 11, characters 26-35:
     11 | (*@ axiom test : (0, 0) = (0, 0, 0) *)
                                    ^^^^^^^^^
     Error: Mismatch between type integer * integer

--- a/test/typechecking/tuple_arity/wrong_arity2.mli
+++ b/test/typechecking/tuple_arity/wrong_arity2.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : (0, 0, 0) = (0, (0, 0)) *)
 
 (* {gospel_expected|
-[1] File "wrong_arity2.mli", line 11, characters 29-40:
+[1] File "./wrong_arity2.mli", line 11, characters 29-40:
     11 | (*@ axiom test : (0, 0, 0) = (0, (0, 0)) *)
                                       ^^^^^^^^^^^
     Error: Mismatch between type integer * integer * integer

--- a/test/typechecking/tuple_arity/wrong_arity3.mli
+++ b/test/typechecking/tuple_arity/wrong_arity3.mli
@@ -11,7 +11,7 @@
 (*@ axiom test : (0, 0, 0) = ((0, 0), 0) *)
 
 (* {gospel_expected|
-[1] File "wrong_arity3.mli", line 11, characters 29-40:
+[1] File "./wrong_arity3.mli", line 11, characters 29-40:
     11 | (*@ axiom test : (0, 0, 0) = ((0, 0), 0) *)
                                       ^^^^^^^^^^^
     Error: Mismatch between type integer * integer * integer

--- a/test/typechecking/tuple_arity/wrong_arity4.mli
+++ b/test/typechecking/tuple_arity/wrong_arity4.mli
@@ -12,7 +12,7 @@
                 (x : integer * integer * integer) = x = y *)
 
 (* {gospel_expected|
-[1] File "wrong_arity4.mli", line 12, characters 56-57:
+[1] File "./wrong_arity4.mli", line 12, characters 56-57:
     12 |                 (x : integer * integer * integer) = x = y *)
                                                                  ^
     Error: Mismatch between type integer * integer

--- a/test/typechecking/tuple_arity/wrong_arity5.mli
+++ b/test/typechecking/tuple_arity/wrong_arity5.mli
@@ -12,7 +12,7 @@
                 (y : integer * integer) = x = y *)
 
 (* {gospel_expected|
-[1] File "wrong_arity5.mli", line 12, characters 46-47:
+[1] File "./wrong_arity5.mli", line 12, characters 46-47:
     12 |                 (y : integer * integer) = x = y *)
                                                        ^
     Error: Mismatch between type integer * integer

--- a/test/typechecking/tuple_arity/wrong_arity6.mli
+++ b/test/typechecking/tuple_arity/wrong_arity6.mli
@@ -12,7 +12,7 @@
                 (y : integer * integer * integer) = x = y *)
 
 (* {gospel_expected|
-[1] File "wrong_arity6.mli", line 12, characters 56-57:
+[1] File "./wrong_arity6.mli", line 12, characters 56-57:
     12 |                 (y : integer * integer * integer) = x = y *)
                                                                  ^
     Error: Mismatch between type integer * integer * integer

--- a/test/typechecking/tuple_arity/wrong_arity7.mli
+++ b/test/typechecking/tuple_arity/wrong_arity7.mli
@@ -12,7 +12,7 @@
                 (y : integer * integer * integer) = x = y *)
 
 (* {gospel_expected|
-[1] File "wrong_arity7.mli", line 12, characters 56-57:
+[1] File "./wrong_arity7.mli", line 12, characters 56-57:
     12 |                 (y : integer * integer * integer) = x = y *)
                                                                  ^
     Error: Mismatch between type integer * integer * integer

--- a/test/typechecking/tuple_arity/wrong_arity8.mli
+++ b/test/typechecking/tuple_arity/wrong_arity8.mli
@@ -12,7 +12,7 @@
                 (y : integer * (integer * integer)) = x = y *)
 
 (* {gospel_expected|
-[1] File "wrong_arity8.mli", line 12, characters 58-59:
+[1] File "./wrong_arity8.mli", line 12, characters 58-59:
     12 |                 (y : integer * (integer * integer)) = x = y *)
                                                                    ^
     Error: Mismatch between type integer * (integer * integer)

--- a/test/typechecking/type_aliases/mismatch_vars1.mli
+++ b/test/typechecking/type_aliases/mismatch_vars1.mli
@@ -14,7 +14,7 @@
 (*@ predicate test (x : 'a t1) (y : 'b t2) = x = y *)
 
 (* {gospel_expected|
-[1] File "mismatch_vars1.mli", line 14, characters 49-50:
+[1] File "./mismatch_vars1.mli", line 14, characters 49-50:
     14 | (*@ predicate test (x : 'a t1) (y : 'b t2) = x = y *)
                                                           ^
     Error: Mismatch between type 'b t1

--- a/test/typechecking/type_aliases/mismatch_vars2.mli
+++ b/test/typechecking/type_aliases/mismatch_vars2.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : 'a t) (y : 'b) = x = y *)
 
 (* {gospel_expected|
-[1] File "mismatch_vars2.mli", line 13, characters 45-46:
+[1] File "./mismatch_vars2.mli", line 13, characters 45-46:
     13 | (*@ predicate test (x : 'a t) (y : 'b) = x = y *)
                                                       ^
     Error: Mismatch between type 'b and type 'a

--- a/test/typechecking/type_aliases/mismatch_vars3.mli
+++ b/test/typechecking/type_aliases/mismatch_vars3.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : 'a t1) (y : integer t1) = x = y *)
 
 (* {gospel_expected|
-[1] File "mismatch_vars3.mli", line 13, characters 54-55:
+[1] File "./mismatch_vars3.mli", line 13, characters 54-55:
     13 | (*@ predicate test (x : 'a t1) (y : integer t1) = x = y *)
                                                                ^
     Error: Mismatch between type integer sequence

--- a/test/typechecking/type_vars/neq_vars1.mli
+++ b/test/typechecking/type_vars/neq_vars1.mli
@@ -11,7 +11,7 @@
 (*@ predicate test (x : 'a) (y : 'b) = x = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars1.mli", line 11, characters 43-44:
+[1] File "./neq_vars1.mli", line 11, characters 43-44:
     11 | (*@ predicate test (x : 'a) (y : 'b) = x = y *)
                                                     ^
     Error: Mismatch between type 'b and type 'a

--- a/test/typechecking/type_vars/neq_vars2.mli
+++ b/test/typechecking/type_vars/neq_vars2.mli
@@ -11,7 +11,7 @@
 (*@ predicate test (x : 'a sequence) (y : 'b sequence) = x = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars2.mli", line 11, characters 61-62:
+[1] File "./neq_vars2.mli", line 11, characters 61-62:
     11 | (*@ predicate test (x : 'a sequence) (y : 'b sequence) = x = y *)
                                                                       ^
     Error: Mismatch between type 'b sequence

--- a/test/typechecking/type_vars/neq_vars3.mli
+++ b/test/typechecking/type_vars/neq_vars3.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : ('a, 'b) t) (y : ('b, 'a) t) = x = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars3.mli", line 13, characters 59-60:
+[1] File "./neq_vars3.mli", line 13, characters 59-60:
     13 | (*@ predicate test (x : ('a, 'b) t) (y : ('b, 'a) t) = x = y *)
                                                                     ^
     Error: Mismatch between type ('b, 'a) t

--- a/test/typechecking/type_vars/neq_vars4.mli
+++ b/test/typechecking/type_vars/neq_vars4.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : ('a, 'a) t) (y : ('b, 'a) t) = x = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars4.mli", line 13, characters 59-60:
+[1] File "./neq_vars4.mli", line 13, characters 59-60:
     13 | (*@ predicate test (x : ('a, 'a) t) (y : ('b, 'a) t) = x = y *)
                                                                     ^
     Error: Mismatch between type ('b, 'a) t

--- a/test/typechecking/type_vars/neq_vars5.mli
+++ b/test/typechecking/type_vars/neq_vars5.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : ('b, 'a) t) (y : ('a, 'a) t) = x = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars5.mli", line 13, characters 59-60:
+[1] File "./neq_vars5.mli", line 13, characters 59-60:
     13 | (*@ predicate test (x : ('b, 'a) t) (y : ('a, 'a) t) = x = y *)
                                                                     ^
     Error: Mismatch between type ('a, 'a) t

--- a/test/typechecking/type_vars/neq_vars6.mli
+++ b/test/typechecking/type_vars/neq_vars6.mli
@@ -13,7 +13,7 @@
 (*@ predicate test (x : ('b, 'a) t) (y : ('a, 'b) t) = x = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars6.mli", line 13, characters 59-60:
+[1] File "./neq_vars6.mli", line 13, characters 59-60:
     13 | (*@ predicate test (x : ('b, 'a) t) (y : ('a, 'b) t) = x = y *)
                                                                     ^
     Error: Mismatch between type ('a, 'b) t

--- a/test/typechecking/type_vars/neq_vars7.mli
+++ b/test/typechecking/type_vars/neq_vars7.mli
@@ -14,7 +14,7 @@
       forall z. x = z = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars7.mli", line 14, characters 24-25:
+[1] File "./neq_vars7.mli", line 14, characters 24-25:
     14 |       forall z. x = z = y *)
                                  ^
     Error: Mismatch between type 'b and type 'a

--- a/test/typechecking/type_vars/neq_vars8.mli
+++ b/test/typechecking/type_vars/neq_vars8.mli
@@ -14,7 +14,7 @@
       Sequence.hd x = y *)
 
 (* {gospel_expected|
-[1] File "neq_vars8.mli", line 14, characters 22-23:
+[1] File "./neq_vars8.mli", line 14, characters 22-23:
     14 |       Sequence.hd x = y *)
                                ^
     Error: Mismatch between type 'b and type 'a

--- a/test/typechecking/val_specs/cant_return_unit1.mli
+++ b/test/typechecking/val_specs/cant_return_unit1.mli
@@ -13,7 +13,7 @@ val f : int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "cant_return_unit1.mli", line 12, characters 3-25:
+[1] File "./cant_return_unit1.mli", line 12, characters 3-25:
     12 | ... f x
     13 |     ensures True ..
     Error: This function has no listed side effects, it cannot return unit

--- a/test/typechecking/val_specs/cant_return_unit2.mli
+++ b/test/typechecking/val_specs/cant_return_unit2.mli
@@ -13,7 +13,7 @@ val f : int ref -> unit
     preserves x *)
 
 (* {gospel_expected|
-[1] File "cant_return_unit2.mli", line 12, characters 3-24:
+[1] File "./cant_return_unit2.mli", line 12, characters 3-24:
     12 | ... f x
     13 |     preserves x ..
     Error: This function has no listed side effects, it cannot return unit

--- a/test/typechecking/val_specs/cant_return_unit3.mli
+++ b/test/typechecking/val_specs/cant_return_unit3.mli
@@ -12,7 +12,7 @@ val f : int ref -> unit
 (*@ pure *)
 
 (* {gospel_expected|
-[1] File "cant_return_unit3.mli", line 12, characters 3-9:
+[1] File "./cant_return_unit3.mli", line 12, characters 3-9:
     12 | (*@ pure *)
             ^^^^^^
     Error: This function has no listed side effects, it cannot return unit

--- a/test/typechecking/val_specs/cant_return_unit4.mli
+++ b/test/typechecking/val_specs/cant_return_unit4.mli
@@ -14,7 +14,7 @@ val f : int ref -> unit
     preserves x *)
 
 (* {gospel_expected|
-[1] File "cant_return_unit4.mli", line 12, characters 3-38:
+[1] File "./cant_return_unit4.mli", line 12, characters 3-38:
     12 | ... () = f x
     13 |     pure
     14 |     preserves x ..

--- a/test/typechecking/val_specs/invalid_arg_number1.mli
+++ b/test/typechecking/val_specs/invalid_arg_number1.mli
@@ -13,7 +13,7 @@ val f : int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_arg_number1.mli", line 11, characters 0-49:
+[1] File "./invalid_arg_number1.mli", line 11, characters 0-49:
     11 | val f : int -> unit
     12 | (*@ f x y
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_arg_number2.mli
+++ b/test/typechecking/val_specs/invalid_arg_number2.mli
@@ -13,7 +13,7 @@ val f : int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_arg_number2.mli", line 11, characters 0-51:
+[1] File "./invalid_arg_number2.mli", line 11, characters 0-51:
     11 | val f : int -> unit
     12 | (*@ f x y z
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_arg_number3.mli
+++ b/test/typechecking/val_specs/invalid_arg_number3.mli
@@ -13,7 +13,7 @@ val f : int -> int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_arg_number3.mli", line 11, characters 0-58:
+[1] File "./invalid_arg_number3.mli", line 11, characters 0-58:
     11 | val f : int -> int -> unit
     12 | (*@ f x y z
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_arg_number4.mli
+++ b/test/typechecking/val_specs/invalid_arg_number4.mli
@@ -13,7 +13,7 @@ val f : int -> int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_arg_number4.mli", line 11, characters 0-54:
+[1] File "./invalid_arg_number4.mli", line 11, characters 0-54:
     11 | val f : int -> int -> unit
     12 | (*@ f x
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_arg_number5.mli
+++ b/test/typechecking/val_specs/invalid_arg_number5.mli
@@ -13,7 +13,7 @@ val f : int -> int -> unit
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_arg_number5.mli", line 11, characters 0-68:
+[1] File "./invalid_arg_number5.mli", line 11, characters 0-68:
     11 | val f : int -> int -> unit
     12 | (*@ f x [y : integer]
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_ret_number1.mli
+++ b/test/typechecking/val_specs/invalid_ret_number1.mli
@@ -13,7 +13,7 @@ val f : unit -> int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_ret_number1.mli", line 11, characters 0-55:
+[1] File "./invalid_ret_number1.mli", line 11, characters 0-55:
     11 | val f : unit -> int
     12 | (*@ x, y = f ()
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_ret_number2.mli
+++ b/test/typechecking/val_specs/invalid_ret_number2.mli
@@ -13,7 +13,7 @@ val f : unit -> int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_ret_number2.mli", line 11, characters 0-58:
+[1] File "./invalid_ret_number2.mli", line 11, characters 0-58:
     11 | val f : unit -> int
     12 | (*@ x, y, z = f ()
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_ret_number3.mli
+++ b/test/typechecking/val_specs/invalid_ret_number3.mli
@@ -13,7 +13,7 @@ val f : unit -> int * int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_ret_number3.mli", line 11, characters 0-64:
+[1] File "./invalid_ret_number3.mli", line 11, characters 0-64:
     11 | val f : unit -> int * int
     12 | (*@ x, y, z = f ()
     13 |     ensures True *)

--- a/test/typechecking/val_specs/invalid_unit1.mli
+++ b/test/typechecking/val_specs/invalid_unit1.mli
@@ -12,7 +12,7 @@ val f : int -> int
 (*@ () = f x
     ensures True *)
 (* {gospel_expected|
-[1] File "invalid_unit1.mli", line 12, characters 4-6:
+[1] File "./invalid_unit1.mli", line 12, characters 4-6:
     12 | (*@ () = f x
              ^^
     Error: This pattern matches on values of type unit, which is incompatible with int

--- a/test/typechecking/val_specs/invalid_unit2.mli
+++ b/test/typechecking/val_specs/invalid_unit2.mli
@@ -13,7 +13,7 @@ val f : int -> int
     ensures True *)
 
 (* {gospel_expected|
-[1] File "invalid_unit2.mli", line 12, characters 10-12:
+[1] File "./invalid_unit2.mli", line 12, characters 10-12:
     12 | (*@ x = f ()
                    ^^
     Error: This pattern matches on values of type unit, which is incompatible with int

--- a/test/typechecking/val_specs/pure_cant_consume.mli
+++ b/test/typechecking/val_specs/pure_cant_consume.mli
@@ -14,7 +14,7 @@ val f : int ref -> unit
     consumes x *)
 
 (* {gospel_expected|
-[1] File "pure_cant_consume.mli", line 11, characters 0-58:
+[1] File "./pure_cant_consume.mli", line 11, characters 0-58:
     11 | val f : int ref -> unit
     12 | (*@ f x
     13 |     pure

--- a/test/typechecking/val_specs/pure_cant_diverge.mli
+++ b/test/typechecking/val_specs/pure_cant_diverge.mli
@@ -13,7 +13,7 @@ val f : unit -> unit
     diverges *)
 
 (* {gospel_expected|
-[1] File "pure_cant_diverge.mli", line 11, characters 0-45:
+[1] File "./pure_cant_diverge.mli", line 11, characters 0-45:
     11 | val f : unit -> unit
     12 | (*@ pure
     13 |     diverges *)

--- a/test/typechecking/val_specs/pure_cant_modify.mli
+++ b/test/typechecking/val_specs/pure_cant_modify.mli
@@ -14,7 +14,7 @@ val f : int ref -> unit
     modifies x *)
 
 (* {gospel_expected|
-[1] File "pure_cant_modify.mli", line 11, characters 0-58:
+[1] File "./pure_cant_modify.mli", line 11, characters 0-58:
     11 | val f : int ref -> unit
     12 | (*@ f x
     13 |     pure

--- a/test/typechecking/val_specs/pure_cant_raise.mli
+++ b/test/typechecking/val_specs/pure_cant_raise.mli
@@ -17,7 +17,7 @@ val f : unit -> unit
       ensures True *)
 
 (* {gospel_expected|
-[1] File "pure_cant_raise.mli", line 13, characters 0-73:
+[1] File "./pure_cant_raise.mli", line 13, characters 0-73:
     13 | val f : unit -> unit
     14 | (*@ f ()
     15 |     pure


### PR DESCRIPTION
The new format comes from dune 3.24.
An alternative would be to use `Filename.basename` before printing.